### PR TITLE
docs(claude): annotate Co-Authored-By override relative to global ~/.claude/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Everything that lands on `main` must meet production-grade standards:
   breaking change for verifiers and clients.
 - **`make check` must pass** (`fmt`, `vet`, `golangci-lint`,
   `test-cover`). CI blocks on any failure.
-- **No AI `Co-Authored-By:` trailers.** Do not append
+- **No AI `Co-Authored-By:` trailers (overrides global `~/.claude/CLAUDE.md`).** Do not append
   `Co-Authored-By: Claude …`, `Co-Authored-By: Copilot …`, or any
   similar trailer naming an AI assistant on commits in this repo.
   This project follows the Developer Certificate of Origin: every


### PR DESCRIPTION
The existing prohibition on AI Co-Authored-By trailers was correct but silent about why a global `~/.claude/CLAUDE.md` session might add one anyway. One parenthetical makes the override explicit so any Claude session working across both repos applies the right rule without needing to reason about the conflict.