### PR TITLE
feat(ra): make version optional on agent registration

### DIFF
--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -1048,6 +1048,11 @@ components:
           type: string
           pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
           example: 1.2.0
+          description: >-
+            Optional. A supplied value is validated against the
+            MAJOR.MINOR.PATCH pattern. When omitted, the agent's version
+            defaults to 1.0.0. An explicit empty string is rejected as
+            malformed — omit the field to take the default.
         agentHost:
           type: string
           maxLength: 253
@@ -1072,7 +1077,6 @@ components:
             must register a new version instead.
       required:
         - agentDisplayName
-        - version
         - agentHost
         - endpoints
 

--- a/internal/domain/semver.go
+++ b/internal/domain/semver.go
@@ -9,6 +9,23 @@ import (
 
 var semverPattern = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
 
+// DefaultVersion is the semver assigned when a registration request
+// omits the `version` field entirely. See ResolveVersion.
+func DefaultVersion() SimplifiedSemVer { return SimplifiedSemVer{major: 1, minor: 0, patch: 0} }
+
+// ResolveVersion maps an optional wire version to a domain semver.
+//
+// A non-nil pointer — including one addressing the empty string — is parsed
+// strictly via ParseSemVer, so an empty or malformed value is rejected
+// with a MALFORMED_SEMVER validation error. This is what distinguishes
+// an omitted field (default) from an explicit empty string (malformed).
+func ResolveVersion(raw *string) (SimplifiedSemVer, error) {
+	if raw == nil {
+		return DefaultVersion(), nil
+	}
+	return ParseSemVer(*raw)
+}
+
 // SimplifiedSemVer represents a simplified semantic version (major.minor.patch).
 // All components must be non-negative integers.
 type SimplifiedSemVer struct {

--- a/internal/domain/semver_test.go
+++ b/internal/domain/semver_test.go
@@ -70,6 +70,31 @@ func TestParseSemVer(t *testing.T) {
 	}
 }
 
+func TestResolveVersion(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	t.Run("nil pointer defaults to 1.0.0", func(t *testing.T) {
+		got, err := ResolveVersion(nil)
+		require.NoError(t, err)
+		assert.True(t, got.Equal(mustSemVer(1, 0, 0)))
+	})
+
+	t.Run("valid value is parsed and preserved", func(t *testing.T) {
+		got, err := ResolveVersion(strPtr("2.3.4"))
+		require.NoError(t, err)
+		assert.True(t, got.Equal(mustSemVer(2, 3, 4)))
+	})
+
+	t.Run("empty and malformed values are rejected as MALFORMED_SEMVER", func(t *testing.T) {
+		for _, raw := range []string{"", "1.2", "abc", "v1.0.0", "1.0.0-rc1", " 1.0.0"} {
+			_, err := ResolveVersion(strPtr(raw))
+			var de *Error
+			require.ErrorAs(t, err, &de, "input %q", raw)
+			assert.Equal(t, "MALFORMED_SEMVER", de.Code, "input %q", raw)
+		}
+	})
+}
+
 func TestSemVer_String(t *testing.T) {
 	v, _ := NewSemVer(1, 2, 3)
 	assert.Equal(t, "1.2.3", v.String())

--- a/internal/ra/handler/registration.go
+++ b/internal/ra/handler/registration.go
@@ -32,7 +32,7 @@ func NewRegistrationHandler(svc *service.RegistrationService) *RegistrationHandl
 type registrationRequest struct {
 	AgentDisplayName          string        `json:"agentDisplayName"`
 	AgentDescription          string        `json:"agentDescription,omitempty"`
-	Version                   string        `json:"version"`
+	Version                   *string       `json:"version"`
 	AgentHost                 string        `json:"agentHost"`
 	Endpoints                 []endpointDTO `json:"endpoints"`
 	IdentityCSRPEM            string        `json:"identityCsrPEM"`
@@ -125,8 +125,8 @@ func (h *RegistrationHandler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse version + host into an AnsName.
-	semver, err := domain.ParseSemVer(req.Version)
+	// Resolve version (absent → 1.0.0 default) + host into an AnsName.
+	semver, err := domain.ResolveVersion(req.Version)
 	if err != nil {
 		WriteError(w, err)
 		return

--- a/internal/ra/handler/registration_errors_test.go
+++ b/internal/ra/handler/registration_errors_test.go
@@ -312,3 +312,141 @@ func TestV1VerifyACME_UnknownAgent(t *testing.T) {
 		t.Fatalf("unknown agent should not succeed; got %d body=%s", rec.Code, rec.Body)
 	}
 }
+
+// ----- optional `version` field on registration -----
+//
+// When `version` is omitted from a registration body the RA defaults
+// it to 1.0.0; an explicit empty string (or any malformed value) is
+// rejected as 422 MALFORMED_SEMVER. Both lanes share the behaviour.
+
+func TestRegister_OmittedVersionDefaultsTo100(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	const host = "omitted-version.example.com"
+
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "X",
+		"agentHost":        host,
+		"endpoints":        []map[string]any{{"agentUrl": "https://omitted-version.example.com", "protocol": "MCP", "transports": []string{"SSE"}}},
+		"serverCsrPEM":     newTestServerCSR(t, host),
+	})
+
+	rec := fx.request(t, http.MethodPost, "/v2/ans/agents",
+		bytes.NewReader(body), fx.asOwner("alice"))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body)
+	}
+	var resp struct {
+		AgentID string `json:"agentId"`
+		Status  string `json:"status"`
+		AnsName string `json:"ansName"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse 202: %v", err)
+	}
+	if resp.Status != "PENDING_VALIDATION" {
+		t.Errorf("status: got %q want PENDING_VALIDATION", resp.Status)
+	}
+	if want := "ans://v1.0.0." + host; resp.AnsName != want {
+		t.Errorf("ansName: got %q want %q", resp.AnsName, want)
+	}
+
+	// The default propagates to the read model.
+	det := fx.request(t, http.MethodGet, "/v2/ans/agents/"+resp.AgentID, nil, fx.asOwner("alice"))
+	if det.Code != http.StatusOK {
+		t.Fatalf("detail status: got %d want 200; body=%s", det.Code, det.Body)
+	}
+	var detail struct {
+		Version string `json:"version"`
+		AnsName string `json:"ansName"`
+	}
+	if err := json.Unmarshal(det.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("parse detail: %v", err)
+	}
+	if detail.Version != "1.0.0" {
+		t.Errorf("detail version: got %q want 1.0.0", detail.Version)
+	}
+}
+
+func TestRegister_EmptyStringVersionRejected(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "X",
+		"version":          "",
+		"agentHost":        "empty-version.example.com",
+		"endpoints":        []map[string]any{{"agentUrl": "https://empty-version.example.com", "protocol": "MCP", "transports": []string{"SSE"}}},
+		"serverCsrPEM":     newTestServerCSR(t, "empty-version.example.com"),
+	})
+	rec := fx.request(t, http.MethodPost, "/v2/ans/agents",
+		bytes.NewReader(body), fx.asOwner("alice"))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf(`version "" status: got %d want 422; body=%s`, rec.Code, rec.Body)
+	}
+}
+
+func TestRegister_SuppliedVersionPreserved(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "X",
+		"version":          "2.5.1",
+		"agentHost":        "supplied-version.example.com",
+		"endpoints":        []map[string]any{{"agentUrl": "https://supplied-version.example.com", "protocol": "MCP", "transports": []string{"SSE"}}},
+		"serverCsrPEM":     newTestServerCSR(t, "supplied-version.example.com"),
+	})
+
+	rec := fx.request(t, http.MethodPost, "/v2/ans/agents",
+		bytes.NewReader(body), fx.asOwner("alice"))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body)
+	}
+	var resp struct {
+		AnsName string `json:"ansName"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if want := "ans://v2.5.1.supplied-version.example.com"; resp.AnsName != want {
+		t.Errorf("ansName: got %q want %q", resp.AnsName, want)
+	}
+}
+
+func TestV1Register_OmittedVersionDefaultsTo100(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "X",
+		"agentHost":        "omitted-version.example.com",
+		"endpoints":        []map[string]any{{"agentUrl": "https://omitted-version.example.com", "protocol": "MCP", "transports": []string{"SSE"}}},
+		"serverCsrPEM":     newTestServerCSR(t, "omitted-version.example.com"),
+	})
+
+	rec := fx.request(t, http.MethodPost, "/v1/agents/register",
+		bytes.NewReader(body), fx.asOwner("alice"))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body)
+	}
+	var resp struct {
+		AnsName string `json:"ansName"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if want := "ans://v1.0.0.omitted-version.example.com"; resp.AnsName != want {
+		t.Errorf("ansName: got %q want %q", resp.AnsName, want)
+	}
+}
+
+func TestV1Register_EmptyStringVersionRejected(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "X",
+		"version":          "",
+		"agentHost":        "empty-version.example.com",
+		"endpoints":        []map[string]any{{"agentUrl": "https://empty-version.example.com", "protocol": "MCP", "transports": []string{"SSE"}}},
+		"serverCsrPEM":     newTestServerCSR(t, "empty-version.example.com"),
+	})
+	rec := fx.request(t, http.MethodPost, "/v1/agents/register",
+		bytes.NewReader(body), fx.asOwner("alice"))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf(`version "" status: got %d want 422; body=%s`, rec.Code, rec.Body)
+	}
+}

--- a/internal/ra/handler/v1registration.go
+++ b/internal/ra/handler/v1registration.go
@@ -67,7 +67,7 @@ func NewV1RegistrationHandler(svc *service.RegistrationService) *V1RegistrationH
 type v1RegistrationRequest struct {
 	AgentDisplayName          string          `json:"agentDisplayName"`
 	AgentDescription          string          `json:"agentDescription,omitempty"`
-	Version                   string          `json:"version"`
+	Version                   *string         `json:"version"`
 	AgentHost                 string          `json:"agentHost"`
 	Endpoints                 []v1EndpointDTO `json:"endpoints"`
 	ServerCSRPEM              string          `json:"serverCsrPEM,omitempty"`
@@ -190,7 +190,7 @@ func (h *V1RegistrationHandler) Register(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	semver, err := domain.ParseSemVer(req.Version)
+	semver, err := domain.ResolveVersion(req.Version)
 	if err != nil {
 		WriteError(w, err)
 		return

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -1048,6 +1048,11 @@ components:
           type: string
           pattern: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
           example: 1.2.0
+          description: >-
+            Optional. A supplied value is validated against the
+            MAJOR.MINOR.PATCH pattern. When omitted, the agent's version
+            defaults to 1.0.0. An explicit empty string is rejected as
+            malformed — omit the field to take the default.
         agentHost:
           type: string
           maxLength: 253
@@ -1072,7 +1077,6 @@ components:
             must register a new version instead.
       required:
         - agentDisplayName
-        - version
         - agentHost
         - endpoints
 


### PR DESCRIPTION
The `version` field on agent registration is now optional in both the V1 and V2 RA lanes. When omitted, the agent's version defaults to 1.0.0; an explicit empty string (or any malformed value) is rejected as 422 MALFORMED_SEMVER, distinguishing an absent field from a bad one.

- domain.ResolveVersion maps an optional wire version (`*string`) to a domain semver: nil → DefaultVersion (1.0.0), non-nil → strict ParseSemVer.
- Registration DTOs change Version from string to *string so JSON omission is observable.
- spec/api-spec-v2.yaml and the docsui mirror drop `version` from the required list and document the optional/default behaviour.
- Tests cover omitted (default), supplied (preserved), and empty/malformed (rejected) across both lanes.