### PR TITLE
build(release): drop windows from goreleaser matrix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,9 +5,19 @@
 #   ans-dns     — development DNS server
 #
 # All four are pure Go (modernc.org/sqlite is a Go transpilation of
-# upstream SQLite, so the SQLite-backed RA and TL no longer need CGO),
-# which means the same goos/goarch matrix applies uniformly: linux,
-# darwin, and windows on amd64 and arm64.
+# upstream SQLite, so the SQLite-backed RA and TL don't need CGO).
+# The release matrix is linux + darwin × amd64 + arm64.
+#
+# Why no windows: ans-tl depends on github.com/transparency-dev/tessera's
+# storage/posix backend, which calls FcntlFlock / O_DIRECTORY / Flock_t
+# / F_WRLCK / F_SETLKW. These are POSIX file-locking primitives and are
+# undefined in Go's syscall_windows.go (Windows uses LockFileEx and a
+# different file-system semantics). darwin works because macOS is
+# POSIX-compliant; windows is not. Rather than ship a heterogeneous
+# archive set (no ans-tl on windows; the other three are buildable),
+# we drop windows entirely. Windows users who need to run any of the
+# binaries can do so via the Dockerfile.* images under WSL2 or Docker
+# Desktop, where the underlying filesystem is POSIX.
 #
 # Library consumers continue to use `go get` / module versions — only
 # the binaries are packaged here.
@@ -31,7 +41,7 @@ builds:
     binary: ans-ra
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    goos: [linux, darwin]
     goarch: [amd64, arm64]
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
@@ -47,7 +57,7 @@ builds:
     binary: ans-tl
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    goos: [linux, darwin]
     goarch: [amd64, arm64]
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
@@ -63,7 +73,7 @@ builds:
     binary: ans-verify
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    goos: [linux, darwin]
     goarch: [amd64, arm64]
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
@@ -79,7 +89,7 @@ builds:
     binary: ans-dns
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    goos: [linux, darwin]
     goarch: [amd64, arm64]
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
@@ -101,10 +111,6 @@ archives:
     name_template: "ans_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
## Summary

The v0.1.2 release failed at the `ans-tl` windows build with:

\`\`\`
github.com/transparency-dev/tessera/storage/posix
  undefined: syscall.O_DIRECTORY
  undefined: syscall.Flock_t
  undefined: syscall.F_WRLCK
  undefined: syscall.FcntlFlock
  undefined: syscall.F_SETLKW
\`\`\`

Tessera's POSIX storage backend uses Unix file-locking primitives (`FcntlFlock` for cross-process write coordination on the Merkle tree's tile files; `O_DIRECTORY` for safe directory ops). These constants and types live in Go's `syscall_unix.go` and aren't defined for Windows — Windows uses different primitives (`LockFileEx`) with different semantics. macOS builds fine because it's POSIX-compliant.

## Why drop windows entirely (not just from `ans-tl`)

Three options were on the table:
- **A.** Drop windows from `ans-tl` only, keep the other three. Heterogeneous archives — windows would have 3 binaries, linux/darwin would have 4. Requires re-adding `allow_different_binary_count: true` and lets a windows user theoretically run `ans-ra` against a remote linux `ans-tl`. Odd topology nobody's asked for.
- **B.** Drop windows from both servers, keep for `ans-verify` + `ans-dns`. Same heterogeneous-archive issue, same flag, but cleaner conceptually.
- **C.** Drop windows entirely (this PR). Uniform archives. Windows users who need any of the binaries can use the `Dockerfile.*` images under WSL2 or Docker Desktop, where the filesystem is POSIX.

C wins on simplicity. The `ans-verify` / `ans-dns` windows-native use case is small enough that "run it via Docker" is fine, and we avoid permanent asymmetry in the artifact matrix.

## Test plan

- [x] `goreleaser check` passes
- [x] Local snapshot build (`goreleaser release --snapshot --clean`) succeeds in 24s, produces 4 uniform archives:
  - `ans_*_linux_amd64.tar.gz`
  - `ans_*_linux_arm64.tar.gz`
  - `ans_*_darwin_amd64.tar.gz`
  - `ans_*_darwin_arm64.tar.gz`
  - Each containing `ans-ra`, `ans-tl`, `ans-verify`, `ans-dns`, `LICENSE`, `README.md`
- [ ] Release workflow runs cleanly when this lands on `main`. The v0.1.2 tag already exists with no binaries; the workflow can be re-run via `workflow_dispatch` to upload to it (`release.mode: append`).

## Recovering v0.1.2

Same recovery path as v0.1.1: once this merges, trigger the Release workflow via `workflow_dispatch` against the v0.1.2 tag and the binaries will be appended to the existing release.