### PR TITLE
fix(release): allow heterogeneous binary count across archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,6 +117,12 @@ builds:
 # One archive per (goos, goarch). Goreleaser only includes builds
 # whose target matches, so linux archives get all four binaries,
 # darwin/windows get only ans-verify + ans-dns.
+#
+# allow_different_binary_count: true is required because of the
+# heterogeneous binary count above. Without it, goreleaser v2 errors
+# out on the assumption that a missing binary signals a misconfigured
+# build. Here it's by design: ans-ra and ans-tl are CGO-linked server
+# binaries that intentionally don't ship for darwin/windows.
 archives:
   - id: ans
     ids:
@@ -124,6 +130,7 @@ archives:
       - ans-tl
       - ans-verify
       - ans-dns
+    allow_different_binary_count: true
     name_template: "ans_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz


### PR DESCRIPTION
## Summary

The v0.1.1 release failed with:

```
invalid archive: 0: archive has different count of binaries for each platform, which may cause your users confusion.
```

This is the first release where goreleaser actually ran (the goreleaser job is gated on `release_created == 'true'`, which v0.1.0 didn't trigger). GoReleaser v2 errors out when an archive contains different binary counts across platforms unless `allow_different_binary_count: true` is set.

The heterogeneous binary count is intentional and already documented in `.goreleaser.yaml`: `ans-ra` and `ans-tl` are CGO-linked server binaries that ship Linux-only (cross-compiling CGO to darwin/windows would multiply the toolchain matrix without serving real demand — servers ship via Docker images), while `ans-verify` and `ans-dns` are pure-Go and ship cross-platform. Linux archives therefore have 4 binaries; darwin/windows archives have 2.

The fix opts into that design with one config flag.

## Test plan

- [x] `goreleaser check` passes locally
- [ ] Release workflow runs cleanly when this lands on `main` and the next release-please PR merges (or via `workflow_dispatch` for recovery — see `release.yml:17`)
- [ ] Optional local end-to-end dry run: `goreleaser release --snapshot --clean --skip publish`

## Recovering the v0.1.1 release

After this merges, the release tag (`v0.1.1`) already exists but has no binaries attached. The release workflow can be re-run via `workflow_dispatch` to upload binaries to the existing release (`release.mode: append` in `.goreleaser.yaml` ensures it won't try to recreate it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)