### PR TITLE
feat(ra): AI Catalog generation, FQDN exclusivity, and seal-before-success activation

### DIFF
--- a/cmd/ans-ra/main.go
+++ b/cmd/ans-ra/main.go
@@ -214,7 +214,7 @@ func run(cfgPath string) error {
 	// fail-closed checks aren't defeated by a typed-nil interface.
 	var tlSealer *tlclient.Client
 	if !cfg.TLClient.Disabled {
-		tlSealer = tlclient.New(cfg.TLClient.BaseURL, cfg.TLClient.APIKey, cfg.TLClient.Timeout)
+		tlSealer = tlclient.New(cfg.TLClient.BaseURL, cfg.TLClient.APIKey, cfg.TLClient.Timeout).WithLogger(logger)
 	} else {
 		logger.Warn().Msg("TL client disabled — agent activation and identity verify/revoke/link operations will fail with TL_UNAVAILABLE (seal-before-success)")
 	}
@@ -229,7 +229,8 @@ func run(cfgPath string) error {
 	}).WithDNSVerifier(dnsVerifier).
 		WithHTTPChallengeVerifier(challenge.NewHTTPVerifier()).
 		WithServerCertificateIssuer(serverCA).
-		WithTLPublicBaseURL(cfg.TLClient.PublicBaseURL)
+		WithTLPublicBaseURL(cfg.TLClient.PublicBaseURL).
+		WithLogger(logger)
 	if tlSealer != nil {
 		regSvc = regSvc.WithAgentSealer(tlSealer)
 	}
@@ -313,7 +314,7 @@ func run(cfgPath string) error {
 	// registrant's own view of how their agent appears in a catalog; it
 	// is NOT public — the crawlable surface is the population export
 	// (later slice) and the AHP-published well-known document.
-	catH := handler.NewCatalogHandler(regSvc)
+	catH := handler.NewCatalogHandler(regSvc, logger)
 	r.With(readOwnership).Get("/v2/ans/agents/{agentId}/catalog-entry", catH.CatalogEntry)
 	// Host-complete AI Catalog document (the file the AHP publishes at
 	// /.well-known/ai-catalog.json). Owner-scoped, served as

--- a/cmd/ans-ra/main.go
+++ b/cmd/ans-ra/main.go
@@ -200,6 +200,25 @@ func run(cfgPath string) error {
 		Strs("profiles", profileIDStrings(discoveryReg.IDs())).
 		Msg("discovery registry ready")
 
+	// One TL client serves both seal-before-success lanes — agent
+	// ACTIVATION (verify-dns) and identity ops. Both seal SYNCHRONOUSLY
+	// (design §5.6.1; ANS-1 §12.3 for agents): the event is durable in the
+	// log before the operation reports success, so neither rides the
+	// outbox. A disabled TL client leaves the sealer nil and both lanes
+	// fail closed with TL_UNAVAILABLE — there is no "seal later" mode for
+	// an ACTIVE transition. (Revocation still rides the async outbox; the
+	// worker below holds its own client.)
+	//
+	// The sealer is kept as a concrete *tlclient.Client and only assigned
+	// into the interfaces when non-nil, so the services' `sealer == nil`
+	// fail-closed checks aren't defeated by a typed-nil interface.
+	var tlSealer *tlclient.Client
+	if !cfg.TLClient.Disabled {
+		tlSealer = tlclient.New(cfg.TLClient.BaseURL, cfg.TLClient.APIKey, cfg.TLClient.Timeout)
+	} else {
+		logger.Warn().Msg("TL client disabled — agent activation and identity verify/revoke/link operations will fail with TL_UNAVAILABLE (seal-before-success)")
+	}
+
 	// Services.
 	regSvc := service.NewRegistrationService(
 		agents, endpoints, certsStore, byoc, renewals, validator, identityCA, bus, outbox, db, discoveryReg,
@@ -209,24 +228,22 @@ func run(cfgPath string) error {
 		RaID:       cfg.Signer.RaID,
 	}).WithDNSVerifier(dnsVerifier).
 		WithHTTPChallengeVerifier(challenge.NewHTTPVerifier()).
-		WithServerCertificateIssuer(serverCA)
+		WithServerCertificateIssuer(serverCA).
+		WithTLPublicBaseURL(cfg.TLClient.PublicBaseURL)
+	if tlSealer != nil {
+		regSvc = regSvc.WithAgentSealer(tlSealer)
+	}
 
 	// Events feed service — projects delivered outbox rows into the
 	// public agent-events stream.
 	eventsSvc := service.NewEventsService(feedStore)
 
 	// Verified identities — the "who" behind the agents. Shares the
-	// producer signer with the registration service: one RA, one
-	// producer identity on every TL lane. Identity events seal
-	// SYNCHRONOUSLY (seal-before-success, design §5.6.1): they never
-	// ride the outbox, so the service gets the TL client directly. A
-	// disabled TL client means identity sealing operations fail
-	// closed with TL_UNAVAILABLE — there is no "seal later" mode.
+	// producer signer and the TL sealer with the registration service:
+	// one RA, one producer identity on every TL lane.
 	var identitySealer service.IdentityEventSealer
-	if !cfg.TLClient.Disabled {
-		identitySealer = tlclient.New(cfg.TLClient.BaseURL, cfg.TLClient.APIKey, cfg.TLClient.Timeout)
-	} else {
-		logger.Warn().Msg("TL client disabled — identity verify/revoke/link operations will fail with TL_UNAVAILABLE (seal-before-success)")
+	if tlSealer != nil {
+		identitySealer = tlSealer
 	}
 	identitySvc := service.NewIdentityService(
 		identityStore, identityLinks, agents, didResolver, identitySealer, leiVerifier, db,
@@ -291,6 +308,18 @@ func run(cfgPath string) error {
 	writeOwnership := ramiddleware.WriteOwnership(agents)
 
 	r.With(readOwnership).Get("/v2/ans/agents/{agentId}", lifeH.Detail)
+
+	// AI Catalog (owner-scoped, read-only). The bare CatalogEntry is the
+	// registrant's own view of how their agent appears in a catalog; it
+	// is NOT public — the crawlable surface is the population export
+	// (later slice) and the AHP-published well-known document.
+	catH := handler.NewCatalogHandler(regSvc)
+	r.With(readOwnership).Get("/v2/ans/agents/{agentId}/catalog-entry", catH.CatalogEntry)
+	// Host-complete AI Catalog document (the file the AHP publishes at
+	// /.well-known/ai-catalog.json). Owner-scoped, served as
+	// application/ai-catalog+json with ETag/304.
+	r.With(readOwnership).Get("/v2/ans/agents/{agentId}/ai-catalog", catH.HostCatalog)
+
 	r.With(readOwnership).Get("/v2/ans/agents/{agentId}/certificates/identity", lifeH.GetIdentityCerts)
 	r.With(readOwnership).Get("/v2/ans/agents/{agentId}/certificates/server", lifeH.GetServerCerts)
 	r.With(readOwnership).Get("/v2/ans/agents/{agentId}/csrs/{csrId}/status", lifeH.GetCSRStatus)

--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -2134,9 +2134,9 @@ components:
           type: string
           description: |
             Stable, version-spanning lineage handle
-            `urn:ai:{agentHost}:agents:{label}`, where `{label}` is the
+            `urn:air:{agentHost}:agents:{label}`, where `{label}` is the
             leftmost DNS label of agentHost. Never the per-version agentId.
-          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+          example: urn:air:ai-agent.acmecorp.com:agents:ai-agent
         displayName:
           type: string
           maxLength: 64
@@ -2288,7 +2288,7 @@ components:
       properties:
         identity:
           type: string
-          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+          example: urn:air:ai-agent.acmecorp.com:agents:ai-agent
         attestations:
           type: array
           description: |

--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -320,9 +320,9 @@ paths:
             operator; the FQDN belongs to that owner until no live
             registration remains).
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: Invalid registration request
           content:
@@ -424,21 +424,21 @@ paths:
         '401':
           description: Authentication failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '403':
           description: Authorization failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '404':
           description: Agent not found or not owned by caller
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: |
             Registration is not catalog-eligible: not ACTIVE (no
@@ -446,15 +446,15 @@ paths:
             A2A/MCP endpoint with a policy-passing metaDataUrl. `code` is
             `NOT_CATALOG_ELIGIBLE`; `detail` names the specific gate.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '500':
           description: Internal server error
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
 
   /ans/agents/{agentId}/ai-catalog:
     get:
@@ -511,27 +511,27 @@ paths:
         '401':
           description: Authentication failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '403':
           description: Authorization failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '404':
           description: Agent not found or not owned by caller
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '500':
           description: Internal server error
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
 
   # ──────────────────────────────────────────────────────────────────
   # Registration Validation
@@ -579,9 +579,9 @@ paths:
             live (it activated first). This registration lost the host and
             was cancelled; it can no longer progress.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: Validation failed
           content:
@@ -647,9 +647,9 @@ paths:
             window. The FQDN belongs to that owner until no live
             registration remains, so this activation is refused.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: DNS records not found or incorrect
           content:
@@ -669,9 +669,9 @@ paths:
             `PENDING_DNS` and nothing is committed; retry verify-dns once
             the TL is reachable.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
 
   # ──────────────────────────────────────────────────────────────────
   # Revocation
@@ -2772,6 +2772,38 @@ components:
         - type
         - title
         - status
+
+    Problem:
+      type: object
+      description: |
+        RFC 7807 Problem Details — the actual error shape every RA failure
+        path emits, served as `application/problem+json`. Clients read
+        `code` for programmatic handling and `detail` for the
+        human-readable explanation.
+
+        (The legacy `ErrorResponse` schema below is retained only for the
+        pre-existing routes still declared against it; new routes point
+        here. Migrating the remaining declarations is tracked separately.)
+      properties:
+        type:
+          type: string
+          description: URI reference identifying the problem type.
+        title:
+          type: string
+          description: Short, human-readable summary of the problem type.
+        status:
+          type: integer
+          description: HTTP status code.
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+        code:
+          type: string
+          description: Stable, machine-readable error code for programmatic handling.
+      required:
+        - title
+        - status
+        - code
 
     ErrorResponse:
       type: object

--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -2135,8 +2135,12 @@ components:
           description: |
             Stable, version-spanning lineage handle
             `urn:air:{agentHost}:agents:{label}`, where `{label}` is the
-            leftmost DNS label of agentHost. Never the per-version agentId.
-          example: urn:air:ai-agent.acmecorp.com:agents:ai-agent
+            agent's display name with whitespace runs collapsed to single
+            hyphens — the same derivation the ARD discovery service (the
+            Finder) mints from feed events, so search results and the
+            published catalog carry one identifier per agent. Never the
+            per-version agentId.
+          example: urn:air:ai-agent.acmecorp.com:agents:Support-Assistant
         displayName:
           type: string
           maxLength: 64

--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -312,7 +312,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
-          description: Agent ID or ANSName already exists
+          description: |
+            Conflict. `code` distinguishes the cause:
+            `ANS_NAME_TAKEN` (this exact versioned ANS name is already
+            registered) or `AGENT_HOST_TAKEN` (the FQDN has a live —
+            ACTIVE or DEPRECATED — registration owned by a different
+            operator; the FQDN belongs to that owner until no live
+            registration remains).
           content:
             application/json:
               schema:
@@ -350,6 +356,158 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentDetails'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Agent not found or not owned by caller
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ──────────────────────────────────────────────────────────────────
+  # AI Catalog (producer-generated discovery artifact)
+  # ──────────────────────────────────────────────────────────────────
+  /ans/agents/{agentId}/catalog-entry:
+    get:
+      tags:
+        - Management
+      summary: Get the agent's AI Catalog entry
+      description: |
+        Returns the agent's AI Catalog `CatalogEntry` — the producer-side
+        record an external AI Catalog / ARD registry ingests. The entry is
+        derived entirely from the registration aggregate (display name,
+        version, endpoints, Transparency-Log badge/receipt URLs); nothing is
+        sealed or fetched, and it is regenerated on lifecycle events.
+
+        **Owner-scoped, read-only.** Returns 404 if the authenticated caller
+        does not own the agent (existence is hidden). This route is the
+        registrant's own view of how their agent appears in a catalog; it is
+        not the public, crawlable surface.
+
+        **Eligibility:** an entry is produced only for an **ACTIVE**
+        registration (the entry's SCITT-receipt attestation and TL badge
+        link to Transparency-Log records that exist only once the agent is
+        sealed at activation — a pending agent has nothing to link to) that
+        is versioned and has at least one A2A or MCP endpoint whose
+        `metaDataUrl` is present and passes the emit-side URL policy
+        (absolute https, no userinfo/query/fragment, host == agentHost).
+        Otherwise the route returns 422 `NOT_CATALOG_ELIGIBLE` (the `detail`
+        names the specific gate: not active, versionless, or no eligible
+        endpoint).
+      operationId: getCatalogEntry
+      parameters:
+        - $ref: '#/components/parameters/AgentIdPath'
+      responses:
+        '200':
+          description: The agent's CatalogEntry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogEntry'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Agent not found or not owned by caller
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: |
+            Registration is not catalog-eligible: not ACTIVE (no
+            Transparency-Log entry to link to yet), versionless, or no
+            A2A/MCP endpoint with a policy-passing metaDataUrl. `code` is
+            `NOT_CATALOG_ELIGIBLE`; `detail` names the specific gate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ans/agents/{agentId}/ai-catalog:
+    get:
+      tags:
+        - Management
+      summary: Get the host-complete AI Catalog document
+      description: |
+        Returns the host-complete AI Catalog **document** for the agent's
+        host — the file an Agent Hosting Platform publishes verbatim at
+        `/.well-known/ai-catalog.json`. It contains one `CatalogEntry` for
+        every **ACTIVE**, catalog-eligible agent registered on that host
+        (deprecated and revoked registrations are pruned from the
+        well-known file; the population export keeps them, marked).
+
+        **Owner-scoped, read-only.** Returns 404 if the authenticated
+        caller does not own the agent (existence is hidden). The caller
+        proves ownership of the keying agent; the document then lists that
+        owner's ACTIVE catalog-eligible agents on the host (the body is
+        scoped to the owner, not just the route key, so a shared host never
+        discloses one owner's agents to another). This is the registrant's
+        refresh target — not a public, crawlable surface.
+
+        **Caching:** the response carries a strong `ETag` (SHA-256 of the
+        body). A conditional request with a matching `If-None-Match`
+        receives `304 Not Modified`.
+      operationId: getHostCatalog
+      parameters:
+        - $ref: '#/components/parameters/AgentIdPath'
+      responses:
+        '200':
+          description: The host-complete AI Catalog document
+          headers:
+            ETag:
+              description: Strong validator (SHA-256 of the document body)
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
+          content:
+            application/ai-catalog+json:
+              schema:
+                $ref: '#/components/schemas/CatalogDocument'
+        '304':
+          description: Not modified (If-None-Match matched the current ETag)
+          headers:
+            ETag:
+              description: Strong validator (SHA-256 of the document body)
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
         '401':
           description: Authentication failed
           content:
@@ -415,6 +573,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            `AGENT_HOST_TAKEN` — a different operator now holds this FQDN
+            live (it activated first). This registration lost the host and
+            was cancelled; it can no longer progress.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation failed
           content:
@@ -436,12 +603,21 @@ paths:
       description: |
         Verifies that all required DNS records have been configured correctly.
         This is the final step for external domain registration.
+
+        **Seal-before-success:** activation does not report `ACTIVE` until
+        the agent's single terminal `AGENT_REGISTERED` event has been
+        sealed in the Transparency Log. The RA submits the event to the TL
+        INLINE and only then commits the ACTIVE transition; if the TL is
+        unavailable the call fails 503 `TL_UNAVAILABLE` (retryable — the
+        agent stays `PENDING_DNS` and nothing is committed). This is what
+        guarantees a catalog entry's SCITT-receipt and badge links can only
+        ever point at a TL record that actually exists.
       operationId: verifyDnsRecords
       parameters:
         - $ref: '#/components/parameters/AgentIdPath'
       responses:
         '202':
-          description: DNS verified, registration active
+          description: DNS verified and AGENT_REGISTERED sealed in the TL; registration active
           content:
             application/json:
               schema:
@@ -464,6 +640,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            `AGENT_HOST_TAKEN` — a different operator activated a
+            registration on this FQDN during this registration's pending
+            window. The FQDN belongs to that owner until no live
+            registration remains, so this activation is refused.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: DNS records not found or incorrect
           content:
@@ -472,6 +658,16 @@ paths:
                 $ref: '#/components/schemas/DnsVerificationError'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: |
+            `TL_UNAVAILABLE` — the Transparency Log could not seal the
+            `AGENT_REGISTERED` event. Retryable: the agent stays
+            `PENDING_DNS` and nothing is committed; retry verify-dns once
+            the TL is reachable.
           content:
             application/json:
               schema:
@@ -1921,6 +2117,210 @@ components:
         - status
         - ansName
         - nextSteps
+
+    # ── AI Catalog (producer-generated discovery artifact) ──────────
+    CatalogEntry:
+      type: object
+      description: |
+        One artifact's AI Catalog record, derived from a registration (AI
+        Catalog draft 2026-06-11 §4.4). A bare entry is served as
+        application/json — it is not itself a catalog document and carries no
+        `specVersion`. Exactly one of `url` or `data` is present: a
+        single-protocol entry carries `url`; a multi-protocol agent carries
+        `data` (an inline nested catalog of per-protocol children) with
+        `mediaType` `application/ai-catalog+json`.
+      properties:
+        identifier:
+          type: string
+          description: |
+            Stable, version-spanning lineage handle
+            `urn:ai:{agentHost}:agents:{label}`, where `{label}` is the
+            leftmost DNS label of agentHost. Never the per-version agentId.
+          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+        displayName:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          maxLength: 150
+        version:
+          type: string
+          example: 2.1.0
+        mediaType:
+          type: string
+          description: |
+            Artifact discriminator: `application/a2a-agent-card+json`,
+            `application/mcp-server-card+json`, or
+            `application/ai-catalog+json` for a multi-protocol nested entry.
+          example: application/a2a-agent-card+json
+        url:
+          type: string
+          format: uri
+          description: |
+            The endpoint's metaDataUrl (the protocol card location). Present
+            on a single-protocol or nested-child entry. Mutually exclusive
+            with `data`.
+        data:
+          allOf:
+            - $ref: '#/components/schemas/CatalogNested'
+          description: |
+            Inline nested catalog of per-protocol children, present only on a
+            multi-protocol outer entry. Mutually exclusive with `url`.
+        tags:
+          type: array
+          items:
+            type: string
+        updatedAt:
+          type: string
+          format: date-time
+        publisher:
+          $ref: '#/components/schemas/CatalogPublisher'
+        metadata:
+          $ref: '#/components/schemas/CatalogEntryMetadata'
+        trustManifest:
+          $ref: '#/components/schemas/CatalogTrustManifest'
+      required:
+        - identifier
+        - displayName
+        - mediaType
+
+    CatalogNested:
+      type: object
+      description: |
+        Inline nested catalog held in a multi-protocol entry's `data` (AI
+        Catalog §6.1 / IMPL §3.5).
+      properties:
+        specVersion:
+          type: string
+          example: "1.0"
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogEntry'
+      required:
+        - specVersion
+        - entries
+
+    CatalogDocument:
+      type: object
+      description: |
+        A host-complete AI Catalog document (AI Catalog §4.2), served as
+        application/ai-catalog+json. The file an AHP publishes at
+        `/.well-known/ai-catalog.json`; `entries` carries one CatalogEntry
+        per ACTIVE, catalog-eligible agent on the host (sorted by
+        identifier then version for a stable ETag).
+      properties:
+        specVersion:
+          type: string
+          example: "1.0"
+        host:
+          $ref: '#/components/schemas/CatalogHostInfo'
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogEntry'
+      required:
+        - specVersion
+        - entries
+
+    CatalogHostInfo:
+      type: object
+      description: |
+        Host Info object (AI Catalog §4.3) identifying the operator of a
+        catalog document. `displayName` is required within Host Info; for a
+        per-host document both fields are the agentHost.
+      properties:
+        identifier:
+          type: string
+          example: ai-agent.acmecorp.com
+        displayName:
+          type: string
+          example: ai-agent.acmecorp.com
+      required:
+        - displayName
+
+    CatalogPublisher:
+      type: object
+      description: |
+        Publishing entity (AI Catalog §4.6). DNS-anchored in this RA;
+        `identifier` and `displayName` are both the agentHost.
+      properties:
+        identifier:
+          type: string
+          example: ai-agent.acmecorp.com
+        displayName:
+          type: string
+          example: ai-agent.acmecorp.com
+        identityType:
+          type: string
+          example: dns
+      required:
+        - identifier
+        - displayName
+
+    CatalogEntryMetadata:
+      type: object
+      description: |
+        Entry-level identifiers a consumer verifies against (IMPL §5.3). No
+        `logId` — the TL is keyed by agentId, not logId.
+      properties:
+        ansName:
+          type: string
+          example: ans://v2.1.0.ai-agent.acmecorp.com
+        agentHost:
+          type: string
+          example: ai-agent.acmecorp.com
+        badgeUrl:
+          type: string
+          format: uri
+          description: |
+            TL status / card-integrity surface (`<tl>/v1/agents/{agentId}`).
+            Omitted when no TL base URL is configured.
+      required:
+        - ansName
+        - agentHost
+
+    CatalogTrustManifest:
+      type: object
+      description: |
+        Verifiable identity + trust metadata (AI Catalog §5). `identity`
+        MUST equal the containing entry's `identifier`.
+      properties:
+        identity:
+          type: string
+          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+        attestations:
+          type: array
+          description: |
+            Present only when a TL base URL is configured. The slice-1
+            attestation is the ANS-Registration SCITT receipt.
+          items:
+            $ref: '#/components/schemas/CatalogAttestation'
+      required:
+        - identity
+
+    CatalogAttestation:
+      type: object
+      description: |
+        A verifiable claim (AI Catalog §5.4). The ANS-Registration
+        attestation points at the agent's SCITT receipt on the Transparency
+        Log; it carries no digest (the receipt proves inclusion, not entry
+        content).
+      properties:
+        type:
+          type: string
+          example: ANS-Registration
+        uri:
+          type: string
+          format: uri
+          example: https://tl.example.org/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt
+        mediaType:
+          type: string
+          example: application/scitt-receipt+cose
+      required:
+        - type
+        - uri
+        - mediaType
 
     NextStep:
       type: object

--- a/internal/adapter/store/sqlite/outbox.go
+++ b/internal/adapter/store/sqlite/outbox.go
@@ -79,6 +79,51 @@ func (s *OutboxStore) Enqueue(
 	return id, nil
 }
 
+// RecordSealed inserts an outbox row that is ALREADY delivered: both
+// sent_at_ms and log_id are set at insert time, so the row is never
+// visible to Claim (which selects `sent_at_ms IS NULL`) and the worker
+// never re-sends it. It exists for events sealed INLINE
+// (seal-before-success — agent activation): the TL has already acked the
+// append and returned logId, but the agent-events feed is a read model
+// over delivered outbox rows (`sent_at_ms IS NOT NULL AND log_id IS NOT
+// NULL`, migration 006), so without this row an inline-sealed event
+// would never surface on GET /v1/agents/events and the Finder would
+// never discover the agent. Called inside the activation transaction so
+// feed visibility commits atomically with the ACTIVE status.
+func (s *OutboxStore) RecordSealed(
+	ctx context.Context,
+	eventType, agentID, schemaVersion string,
+	payload []byte,
+	logID string,
+) (int64, error) {
+	if len(payload) == 0 {
+		return 0, errors.New("sqlite/outbox: payload is empty")
+	}
+	if logID == "" {
+		return 0, errors.New("sqlite/outbox: logID is empty — a sealed row must carry the TL ack's logId")
+	}
+	switch schemaVersion {
+	case "V1", "V2":
+	default:
+		return 0, fmt.Errorf("sqlite/outbox: invalid schemaVersion %q (want V1 or V2)", schemaVersion)
+	}
+	const q = `
+        INSERT INTO outbox_events(event_type, agent_id, schema_version, payload_json,
+            next_attempt_at_ms, created_at_ms, sent_at_ms, log_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	now := time.Now().UnixMilli()
+	res, err := s.db.extx(ctx).ExecContext(ctx, q, eventType, agentID, schemaVersion, string(payload),
+		now, now, now, logID)
+	if err != nil {
+		return 0, mapSQLErr(err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
 // Claim returns up to batchSize pending outbox events whose
 // next_attempt_at_ms has passed. Callers process each event and then
 // call MarkSent or MarkFailed. There is no explicit lease — we rely on

--- a/internal/adapter/tlclient/client.go
+++ b/internal/adapter/tlclient/client.go
@@ -266,3 +266,27 @@ func (c *Client) SealIdentityEvent(ctx context.Context, innerCanonical []byte, p
 			"the transparency log rejected the identity event", err)
 	}
 }
+
+// SealAgentEvent submits a producer-signed AGENT event on the V1 or V2
+// ingest lane and returns only after the TL acknowledges the seal — the
+// client half of seal-before-success for agent ACTIVATION (ANS-1 §12.3:
+// "the RA MUST NOT activate without a sealed event"). Used by the
+// registration service to seal AGENT_REGISTERED inline at verify-dns,
+// before the agent is reported ACTIVE. Error mapping mirrors
+// SealIdentityEvent: transient → TL_UNAVAILABLE (retryable, nothing
+// consumed — the activation can be retried), permanent → TL_REJECTED_EVENT
+// (the RA produced an event the TL refuses — a pipeline bug operators must
+// see). schemaVersion selects the lane ("V1" or "V2").
+func (c *Client) SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) error {
+	_, err := c.Append(ctx, schemaVersion, innerCanonical, producerSig)
+	switch {
+	case err == nil:
+		return nil
+	case IsTransient(err):
+		return domain.NewUnavailableError("TL_UNAVAILABLE",
+			"the transparency log did not confirm the seal; activation is retryable and nothing was consumed")
+	default:
+		return domain.NewInternalError("TL_REJECTED_EVENT",
+			"the transparency log rejected the agent event", err)
+	}
+}

--- a/internal/adapter/tlclient/client.go
+++ b/internal/adapter/tlclient/client.go
@@ -36,6 +36,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/godaddy/ans/internal/domain"
 )
 
@@ -84,6 +86,7 @@ type Client struct {
 	baseURL string
 	apiKey  string
 	http    *http.Client
+	logger  zerolog.Logger
 }
 
 // New constructs a Client. baseURL is the TL's listen URL (no
@@ -96,6 +99,7 @@ func New(baseURL, apiKey string, timeout time.Duration) *Client {
 		baseURL: baseURL,
 		apiKey:  apiKey,
 		http:    &http.Client{Timeout: timeout},
+		logger:  zerolog.Nop(),
 	}
 }
 
@@ -241,6 +245,28 @@ func IsPermanent(err error) bool {
 	return errors.As(err, &p)
 }
 
+// WithLogger attaches the structured logger used to record the raw
+// transport cause of a failed seal BEFORE the domain mapping strips it —
+// the RA-side line that distinguishes a timeout from connection-refused
+// from a 429 during a TL incident. Defaults to zerolog.Nop().
+func (c *Client) WithLogger(logger zerolog.Logger) *Client {
+	c.logger = logger.With().Str("component", "tl-client").Logger()
+	return c
+}
+
+// logSealFailure records the unmapped transport error for a failed seal.
+// WARN for transient faults (retryable; expected during a TL incident),
+// ERROR for permanent rejections (the RA produced an event the TL
+// refuses). The domain error the caller receives carries only the
+// sanitized category, so this line is where the cause survives.
+func (c *Client) logSealFailure(lane string, err error) {
+	ev := c.logger.Error()
+	if IsTransient(err) {
+		ev = c.logger.Warn()
+	}
+	ev.Err(err).Str("lane", lane).Msg("TL seal failed")
+}
+
 // SealIdentityEvent submits a producer-signed identity event on the
 // IDENTITY lane and returns only after the TL acknowledges the seal —
 // the client half of seal-before-success (design §5.6.1). Identity
@@ -255,6 +281,9 @@ func IsPermanent(err error) bool {
 //     a pipeline bug, not weather; operators must see it.
 func (c *Client) SealIdentityEvent(ctx context.Context, innerCanonical []byte, producerSig string) error {
 	_, err := c.Append(ctx, "IDENTITY", innerCanonical, producerSig)
+	if err != nil {
+		c.logSealFailure("IDENTITY", err)
+	}
 	switch {
 	case err == nil:
 		return nil
@@ -283,6 +312,9 @@ func (c *Client) SealIdentityEvent(ctx context.Context, innerCanonical []byte, p
 // ("V1" or "V2").
 func (c *Client) SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) (string, error) {
 	res, err := c.Append(ctx, schemaVersion, innerCanonical, producerSig)
+	if err != nil {
+		c.logSealFailure(schemaVersion, err)
+	}
 	switch {
 	case err == nil:
 		return res.LogID, nil

--- a/internal/adapter/tlclient/client.go
+++ b/internal/adapter/tlclient/client.go
@@ -272,21 +272,25 @@ func (c *Client) SealIdentityEvent(ctx context.Context, innerCanonical []byte, p
 // client half of seal-before-success for agent ACTIVATION (ANS-1 §12.3:
 // "the RA MUST NOT activate without a sealed event"). Used by the
 // registration service to seal AGENT_REGISTERED inline at verify-dns,
-// before the agent is reported ACTIVE. Error mapping mirrors
-// SealIdentityEvent: transient → TL_UNAVAILABLE (retryable, nothing
-// consumed — the activation can be retried), permanent → TL_REJECTED_EVENT
-// (the RA produced an event the TL refuses — a pipeline bug operators must
-// see). schemaVersion selects the lane ("V1" or "V2").
-func (c *Client) SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) error {
-	_, err := c.Append(ctx, schemaVersion, innerCanonical, producerSig)
+// before the agent is reported ACTIVE. On success it returns the
+// TL-assigned logId from the ack — the activation path persists it on a
+// pre-delivered outbox row so the sealed event surfaces on the
+// agent-events feed (which gates on log_id) without riding the worker.
+// Error mapping mirrors SealIdentityEvent: transient → TL_UNAVAILABLE
+// (retryable, nothing consumed — the activation can be retried),
+// permanent → TL_REJECTED_EVENT (the RA produced an event the TL refuses
+// — a pipeline bug operators must see). schemaVersion selects the lane
+// ("V1" or "V2").
+func (c *Client) SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) (string, error) {
+	res, err := c.Append(ctx, schemaVersion, innerCanonical, producerSig)
 	switch {
 	case err == nil:
-		return nil
+		return res.LogID, nil
 	case IsTransient(err):
-		return domain.NewUnavailableError("TL_UNAVAILABLE",
+		return "", domain.NewUnavailableError("TL_UNAVAILABLE",
 			"the transparency log did not confirm the seal; activation is retryable and nothing was consumed")
 	default:
-		return domain.NewInternalError("TL_REJECTED_EVENT",
+		return "", domain.NewInternalError("TL_REJECTED_EVENT",
 			"the transparency log rejected the agent event", err)
 	}
 }

--- a/internal/ard/urn.go
+++ b/internal/ard/urn.go
@@ -1,0 +1,57 @@
+// Package ard holds the projection rules shared by every surface that
+// mints ARD (Agentic Resource Discovery) identifiers from registration
+// data. Two independent surfaces project the same registrations — the
+// Finder's search results (internal/finder/project) and the RA's
+// published AI Catalog (internal/catalog) — and "both hand consumers ONE
+// lineage identifier per agent" is a stated invariant. Keeping the
+// derivation here makes that invariant structural instead of two
+// mirrored copies held in lockstep by comments (which diverged twice
+// while they were copies).
+package ard
+
+import "strings"
+
+// urnNamespace is the fixed hierarchical segment between the publisher
+// host and the agent label in a minted URN. ANS registers agents, so
+// every entry lives under the `agents` namespace.
+const urnNamespace = "agents"
+
+// MintURN builds the ARD discovery identifier for an agent
+// (ARD spec v0.9 §4.2.1):
+//
+//	urn:air:<agentHost>:agents:<label>
+//
+// The URN is a LINEAGE HANDLE, not a per-registration key: successive
+// versions of the same logical agent (same host + same display name)
+// deliberately share it. Per-registration uniqueness is carried in the
+// wrapper (AgentID/AnsName/LogID) and in metadata, never in the URN.
+// The intra-host label space (everything after the host) is the
+// publisher's to manage.
+//
+// agentHost is the attested host, already syntax-validated upstream; it
+// is lowercased here so the publisher segment is canonical. The label is
+// the sanitized display name via Labelize. An empty label (display name
+// missing or sanitized away to nothing) yields a false second result:
+// callers skip or reject the projection rather than substituting any
+// fallback, because a URN without a real terminal segment is not a
+// usable discovery handle.
+func MintURN(agentHost, sanitizedDisplayName string) (string, bool) {
+	label := Labelize(sanitizedDisplayName)
+	if label == "" {
+		return "", false
+	}
+	return "urn:air:" + strings.ToLower(agentHost) + ":" + urnNamespace + ":" + label, true
+}
+
+// Labelize turns a sanitized display name into a URN terminal segment:
+// trim, then collapse each run of whitespace to a single hyphen. It does
+// not change case (intra-host label space is publisher-owned) and does
+// not otherwise rewrite characters — the caller's text sanitizer has
+// already removed control and bidi runes upstream.
+func Labelize(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(s), "-")
+}

--- a/internal/ard/urn_test.go
+++ b/internal/ard/urn_test.go
@@ -1,0 +1,48 @@
+package ard
+
+import "testing"
+
+// TestMintURN pins the shared derivation both projection surfaces (the
+// Finder's search results and the RA's published catalog) depend on:
+// lowercased host, `agents` namespace, labelized display name, and the
+// no-label refusal.
+func TestMintURN(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		displayName string
+		want        string
+		ok          bool
+	}{
+		{"simple", "agent.example.com", "demo-agent", "urn:air:agent.example.com:agents:demo-agent", true},
+		{"spaces collapse to hyphens", "agent.example.com", "Acme Support Agent", "urn:air:agent.example.com:agents:Acme-Support-Agent", true},
+		{"host lowercased, label case kept", "AGENT.Example.COM", "CasePreserved", "urn:air:agent.example.com:agents:CasePreserved", true},
+		{"internal whitespace runs", "a.example.com", "  spaced   out\tname ", "urn:air:a.example.com:agents:spaced-out-name", true},
+		{"empty display name refused", "a.example.com", "", "", false},
+		{"whitespace-only refused", "a.example.com", " \t ", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := MintURN(tc.host, tc.displayName)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("MintURN(%q, %q) = (%q, %v), want (%q, %v)",
+					tc.host, tc.displayName, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestLabelize(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"demo-agent", "demo-agent"},
+		{"Acme Support Agent", "Acme-Support-Agent"},
+		{"  edges trimmed  ", "edges-trimmed"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tc := range tests {
+		if got := Labelize(tc.in); got != tc.want {
+			t.Errorf("Labelize(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,157 @@
+// Package catalog generates AI Catalog artifacts from a registration
+// aggregate. It is the single generation seam (IMPL-ai-catalog §10): every
+// emitted catalog shape — the per-agent CatalogEntry today, the per-host
+// document and population export later — is composed here, so the pending
+// IANA churn (the urn:ai NID, the application/ai-catalog+json media type,
+// the type/mediaType discriminator rename) lands in one place.
+//
+// ANS is a producer only: every byte is derived from the RA's own
+// registration aggregate. Nothing here is sealed in the Transparency Log
+// and nothing new is verified — the artifact's trust comes from the
+// ANS-Registration attestation it carries (a SCITT-receipt URI a consumer
+// verifies against the TL). The package is pure: no I/O, no clock, no
+// global state, so any document can be regenerated from current RA state.
+//
+// Authoritative shape: the AI Catalog draft of 2026-06-11. Field names,
+// the one-of url|data invariant, and the media types follow that draft;
+// the projection choices (the urn:ai:{host}:agents:{label} lineage handle,
+// the ANS-Registration attestation, the {ansName,agentHost,badgeUrl}
+// metadata) follow IMPL-ai-catalog-generation.md.
+package catalog
+
+// SpecVersion is the AI Catalog document version this generator emits. It
+// is pinned and never overstated (AI Catalog §8.4 producer rule); it
+// labels the nested catalog a multi-protocol entry inlines (§3.5) and,
+// from slice 2, the per-host and export documents.
+const SpecVersion = "1.0"
+
+// Media types and the trust-manifest vocabulary, all from the 2026-06-11
+// draft. MediaTypeCatalog discriminates a (possibly nested) catalog
+// document; the A2A/MCP values discriminate a single protocol card.
+const (
+	MediaTypeCatalog = "application/ai-catalog+json"
+	mediaTypeA2A     = "application/a2a-agent-card+json"
+	mediaTypeMCP     = "application/mcp-server-card+json"
+
+	// attestationType is the trust-manifest attestation that points a
+	// consumer at the agent's SCITT receipt on the Transparency Log
+	// (IMPL §5.2). It is the only attestation slice 1 emits.
+	attestationType  = "ANS-Registration"
+	receiptMediaType = "application/scitt-receipt+cose"
+
+	// identityTypeDNS marks the publisher identity as DNS-anchored.
+	// Graduates to "did" once an owner links a did:web identity (§9);
+	// slice 1 is always "dns".
+	identityTypeDNS = "dns"
+)
+
+// Entry is one CatalogEntry — a single artifact's record (IMPL §3). The
+// same type serves a top-level entry, a multi-protocol outer entry (which
+// carries Data instead of URL), and a lean nested child (identifier /
+// displayName / mediaType / url only): every non-required field is
+// omitempty, so each shape marshals correctly without a separate type.
+//
+// Field order mirrors the IMPL Appendix B worked examples so emitted JSON
+// diffs line-for-line against the spec. A bare Entry is served as
+// application/json — it is not itself a catalog document and carries no
+// specVersion (§2).
+type Entry struct {
+	// Identifier is the stable, version-spanning lineage handle
+	// urn:ai:{agentHost}:agents:{label} (§3.3) — never the per-version
+	// agentId. MUST.
+	Identifier string `json:"identifier"`
+	// DisplayName is the agent's human-readable name (≤64). MUST.
+	DisplayName string `json:"displayName"`
+	// Description is a short capability summary (≤150). Optional.
+	Description string `json:"description,omitempty"`
+	// Version is the bare semver (e.g. "2.1.0"). Required for
+	// eligibility (§3.6 Gate 1); absent on lean nested children.
+	Version string `json:"version,omitempty"`
+	// MediaType discriminates the artifact: an A2A/MCP card media type
+	// for a single-protocol entry, or MediaTypeCatalog for a
+	// multi-protocol outer entry (§3.5). MUST.
+	MediaType string `json:"mediaType"`
+	// URL points at the protocol metadata document (the endpoint's
+	// metaDataUrl). Exactly one of URL / Data is set per entry (§3.6);
+	// a leaf entry uses URL.
+	URL string `json:"url,omitempty"`
+	// Data inlines a nested catalog of per-protocol children, used only
+	// by the multi-protocol outer entry (§3.5). Never raw card bytes —
+	// ANS does not retain those.
+	Data *NestedCatalog `json:"data,omitempty"`
+	// Tags are discovery keywords passed through from the endpoint's
+	// functions[].tags. Optional.
+	Tags []string `json:"tags,omitempty"`
+	// UpdatedAt is an RFC 3339 timestamp of the last lifecycle change.
+	// Optional.
+	UpdatedAt string `json:"updatedAt,omitempty"`
+	// Publisher identifies the publishing entity (§3.7). Optional in
+	// the spec; always emitted.
+	Publisher *Publisher `json:"publisher,omitempty"`
+	// Metadata carries the identifiers a consumer needs to verify
+	// (§5.3): ansName, agentHost, badgeUrl. Optional in the spec;
+	// always emitted on a top-level entry.
+	Metadata *Metadata `json:"metadata,omitempty"`
+	// TrustManifest binds the entry to its SCITT-receipt attestation
+	// (§5), making it L3-Trusted. Optional in the spec; emitted on a
+	// top-level entry (attestations present only when the TL base URL
+	// is configured).
+	TrustManifest *TrustManifest `json:"trustManifest,omitempty"`
+}
+
+// NestedCatalog is the inline document a multi-protocol outer entry holds
+// in its Data field (§3.5): a self-contained catalog whose entries are the
+// per-protocol children. It carries specVersion because it is a catalog
+// document, but no host — it is inline data, never re-fetched.
+type NestedCatalog struct {
+	SpecVersion string  `json:"specVersion"`
+	Entries     []Entry `json:"entries"`
+}
+
+// Publisher identifies the entity publishing the artifact (AI Catalog
+// §4.6, IMPL §3.7). Identifier and DisplayName are required within a
+// Publisher; ANS has no verified org name, so both are the agentHost in
+// slice 1 (honest, no unverified claim) and IdentityType is "dns".
+type Publisher struct {
+	Identifier   string `json:"identifier"`
+	DisplayName  string `json:"displayName"`
+	IdentityType string `json:"identityType,omitempty"`
+}
+
+// Metadata is the entry-level metadata block (IMPL §5.3): plain keys
+// carrying the identifiers a consumer verifies against. No logId — the TL
+// has no lookup-by-logId route; it is keyed by agentId, which is visible
+// in both BadgeURL and the attestation receipt URI.
+type Metadata struct {
+	// AnsName is the canonical, DNS-resolvable ANS handle
+	// (ans://v{ver}.{host}); not derivable from the URN.
+	AnsName string `json:"ansName"`
+	// AgentHost is the sealed authority a consumer matches the URN's
+	// host segment against (§5.2 step 2).
+	AgentHost string `json:"agentHost"`
+	// BadgeURL is the TL status/card-integrity surface
+	// (<tl>/v1/agents/{agentId}). Omitted when no TL base URL is
+	// configured.
+	BadgeURL string `json:"badgeUrl,omitempty"`
+}
+
+// TrustManifest provides verifiable identity and trust metadata for the
+// entry (AI Catalog §5). Identity is the only MUST member and MUST equal
+// the containing entry's Identifier (§5.1); Attestations is optional and,
+// in slice 1, holds exactly the ANS-Registration SCITT-receipt attestation
+// when a TL base URL is configured.
+type TrustManifest struct {
+	Identity     string        `json:"identity"`
+	Attestations []Attestation `json:"attestations,omitempty"`
+}
+
+// Attestation is one verifiable claim (AI Catalog §5.4). The slice-1
+// attestation points at the agent's SCITT receipt on the TL; Type, URI,
+// and MediaType are all required. No digest: the receipt proves inclusion
+// of the latest sealed event, not the entry's content, so a content digest
+// would over-claim what it verifies (§3.2).
+type Attestation struct {
+	Type      string `json:"type"`
+	URI       string `json:"uri"`
+	MediaType string `json:"mediaType"`
+}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -57,8 +57,10 @@ const (
 // specVersion (§2).
 type Entry struct {
 	// Identifier is the stable, version-spanning lineage handle
-	// urn:air:{agentHost}:agents:{label} (§3.3) — never the per-version
-	// agentId. MUST.
+	// urn:air:{agentHost}:agents:{label} (ARD §4.2.1) — never the
+	// per-version agentId. {label} is the labelized display name, the
+	// same derivation the ARD Finder mints (see generate.go deriveLabel).
+	// MUST.
 	Identifier string `json:"identifier"`
 	// DisplayName is the agent's human-readable name (≤64). MUST.
 	DisplayName string `json:"displayName"`

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -2,7 +2,7 @@
 // aggregate. It is the single generation seam (IMPL-ai-catalog §10): every
 // emitted catalog shape — the per-agent CatalogEntry today, the per-host
 // document and population export later — is composed here, so the pending
-// IANA churn (the urn:ai NID, the application/ai-catalog+json media type,
+// IANA churn (the urn:air NID, the application/ai-catalog+json media type,
 // the type/mediaType discriminator rename) lands in one place.
 //
 // ANS is a producer only: every byte is derived from the RA's own
@@ -14,7 +14,7 @@
 //
 // Authoritative shape: the AI Catalog draft of 2026-06-11. Field names,
 // the one-of url|data invariant, and the media types follow that draft;
-// the projection choices (the urn:ai:{host}:agents:{label} lineage handle,
+// the projection choices (the urn:air:{host}:agents:{label} lineage handle,
 // the ANS-Registration attestation, the {ansName,agentHost,badgeUrl}
 // metadata) follow IMPL-ai-catalog-generation.md.
 package catalog
@@ -57,7 +57,7 @@ const (
 // specVersion (§2).
 type Entry struct {
 	// Identifier is the stable, version-spanning lineage handle
-	// urn:ai:{agentHost}:agents:{label} (§3.3) — never the per-version
+	// urn:air:{agentHost}:agents:{label} (§3.3) — never the per-version
 	// agentId. MUST.
 	Identifier string `json:"identifier"`
 	// DisplayName is the agent's human-readable name (≤64). MUST.

--- a/internal/catalog/document.go
+++ b/internal/catalog/document.go
@@ -1,0 +1,74 @@
+package catalog
+
+import (
+	"sort"
+
+	"github.com/godaddy/ans/internal/domain"
+)
+
+// Document is a catalog document (AI Catalog §4.2): the file an Agent
+// Hosting Platform publishes at /.well-known/ai-catalog.json. Unlike a
+// bare Entry, it carries specVersion and a host object and is served as
+// application/ai-catalog+json.
+type Document struct {
+	SpecVersion string    `json:"specVersion"`
+	Host        *HostInfo `json:"host,omitempty"`
+	Entries     []Entry   `json:"entries"`
+}
+
+// HostInfo identifies the operator of a catalog document (AI Catalog
+// §4.3). DisplayName is MUST-present within Host Info (§4.1); for a
+// per-host document both fields are the agentHost.
+type HostInfo struct {
+	Identifier  string `json:"identifier,omitempty"`
+	DisplayName string `json:"displayName"`
+}
+
+// BuildHostDocument composes the host-complete per-host catalog document
+// (§4): one CatalogEntry per catalog-eligible agent registered on
+// agentHost. regs is every registration for the host (any version, any
+// status), each with its Endpoints populated by the caller.
+//
+// Inclusion is decided entirely by BuildEntry: a registration appears only
+// if it is ACTIVE (sealed in the TL — §8 likewise has AHPs prune
+// deprecated/revoked from their well-known file; the population export
+// keeps them marked, §7.4), versioned, and has an eligible endpoint (§3.6).
+// Everything else is silently absent. Entries are sorted (identifier, then
+// version) so the emitted bytes — and therefore the ETag — are stable
+// across re-derivations.
+func BuildHostDocument(agentHost string, regs []*domain.AgentRegistration, opts Options) Document {
+	entries := make([]Entry, 0, len(regs))
+	for _, reg := range regs {
+		if reg == nil {
+			continue
+		}
+		entry, err := BuildEntry(reg, opts)
+		if err != nil {
+			// Not catalog-eligible (not ACTIVE, versionless, or no
+			// A2A/MCP endpoint with a policy-passing metaDataUrl) → absent.
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	sortEntries(entries)
+
+	host := sanitizeText(agentHost)
+	return Document{
+		SpecVersion: SpecVersion,
+		Host:        &HostInfo{Identifier: host, DisplayName: host},
+		Entries:     entries,
+	}
+}
+
+// sortEntries orders entries deterministically by identifier then
+// version. On a single host the identifier (the lineage handle) is shared
+// across versions, so this groups an agent's versions together in a
+// stable order — keeping the document bytes, and the ETag, reproducible.
+func sortEntries(entries []Entry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Identifier != entries[j].Identifier {
+			return entries[i].Identifier < entries[j].Identifier
+		}
+		return entries[i].Version < entries[j].Version
+	})
+}

--- a/internal/catalog/document_test.go
+++ b/internal/catalog/document_test.go
@@ -1,0 +1,169 @@
+package catalog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/godaddy/ans/internal/domain"
+)
+
+// activeReg builds an ACTIVE registration on the given host/version with a
+// single eligible MCP endpoint (metaDataUrl on the same host).
+func activeReg(t *testing.T, host, version string) *domain.AgentRegistration {
+	t.Helper()
+	reg := newRegHost(t, host, version, domain.AgentEndpoint{
+		Protocol:    domain.ProtocolMCP,
+		AgentURL:    "https://" + host + "/mcp",
+		MetadataURL: "https://" + host + "/.well-known/mcp/server-card.json",
+	})
+	reg.Status = domain.StatusActive
+	return reg
+}
+
+func TestBuildHostDocument_HostObjectAndEntries(t *testing.T) {
+	host := "ai-agent.acme.example.com"
+	regs := []*domain.AgentRegistration{activeReg(t, host, "1.0.0")}
+
+	doc := BuildHostDocument(host, regs, Options{TLPublicBaseURL: testTLBase})
+
+	if doc.SpecVersion != SpecVersion {
+		t.Errorf("specVersion = %q, want %q", doc.SpecVersion, SpecVersion)
+	}
+	if doc.Host == nil || doc.Host.Identifier != host || doc.Host.DisplayName != host {
+		t.Errorf("host object = %+v, want identifier=displayName=%q", doc.Host, host)
+	}
+	if len(doc.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(doc.Entries))
+	}
+	if doc.Entries[0].Identifier != "urn:ai:"+host+":agents:ai-agent" {
+		t.Errorf("entry identifier = %q", doc.Entries[0].Identifier)
+	}
+
+	// host.displayName MUST be present on the wire even though it equals
+	// the identifier (§4.1).
+	if js := mustJSON(t, doc); !contains(js, `"displayName":"`+host+`"`) {
+		t.Errorf("host.displayName must serialize: %s", js)
+	}
+}
+
+func TestBuildHostDocument_OnlyActiveEligible(t *testing.T) {
+	host := "h.example.com"
+
+	active := activeReg(t, host, "1.0.0")
+
+	pending := activeReg(t, host, "1.1.0")
+	pending.Status = domain.StatusPendingValidation // excluded: not ACTIVE
+
+	deprecated := activeReg(t, host, "0.9.0")
+	deprecated.Status = domain.StatusDeprecated // excluded: AHPs prune from well-known (§8)
+
+	revoked := activeReg(t, host, "0.8.0")
+	revoked.Status = domain.StatusRevoked // excluded
+
+	// ACTIVE but ineligible (no metaDataUrl) → absent.
+	ineligible := newRegHost(t, host, "2.0.0", domain.AgentEndpoint{
+		Protocol: domain.ProtocolMCP,
+		AgentURL: "https://" + host + "/mcp",
+	})
+	ineligible.Status = domain.StatusActive
+
+	doc := BuildHostDocument(host, []*domain.AgentRegistration{
+		pending, active, deprecated, revoked, ineligible,
+	}, Options{TLPublicBaseURL: testTLBase})
+
+	if len(doc.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1 (only the ACTIVE eligible agent)", len(doc.Entries))
+	}
+	if doc.Entries[0].Version != "1.0.0" {
+		t.Errorf("entry version = %q, want 1.0.0", doc.Entries[0].Version)
+	}
+}
+
+func TestBuildHostDocument_MultiVersionSortedAndStable(t *testing.T) {
+	host := "h.example.com"
+	// Supply versions out of order; expect deterministic (identifier,
+	// version) ordering so the ETag is reproducible.
+	regs := []*domain.AgentRegistration{
+		activeReg(t, host, "2.0.0"),
+		activeReg(t, host, "1.0.0"),
+		activeReg(t, host, "1.2.0"),
+	}
+	doc := BuildHostDocument(host, regs, Options{TLPublicBaseURL: testTLBase})
+	if len(doc.Entries) != 3 {
+		t.Fatalf("entries = %d, want 3", len(doc.Entries))
+	}
+	got := []string{doc.Entries[0].Version, doc.Entries[1].Version, doc.Entries[2].Version}
+	want := []string{"1.0.0", "1.2.0", "2.0.0"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("version order = %v, want %v", got, want)
+		}
+	}
+	// Same inputs → identical bytes (ETag stability).
+	doc2 := BuildHostDocument(host, []*domain.AgentRegistration{
+		activeReg(t, host, "1.2.0"), activeReg(t, host, "2.0.0"), activeReg(t, host, "1.0.0"),
+	}, Options{TLPublicBaseURL: testTLBase})
+	if mustJSON(t, doc) != mustJSON(t, doc2) {
+		t.Error("documents from the same registrations (different input order) must serialize identically")
+	}
+}
+
+func TestBuildHostDocument_EmptyWhenNoEligible(t *testing.T) {
+	host := "empty.example.com"
+	// One PENDING, one ACTIVE-but-ineligible → no entries, but the
+	// document is still well-formed (specVersion + host + empty entries).
+	pending := activeReg(t, host, "1.0.0")
+	pending.Status = domain.StatusPendingDNS
+
+	doc := BuildHostDocument(host, []*domain.AgentRegistration{pending}, Options{})
+	if doc.SpecVersion != SpecVersion || doc.Host == nil {
+		t.Fatalf("document must stay well-formed when empty: %+v", doc)
+	}
+	if len(doc.Entries) != 0 {
+		t.Errorf("entries = %d, want 0", len(doc.Entries))
+	}
+	// entries MUST serialize as [] (not null) so consumers can iterate.
+	if js := mustJSON(t, doc); !contains(js, `"entries":[]`) {
+		t.Errorf("empty entries must marshal as []: %s", js)
+	}
+}
+
+func TestBuildHostDocument_NilRegSkipped(t *testing.T) {
+	host := "h.example.com"
+	doc := BuildHostDocument(host, []*domain.AgentRegistration{nil, activeReg(t, host, "1.0.0")}, Options{TLPublicBaseURL: testTLBase})
+	if len(doc.Entries) != 1 {
+		t.Fatalf("nil registration must be skipped; entries = %d", len(doc.Entries))
+	}
+}
+
+// TestSortEntries exercises sortEntries directly, including the
+// distinct-identifier branch that a single-host document never hits (one
+// host = one lineage label) but the slice-3 multi-host export will.
+func TestSortEntries(t *testing.T) {
+	entries := []Entry{
+		{Identifier: "urn:ai:b.example.com:agents:b", Version: "1.0.0"},
+		{Identifier: "urn:ai:a.example.com:agents:a", Version: "2.0.0"},
+		{Identifier: "urn:ai:a.example.com:agents:a", Version: "1.0.0"},
+	}
+	sortEntries(entries)
+	want := []struct{ id, ver string }{
+		{"urn:ai:a.example.com:agents:a", "1.0.0"},
+		{"urn:ai:a.example.com:agents:a", "2.0.0"},
+		{"urn:ai:b.example.com:agents:b", "1.0.0"},
+	}
+	for i, w := range want {
+		if entries[i].Identifier != w.id || entries[i].Version != w.ver {
+			t.Fatalf("entry %d = (%q,%q), want (%q,%q)", i, entries[i].Identifier, entries[i].Version, w.id, w.ver)
+		}
+	}
+}
+
+// guard: a freshly built host document round-trips through encoding/json
+// without error (used by the handler to compute the ETag + body).
+func TestBuildHostDocument_Marshalable(t *testing.T) {
+	host := "h.example.com"
+	doc := BuildHostDocument(host, []*domain.AgentRegistration{activeReg(t, host, "1.0.0")}, Options{TLPublicBaseURL: testTLBase})
+	if _, err := json.Marshal(doc); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}

--- a/internal/catalog/document_test.go
+++ b/internal/catalog/document_test.go
@@ -35,7 +35,7 @@ func TestBuildHostDocument_HostObjectAndEntries(t *testing.T) {
 	if len(doc.Entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(doc.Entries))
 	}
-	if doc.Entries[0].Identifier != "urn:air:"+host+":agents:ai-agent" {
+	if doc.Entries[0].Identifier != "urn:air:"+host+":agents:Acme-Support-Agent" {
 		t.Errorf("entry identifier = %q", doc.Entries[0].Identifier)
 	}
 

--- a/internal/catalog/document_test.go
+++ b/internal/catalog/document_test.go
@@ -35,7 +35,7 @@ func TestBuildHostDocument_HostObjectAndEntries(t *testing.T) {
 	if len(doc.Entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(doc.Entries))
 	}
-	if doc.Entries[0].Identifier != "urn:ai:"+host+":agents:ai-agent" {
+	if doc.Entries[0].Identifier != "urn:air:"+host+":agents:ai-agent" {
 		t.Errorf("entry identifier = %q", doc.Entries[0].Identifier)
 	}
 
@@ -141,15 +141,15 @@ func TestBuildHostDocument_NilRegSkipped(t *testing.T) {
 // host = one lineage label) but the slice-3 multi-host export will.
 func TestSortEntries(t *testing.T) {
 	entries := []Entry{
-		{Identifier: "urn:ai:b.example.com:agents:b", Version: "1.0.0"},
-		{Identifier: "urn:ai:a.example.com:agents:a", Version: "2.0.0"},
-		{Identifier: "urn:ai:a.example.com:agents:a", Version: "1.0.0"},
+		{Identifier: "urn:air:b.example.com:agents:b", Version: "1.0.0"},
+		{Identifier: "urn:air:a.example.com:agents:a", Version: "2.0.0"},
+		{Identifier: "urn:air:a.example.com:agents:a", Version: "1.0.0"},
 	}
 	sortEntries(entries)
 	want := []struct{ id, ver string }{
-		{"urn:ai:a.example.com:agents:a", "1.0.0"},
-		{"urn:ai:a.example.com:agents:a", "2.0.0"},
-		{"urn:ai:b.example.com:agents:b", "1.0.0"},
+		{"urn:air:a.example.com:agents:a", "1.0.0"},
+		{"urn:air:a.example.com:agents:a", "2.0.0"},
+		{"urn:air:b.example.com:agents:b", "1.0.0"},
 	}
 	for i, w := range want {
 		if entries[i].Identifier != w.id || entries[i].Version != w.ver {

--- a/internal/catalog/generate.go
+++ b/internal/catalog/generate.go
@@ -1,0 +1,308 @@
+package catalog
+
+import (
+	"strings"
+	"time"
+
+	"github.com/godaddy/ans/internal/domain"
+)
+
+// Options configures CatalogEntry generation.
+type Options struct {
+	// TLPublicBaseURL is the externally-reachable Transparency Log base
+	// URL (e.g. "https://tl.example.org"). When empty — TL not
+	// configured — the entry omits the badge URL and the trust
+	// manifest's attestations rather than emit a malformed URI (§5.2);
+	// the manifest still carries its identity. In production this is
+	// required RA config, so attestations are always present.
+	TLPublicBaseURL string
+	// AllowInsecureURLs permits http metaDataUrl values to pass the URL
+	// policy. A dev-only override (§3.8); false in production, where
+	// only https is emitted.
+	AllowInsecureURLs bool
+}
+
+// NotEligibleError reports that a registration produces no CatalogEntry
+// (IMPL §3.6). The handler maps it to 422 NOT_CATALOG_ELIGIBLE; the
+// registration response uses Reason as the machine-readable omission code.
+type NotEligibleError struct {
+	// Reason is a machine-readable code: ReasonNoVersion,
+	// ReasonNotActive, or ReasonNoEligibleEndpoint.
+	Reason string
+	msg    string
+}
+
+// Machine-readable NotEligibleError reasons.
+const (
+	// ReasonNoVersion: the registration is versionless (§3.6 Gate 1).
+	ReasonNoVersion = "NO_VERSION"
+	// ReasonNotActive: the agent is not ACTIVE. A catalog entry carries an
+	// ANS-Registration attestation (its SCITT receipt) and a TL badge URL,
+	// and those Transparency-Log records only exist once the agent has been
+	// sealed at activation. A pre-activation registration has no TL entry
+	// to link to, so no catalog entry is produced until the agent is live.
+	ReasonNotActive = "AGENT_NOT_ACTIVE"
+	// ReasonNoEligibleEndpoint: no A2A/MCP endpoint carries a
+	// policy-passing metaDataUrl (§3.6 Gate 2).
+	ReasonNoEligibleEndpoint = "NO_ELIGIBLE_ENDPOINT"
+)
+
+func (e *NotEligibleError) Error() string { return e.msg }
+
+// BuildEntry serializes a registration aggregate into its CatalogEntry
+// (IMPL §3). Every field is derived from the aggregate; nothing is fetched.
+// It returns a *NotEligibleError when the registration produces no entry:
+// versionless (§3.6 Gate 1), not ACTIVE (no Transparency-Log entry to link
+// to yet), or no A2A/MCP endpoint with a policy-passing metaDataUrl (§3.6
+// Gate 2). reg.Endpoints must be populated by the caller.
+//
+// The ACTIVE gate is load-bearing, not cosmetic: a catalog entry's trust
+// manifest points at the agent's SCITT receipt and its metadata carries the
+// TL badge URL, and both of those Transparency-Log records are created only
+// when the agent is sealed at activation (verify-dns). Producing an entry
+// for a pre-activation registration would advertise links to TL records
+// that do not exist — so no entry is generated until the agent is live.
+//
+// Endpoint eligibility is evaluated per endpoint (§3.6 pseudocode): HTTP-API
+// and unknown protocols produce no entry; an endpoint with no metaDataUrl
+// produces no entry (no well-known fallback — ANS only points at metadata
+// the registrant actually declared); a metaDataUrl that fails the URL
+// policy (§3.8) is skipped. One eligible endpoint yields a plain top-level
+// entry; two or more yield a nested outer entry (§3.5) whose Data holds a
+// per-protocol child for each, so one agent can expose A2A and MCP without
+// two top-level entries colliding on (identifier, version).
+func BuildEntry(reg *domain.AgentRegistration, opts Options) (Entry, error) {
+	if reg == nil {
+		return Entry{}, &NotEligibleError{
+			Reason: ReasonNoVersion,
+			msg:    "registration is nil",
+		}
+	}
+
+	// Gate 1: versioned only. Every catalog-eligible registration
+	// carries a version (the ANSName is ans://{version}.{agentHost}),
+	// which also keeps (identifier, version) unique by construction
+	// (§3.4). Structurally always true in this RA — there is no
+	// versionless registration path — but enforced honestly for spec
+	// fidelity and any future base-only profile.
+	if reg.AnsName.IsZero() || reg.AnsName.Version().IsZero() {
+		return Entry{}, &NotEligibleError{
+			Reason: ReasonNoVersion,
+			msg:    "registration has no version; only versioned registrations are catalog-eligible",
+		}
+	}
+
+	// Gate: the agent must be ACTIVE — sealed in the Transparency Log — so
+	// the entry's SCITT-receipt attestation and badge URL reference TL
+	// records that actually exist. A pending/failed registration has no TL
+	// entry, so it is not catalogued until it goes live.
+	if reg.Status != domain.StatusActive {
+		return Entry{}, &NotEligibleError{
+			Reason: ReasonNotActive,
+			msg:    "agent is not ACTIVE; a catalog entry is published only after the agent is sealed in the Transparency Log",
+		}
+	}
+
+	agentHost := reg.AnsName.AgentHost()
+	urn := sanitizeText(buildURN(agentHost, deriveLabel(agentHost)))
+
+	// Gate 2: collect endpoints eligible for an entry.
+	eligible := collectEligibleEndpoints(reg.Endpoints, agentHost, opts.AllowInsecureURLs)
+	if len(eligible) == 0 {
+		return Entry{}, &NotEligibleError{
+			Reason: ReasonNoEligibleEndpoint,
+			msg:    "registration has no A2A or MCP endpoint with a metadata URL eligible for cataloging",
+		}
+	}
+
+	entry := Entry{
+		Identifier:  urn,
+		DisplayName: sanitizeText(reg.Details.DisplayName),
+		Description: sanitizeText(reg.Details.Description),
+		Version:     sanitizeText(reg.AnsName.Version().String()),
+		// UpdatedAt: registration (or last-renewal) time is a deliberate
+		// proxy for IMPL §3.1's "activation / latest seal timestamp" — the
+		// RA persists no activation timestamp (Activate discards `now` into
+		// the event only), and updatedAt is optional, so this is a fidelity
+		// proxy, not the sealed go-live time.
+		UpdatedAt:     rfc3339(reg.Details.EffectiveTimestamp()),
+		Publisher:     buildPublisher(agentHost),
+		Metadata:      buildMetadata(reg, opts.TLPublicBaseURL),
+		TrustManifest: buildTrustManifest(urn, reg.AgentID, opts.TLPublicBaseURL),
+	}
+
+	if len(eligible) == 1 {
+		// Single includable endpoint → plain top-level entry (§3.5).
+		entry.MediaType = eligible[0].mediaType
+		entry.URL = eligible[0].url
+		entry.Tags = sanitizeTags(eligible[0].tags)
+		return entry, nil
+	}
+
+	// Multiple includable endpoints → nested outer entry (§3.5). The
+	// outer entry legally uses Data (an ANS-generated nested catalog,
+	// not raw card bytes) and carries the trust manifest; children stay
+	// lean.
+	entry.MediaType = MediaTypeCatalog
+	children := make([]Entry, 0, len(eligible))
+	for _, e := range eligible {
+		children = append(children, Entry{
+			Identifier:  urn + ":" + strings.ToLower(string(e.protocol)),
+			DisplayName: sanitizeText(reg.Details.DisplayName) + " (" + string(e.protocol) + ")",
+			MediaType:   e.mediaType,
+			URL:         e.url,
+		})
+	}
+	entry.Data = &NestedCatalog{SpecVersion: SpecVersion, Entries: children}
+	return entry, nil
+}
+
+// eligibleEndpoint is one endpoint that passed the §3.6 gate.
+type eligibleEndpoint struct {
+	protocol  domain.Protocol
+	mediaType string
+	url       string
+	tags      []string
+}
+
+// collectEligibleEndpoints applies the §3.6 per-endpoint gate, preserving
+// registration order: keep A2A/MCP endpoints whose metaDataUrl is present
+// and passes the URL policy; skip everything else.
+func collectEligibleEndpoints(endpoints []domain.AgentEndpoint, agentHost string, allowInsecure bool) []eligibleEndpoint {
+	out := make([]eligibleEndpoint, 0, len(endpoints))
+	for _, e := range endpoints {
+		mt, ok := protocolMediaType(e.Protocol)
+		if !ok {
+			continue // HTTP-API / unknown → no entry
+		}
+		if e.MetadataURL == "" {
+			continue // no declared metadata → no entry (no fallback)
+		}
+		safeURL, ok := validateEmittedURL(e.MetadataURL, agentHost, allowInsecure)
+		if !ok {
+			continue // fails URL policy → skip endpoint
+		}
+		out = append(out, eligibleEndpoint{
+			protocol:  e.Protocol,
+			mediaType: mt,
+			url:       safeURL,
+			tags:      collectTags(e.Functions),
+		})
+	}
+	return out
+}
+
+// protocolMediaType maps a catalog-eligible protocol to its artifact media
+// type. HTTP-API and any unknown protocol return false — they produce no
+// catalog artifact type (§3.6). The protocol enum is A2A/MCP/HTTP-API;
+// there is no PAYMENT.
+func protocolMediaType(p domain.Protocol) (string, bool) {
+	switch p {
+	case domain.ProtocolA2A:
+		return mediaTypeA2A, true
+	case domain.ProtocolMCP:
+		return mediaTypeMCP, true
+	default:
+		return "", false
+	}
+}
+
+// deriveLabel returns the lineage label for the URN: the leftmost DNS label
+// of agentHost (e.g. ai-agent.acmecorp.com → "ai-agent"). agentHost is
+// RFC-1123 validated upstream (at least two non-empty labels), so the
+// result is always non-empty. The label is stable across versions —
+// agentHost is immutable (ANS-1 §5), and one agentHost is one logical
+// agent (§3.4) — and is keyed on neither agentId (rotates per version) nor
+// displayName (mutable), satisfying §3.3 from data the RA already holds.
+func deriveLabel(agentHost string) string {
+	host := strings.ToLower(strings.TrimSpace(agentHost))
+	if i := strings.IndexByte(host, '.'); i > 0 {
+		return host[:i]
+	}
+	return host
+}
+
+// buildURN composes the domain-anchored lineage handle (§3.3). The host
+// segment is the registration's own agentHost, so a registry reads the
+// publisher domain directly from the identifier.
+func buildURN(agentHost, label string) string {
+	return "urn:ai:" + agentHost + ":agents:" + label
+}
+
+// buildPublisher builds the Publisher block (§3.7). ANS has no verified
+// org name, so identifier and displayName are both the agentHost (honest,
+// no unverified claim) and the identity is DNS-anchored.
+func buildPublisher(agentHost string) *Publisher {
+	host := sanitizeText(agentHost)
+	return &Publisher{
+		Identifier:   host,
+		DisplayName:  host,
+		IdentityType: identityTypeDNS,
+	}
+}
+
+// buildMetadata builds the entry metadata block (§5.3). BadgeURL is
+// included only when a TL base URL is configured.
+func buildMetadata(reg *domain.AgentRegistration, tlBaseURL string) *Metadata {
+	m := &Metadata{
+		AnsName:   sanitizeText(reg.AnsName.String()),
+		AgentHost: sanitizeText(reg.AnsName.AgentHost()),
+	}
+	if tlBaseURL != "" {
+		m.BadgeURL = badgeURL(tlBaseURL, reg.AgentID)
+	}
+	return m
+}
+
+// buildTrustManifest builds the trust manifest (§5). Identity MUST equal
+// the entry's identifier (§5.1). The ANS-Registration SCITT-receipt
+// attestation is added only when a TL base URL is configured; otherwise
+// the manifest carries identity alone (attestations is optional per the
+// 2026-06-11 draft §5.2), avoiding a malformed receipt URI.
+func buildTrustManifest(identifier, agentID, tlBaseURL string) *TrustManifest {
+	tm := &TrustManifest{Identity: identifier}
+	if tlBaseURL != "" {
+		tm.Attestations = []Attestation{{
+			Type:      attestationType,
+			URI:       receiptURL(tlBaseURL, agentID),
+			MediaType: receiptMediaType,
+		}}
+	}
+	return tm
+}
+
+// collectTags flattens and de-duplicates the tags across an endpoint's
+// functions, sanitizing each (§3.1 tags pass-through). Order is
+// first-seen; sanitizeTags drops empties and duplicates.
+func collectTags(functions []domain.AgentFunction) []string {
+	if len(functions) == 0 {
+		return nil
+	}
+	var tags []string
+	for _, fn := range functions {
+		tags = append(tags, fn.Tags...)
+	}
+	return sanitizeTags(tags)
+}
+
+// badgeURL is the TL badge surface for an agent: <tl>/v1/agents/{agentId}
+// (TL API spec). Built from already-validated config, not registrant
+// input, so it does not pass the agentHost-bound URL policy.
+func badgeURL(tlBaseURL, agentID string) string {
+	return strings.TrimRight(tlBaseURL, "/") + "/v1/agents/" + agentID
+}
+
+// receiptURL is the SCITT-receipt surface for an agent:
+// <tl>/v1/agents/{agentId}/receipt (TL API spec §5.2).
+func receiptURL(tlBaseURL, agentID string) string {
+	return badgeURL(tlBaseURL, agentID) + "/receipt"
+}
+
+// rfc3339 formats t as an RFC 3339 UTC timestamp, or "" when t is zero so
+// the caller can omit a missing updatedAt cleanly.
+func rfc3339(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/catalog/generate.go
+++ b/internal/catalog/generate.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/godaddy/ans/internal/ard"
 	"github.com/godaddy/ans/internal/domain"
 )
 
@@ -110,23 +111,21 @@ func BuildEntry(reg *domain.AgentRegistration, opts Options) (Entry, error) {
 
 	agentHost := reg.AnsName.AgentHost()
 
-	// Gate: a mintable label. The URN's terminal segment is the labelized
-	// display name — the SAME derivation the ARD Finder uses when it
-	// projects feed events into search results (see
-	// internal/finder/project/urn.go mintURN), so discovery and the
+	// Gate: a mintable identifier. The URN derivation is shared with the
+	// ARD Finder's search projection (internal/ard), so discovery and the
 	// published catalog hand consumers ONE lineage identifier per agent.
 	// A display name that is missing (it is optional at registration) or
 	// sanitizes away to nothing yields no usable discovery handle; the
 	// Finder skips such events, and the catalog mirrors that as
 	// not-eligible rather than substituting a fallback segment.
-	label := deriveLabel(sanitizeText(reg.Details.DisplayName))
-	if label == "" {
+	urn, ok := mintURN(agentHost, sanitizeText(reg.Details.DisplayName))
+	if !ok {
 		return Entry{}, &NotEligibleError{
 			Reason: ReasonNoLabel,
 			msg:    "registration has no display name to derive the URN label from; a catalog entry needs a usable lineage identifier",
 		}
 	}
-	urn := sanitizeText(buildURN(agentHost, label))
+	urn = sanitizeText(urn)
 
 	// Gate 2: collect endpoints eligible for an entry.
 	eligible := collectEligibleEndpoints(reg.Endpoints, agentHost, opts.AllowInsecureURLs)
@@ -169,8 +168,13 @@ func BuildEntry(reg *domain.AgentRegistration, opts Options) (Entry, error) {
 	children := make([]Entry, 0, len(eligible))
 	for _, e := range eligible {
 		children = append(children, Entry{
-			Identifier:  urn + ":" + strings.ToLower(string(e.protocol)),
-			DisplayName: sanitizeText(reg.Details.DisplayName) + " (" + string(e.protocol) + ")",
+			Identifier: urn + ":" + strings.ToLower(string(e.protocol)),
+			// The child reuses the parent's name verbatim: it is already
+			// fully discriminated by its :a2a/:mcp identifier segment and
+			// its mediaType, and any suffix could push a maximum-length
+			// (64-char) registered name past the published CatalogEntry
+			// displayName cap — a 200 body that fails our own schema.
+			DisplayName: sanitizeText(reg.Details.DisplayName),
 			MediaType:   e.mediaType,
 			URL:         e.url,
 		})
@@ -229,30 +233,17 @@ func protocolMediaType(p domain.Protocol) (string, bool) {
 	}
 }
 
-// deriveLabel returns the URN's terminal lineage segment: the sanitized
-// display name, trimmed, with each internal whitespace run collapsed to a
-// single hyphen (e.g. "Support  Assistant" → "Support-Assistant"). Case is
-// preserved — the intra-host label space is the publisher's to manage.
-// This is deliberately the SAME rule the ARD Finder applies when minting
-// identifiers from feed events (internal/finder/project/urn.go labelize),
-// so a consumer correlating a search result with the host's published
-// ai-catalog.json sees one lineage handle, not two. Successive versions of
-// one logical agent share the label by sharing a display name; an empty
-// result means no handle can be minted and the caller gates on it.
-func deriveLabel(displayName string) string {
-	s := strings.TrimSpace(displayName)
-	if s == "" {
-		return ""
-	}
-	return strings.Join(strings.Fields(s), "-")
-}
-
-// buildURN composes the domain-anchored lineage handle (ARD §4.2.1). The
-// host segment is the registration's own agentHost (lowercased), so a
-// registry reads the publisher domain directly from the identifier; the
-// label keeps its case — the intra-host label space is the publisher's.
-func buildURN(agentHost, label string) string {
-	return "urn:air:" + strings.ToLower(agentHost) + ":agents:" + label
+// mintURN is ard.MintURN — the single shared derivation of the
+// urn:air:{agentHost}:agents:{label} lineage handle, used by both this
+// catalog and the ARD Finder's search projection
+// (internal/finder/project/urn.go). Sharing the implementation is what
+// makes "search results and the published catalog hand consumers one
+// identifier per agent" structural rather than two mirrored copies.
+// Successive versions of one logical agent share the handle by sharing a
+// display name; a false second result means no usable label exists and
+// the caller gates on it (ReasonNoLabel).
+func mintURN(agentHost, sanitizedDisplayName string) (string, bool) {
+	return ard.MintURN(agentHost, sanitizedDisplayName)
 }
 
 // buildPublisher builds the Publisher block (§3.7). ANS has no verified

--- a/internal/catalog/generate.go
+++ b/internal/catalog/generate.go
@@ -226,7 +226,7 @@ func deriveLabel(agentHost string) string {
 // segment is the registration's own agentHost, so a registry reads the
 // publisher domain directly from the identifier.
 func buildURN(agentHost, label string) string {
-	return "urn:ai:" + agentHost + ":agents:" + label
+	return "urn:air:" + agentHost + ":agents:" + label
 }
 
 // buildPublisher builds the Publisher block (§3.7). ANS has no verified

--- a/internal/catalog/generate.go
+++ b/internal/catalog/generate.go
@@ -45,6 +45,11 @@ const (
 	// ReasonNoEligibleEndpoint: no A2A/MCP endpoint carries a
 	// policy-passing metaDataUrl (§3.6 Gate 2).
 	ReasonNoEligibleEndpoint = "NO_ELIGIBLE_ENDPOINT"
+	// ReasonNoLabel: the display name is missing or sanitizes away to
+	// nothing, so no URN label can be minted. Mirrors the ARD Finder,
+	// which skips such feed events instead of substituting a fallback
+	// discovery handle.
+	ReasonNoLabel = "NO_LABEL"
 )
 
 func (e *NotEligibleError) Error() string { return e.msg }
@@ -104,7 +109,24 @@ func BuildEntry(reg *domain.AgentRegistration, opts Options) (Entry, error) {
 	}
 
 	agentHost := reg.AnsName.AgentHost()
-	urn := sanitizeText(buildURN(agentHost, deriveLabel(agentHost)))
+
+	// Gate: a mintable label. The URN's terminal segment is the labelized
+	// display name — the SAME derivation the ARD Finder uses when it
+	// projects feed events into search results (see
+	// internal/finder/project/urn.go mintURN), so discovery and the
+	// published catalog hand consumers ONE lineage identifier per agent.
+	// A display name that is missing (it is optional at registration) or
+	// sanitizes away to nothing yields no usable discovery handle; the
+	// Finder skips such events, and the catalog mirrors that as
+	// not-eligible rather than substituting a fallback segment.
+	label := deriveLabel(sanitizeText(reg.Details.DisplayName))
+	if label == "" {
+		return Entry{}, &NotEligibleError{
+			Reason: ReasonNoLabel,
+			msg:    "registration has no display name to derive the URN label from; a catalog entry needs a usable lineage identifier",
+		}
+	}
+	urn := sanitizeText(buildURN(agentHost, label))
 
 	// Gate 2: collect endpoints eligible for an entry.
 	eligible := collectEligibleEndpoints(reg.Endpoints, agentHost, opts.AllowInsecureURLs)
@@ -207,26 +229,30 @@ func protocolMediaType(p domain.Protocol) (string, bool) {
 	}
 }
 
-// deriveLabel returns the lineage label for the URN: the leftmost DNS label
-// of agentHost (e.g. ai-agent.acmecorp.com → "ai-agent"). agentHost is
-// RFC-1123 validated upstream (at least two non-empty labels), so the
-// result is always non-empty. The label is stable across versions —
-// agentHost is immutable (ANS-1 §5), and one agentHost is one logical
-// agent (§3.4) — and is keyed on neither agentId (rotates per version) nor
-// displayName (mutable), satisfying §3.3 from data the RA already holds.
-func deriveLabel(agentHost string) string {
-	host := strings.ToLower(strings.TrimSpace(agentHost))
-	if i := strings.IndexByte(host, '.'); i > 0 {
-		return host[:i]
+// deriveLabel returns the URN's terminal lineage segment: the sanitized
+// display name, trimmed, with each internal whitespace run collapsed to a
+// single hyphen (e.g. "Support  Assistant" → "Support-Assistant"). Case is
+// preserved — the intra-host label space is the publisher's to manage.
+// This is deliberately the SAME rule the ARD Finder applies when minting
+// identifiers from feed events (internal/finder/project/urn.go labelize),
+// so a consumer correlating a search result with the host's published
+// ai-catalog.json sees one lineage handle, not two. Successive versions of
+// one logical agent share the label by sharing a display name; an empty
+// result means no handle can be minted and the caller gates on it.
+func deriveLabel(displayName string) string {
+	s := strings.TrimSpace(displayName)
+	if s == "" {
+		return ""
 	}
-	return host
+	return strings.Join(strings.Fields(s), "-")
 }
 
-// buildURN composes the domain-anchored lineage handle (§3.3). The host
-// segment is the registration's own agentHost, so a registry reads the
-// publisher domain directly from the identifier.
+// buildURN composes the domain-anchored lineage handle (ARD §4.2.1). The
+// host segment is the registration's own agentHost (lowercased), so a
+// registry reads the publisher domain directly from the identifier; the
+// label keeps its case — the intra-host label space is the publisher's.
 func buildURN(agentHost, label string) string {
-	return "urn:air:" + agentHost + ":agents:" + label
+	return "urn:air:" + strings.ToLower(agentHost) + ":agents:" + label
 }
 
 // buildPublisher builds the Publisher block (§3.7). ANS has no verified

--- a/internal/catalog/generate_test.go
+++ b/internal/catalog/generate_test.go
@@ -78,9 +78,9 @@ func mustJSON(t *testing.T, v any) string {
 
 // TestBuildEntry_SingleA2A_Golden pins the full single-protocol entry
 // shape, byte-for-byte, against the IMPL Appendix B.1 worked example —
-// with the identifier label derived from the leftmost DNS label
-// ("ai-agent") rather than B.1's supplied "support", since this RA derives
-// the label from the agentHost. Catches field-order and shape drift.
+// with the identifier label derived from the labelized display name
+// ("Acme Support Agent" → "Acme-Support-Agent"), the same derivation the
+// ARD Finder mints from feed events. Catches field-order and shape drift.
 func TestBuildEntry_SingleA2A_Golden(t *testing.T) {
 	reg := newReg(t, a2aEndpoint())
 
@@ -89,7 +89,7 @@ func TestBuildEntry_SingleA2A_Golden(t *testing.T) {
 		t.Fatalf("BuildEntry: %v", err)
 	}
 
-	const want = `{"identifier":"urn:air:ai-agent.acmecorp.com:agents:ai-agent",` +
+	const want = `{"identifier":"urn:air:ai-agent.acmecorp.com:agents:Acme-Support-Agent",` +
 		`"displayName":"Acme Support Agent",` +
 		`"description":"Customer-support agent for Acme retail accounts.",` +
 		`"version":"2.1.0",` +
@@ -98,7 +98,7 @@ func TestBuildEntry_SingleA2A_Golden(t *testing.T) {
 		`"updatedAt":"2026-06-12T17:03:11Z",` +
 		`"publisher":{"identifier":"ai-agent.acmecorp.com","displayName":"ai-agent.acmecorp.com","identityType":"dns"},` +
 		`"metadata":{"ansName":"ans://v2.1.0.ai-agent.acmecorp.com","agentHost":"ai-agent.acmecorp.com","badgeUrl":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000"},` +
-		`"trustManifest":{"identity":"urn:air:ai-agent.acmecorp.com:agents:ai-agent","attestations":[{"type":"ANS-Registration","uri":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt","mediaType":"application/scitt-receipt+cose"}]}}`
+		`"trustManifest":{"identity":"urn:air:ai-agent.acmecorp.com:agents:Acme-Support-Agent","attestations":[{"type":"ANS-Registration","uri":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt","mediaType":"application/scitt-receipt+cose"}]}}`
 
 	if got := mustJSON(t, entry); got != want {
 		t.Errorf("entry JSON mismatch:\n got: %s\nwant: %s", got, want)
@@ -404,18 +404,37 @@ func TestBuildEntry_NotActive(t *testing.T) {
 	}
 }
 
+// TestDeriveLabel pins the label rule to the ARD Finder's labelize
+// (internal/finder/project/urn.go): trim, collapse whitespace runs to
+// single hyphens, preserve case, empty in → empty out (the caller gates).
 func TestDeriveLabel(t *testing.T) {
-	tests := []struct{ host, want string }{
-		{"ai-agent.acmecorp.com", "ai-agent"},
-		{"acmecorp.com", "acmecorp"},
-		{"AI-AGENT.ACMECORP.COM", "ai-agent"},
-		{"singlelabel", "singlelabel"},         // no-dot fallback
-		{".leadingdot.com", ".leadingdot.com"}, // IndexByte == 0 → whole host
+	tests := []struct{ displayName, want string }{
+		{"Acme Support Agent", "Acme-Support-Agent"},
+		{"demo-agent", "demo-agent"},
+		{"  spaced   out\tname ", "spaced-out-name"}, // runs collapse, edges trim
+		{"CasePreserved", "CasePreserved"},           // label case is publisher-owned
+		{"", ""},                                     // missing display name → no mintable label
+		{"   \t  ", ""},                              // whitespace-only → no mintable label
 	}
 	for _, tc := range tests {
-		if got := deriveLabel(tc.host); got != tc.want {
-			t.Errorf("deriveLabel(%q) = %q, want %q", tc.host, got, tc.want)
+		if got := deriveLabel(tc.displayName); got != tc.want {
+			t.Errorf("deriveLabel(%q) = %q, want %q", tc.displayName, got, tc.want)
 		}
+	}
+}
+
+// TestBuildEntry_NoLabel covers the mintable-label gate: a registration
+// whose display name is empty (or sanitizes away to nothing) has no URN
+// terminal segment, so no entry is produced — mirroring the ARD Finder,
+// which skips such feed events rather than substituting a fallback.
+func TestBuildEntry_NoLabel(t *testing.T) {
+	reg := newReg(t, a2aEndpoint())
+	reg.Details.DisplayName = "\u200b" // Cf-only: sanitizes to empty
+
+	_, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	var ne *NotEligibleError
+	if !errors.As(err, &ne) || ne.Reason != ReasonNoLabel {
+		t.Fatalf("want NO_LABEL NotEligibleError, got %v", err)
 	}
 }
 

--- a/internal/catalog/generate_test.go
+++ b/internal/catalog/generate_test.go
@@ -1,0 +1,429 @@
+package catalog
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/godaddy/ans/internal/domain"
+)
+
+const (
+	testHost    = "ai-agent.acmecorp.com"
+	testAgentID = "550e8400-e29b-41d4-a716-446655440000"
+	testTLBase  = "https://transparency-log.example.com"
+)
+
+var testUpdatedAt = time.Date(2026, 6, 12, 17, 3, 11, 0, time.UTC)
+
+// newReg builds a versioned registration with the given endpoints. The
+// host is the canonical test host; the version is 2.1.0.
+func newReg(t *testing.T, endpoints ...domain.AgentEndpoint) *domain.AgentRegistration {
+	t.Helper()
+	return newRegHost(t, testHost, "2.1.0", endpoints...)
+}
+
+func newRegHost(t *testing.T, host, version string, endpoints ...domain.AgentEndpoint) *domain.AgentRegistration {
+	t.Helper()
+	sv, err := domain.ParseSemVer(version)
+	if err != nil {
+		t.Fatalf("ParseSemVer(%q): %v", version, err)
+	}
+	ans, err := domain.NewAnsName(sv, host)
+	if err != nil {
+		t.Fatalf("NewAnsName(%q,%q): %v", version, host, err)
+	}
+	return &domain.AgentRegistration{
+		AgentID: testAgentID,
+		AnsName: ans,
+		// Catalog entries are produced only for ACTIVE agents (the TL
+		// records the entry links to exist only after activation), so the
+		// happy-path helper builds an ACTIVE registration. Tests that
+		// exercise the not-active gate override Status explicitly.
+		Status: domain.StatusActive,
+		Details: domain.RegistrationDetails{
+			DisplayName:           "Acme Support Agent",
+			Description:           "Customer-support agent for Acme retail accounts.",
+			RegistrationTimestamp: testUpdatedAt,
+		},
+		Endpoints: endpoints,
+	}
+}
+
+func a2aEndpoint() domain.AgentEndpoint {
+	return domain.AgentEndpoint{
+		Protocol:    domain.ProtocolA2A,
+		AgentURL:    "https://" + testHost + "/a2a",
+		MetadataURL: "https://" + testHost + "/.well-known/agent-card.json",
+	}
+}
+
+func mcpEndpoint() domain.AgentEndpoint {
+	return domain.AgentEndpoint{
+		Protocol:    domain.ProtocolMCP,
+		AgentURL:    "https://" + testHost + "/mcp",
+		MetadataURL: "https://" + testHost + "/.well-known/mcp/server-card.json",
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestBuildEntry_SingleA2A_Golden pins the full single-protocol entry
+// shape, byte-for-byte, against the IMPL Appendix B.1 worked example —
+// with the identifier label derived from the leftmost DNS label
+// ("ai-agent") rather than B.1's supplied "support", since this RA derives
+// the label from the agentHost. Catches field-order and shape drift.
+func TestBuildEntry_SingleA2A_Golden(t *testing.T) {
+	reg := newReg(t, a2aEndpoint())
+
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	const want = `{"identifier":"urn:ai:ai-agent.acmecorp.com:agents:ai-agent",` +
+		`"displayName":"Acme Support Agent",` +
+		`"description":"Customer-support agent for Acme retail accounts.",` +
+		`"version":"2.1.0",` +
+		`"mediaType":"application/a2a-agent-card+json",` +
+		`"url":"https://ai-agent.acmecorp.com/.well-known/agent-card.json",` +
+		`"updatedAt":"2026-06-12T17:03:11Z",` +
+		`"publisher":{"identifier":"ai-agent.acmecorp.com","displayName":"ai-agent.acmecorp.com","identityType":"dns"},` +
+		`"metadata":{"ansName":"ans://v2.1.0.ai-agent.acmecorp.com","agentHost":"ai-agent.acmecorp.com","badgeUrl":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000"},` +
+		`"trustManifest":{"identity":"urn:ai:ai-agent.acmecorp.com:agents:ai-agent","attestations":[{"type":"ANS-Registration","uri":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt","mediaType":"application/scitt-receipt+cose"}]}}`
+
+	if got := mustJSON(t, entry); got != want {
+		t.Errorf("entry JSON mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestBuildEntry_SingleMCP checks the MCP media type and that a single
+// includable endpoint stays a plain top-level entry (no nesting).
+func TestBuildEntry_SingleMCP(t *testing.T) {
+	reg := newReg(t, mcpEndpoint())
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.MediaType != mediaTypeMCP {
+		t.Errorf("mediaType = %q, want %q", entry.MediaType, mediaTypeMCP)
+	}
+	if entry.Data != nil {
+		t.Errorf("single endpoint must not nest; got Data = %+v", entry.Data)
+	}
+	if entry.URL != mcpEndpoint().MetadataURL {
+		t.Errorf("url = %q, want %q", entry.URL, mcpEndpoint().MetadataURL)
+	}
+}
+
+// TestBuildEntry_MultiProtocol_Nested pins the dual-protocol nested entry
+// (§3.5): outer mediaType is the catalog type, Data holds one lean child
+// per protocol, the trust manifest sits on the outer entry, and the outer
+// entry carries no url.
+func TestBuildEntry_MultiProtocol_Nested(t *testing.T) {
+	reg := newReg(t, a2aEndpoint(), mcpEndpoint())
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+
+	if entry.MediaType != MediaTypeCatalog {
+		t.Errorf("outer mediaType = %q, want %q", entry.MediaType, MediaTypeCatalog)
+	}
+	if entry.URL != "" {
+		t.Errorf("outer entry must use data, not url; got url = %q", entry.URL)
+	}
+	if entry.Data == nil {
+		t.Fatalf("outer entry must carry Data")
+	}
+	if entry.Data.SpecVersion != SpecVersion {
+		t.Errorf("nested specVersion = %q, want %q", entry.Data.SpecVersion, SpecVersion)
+	}
+	if entry.TrustManifest == nil || entry.TrustManifest.Identity != entry.Identifier {
+		t.Errorf("trust manifest must sit on outer entry with matching identity")
+	}
+	if len(entry.Data.Entries) != 2 {
+		t.Fatalf("nested children = %d, want 2", len(entry.Data.Entries))
+	}
+
+	a2a := entry.Data.Entries[0]
+	if a2a.Identifier != entry.Identifier+":a2a" {
+		t.Errorf("a2a child identifier = %q", a2a.Identifier)
+	}
+	if a2a.DisplayName != "Acme Support Agent (A2A)" {
+		t.Errorf("a2a child displayName = %q", a2a.DisplayName)
+	}
+	if a2a.MediaType != mediaTypeA2A || a2a.URL != a2aEndpoint().MetadataURL {
+		t.Errorf("a2a child media/url = %q/%q", a2a.MediaType, a2a.URL)
+	}
+	// Children stay lean: no trust manifest, metadata, or publisher.
+	if a2a.TrustManifest != nil || a2a.Metadata != nil || a2a.Publisher != nil {
+		t.Errorf("nested child must be lean, got %+v", a2a)
+	}
+	mcp := entry.Data.Entries[1]
+	if mcp.Identifier != entry.Identifier+":mcp" || mcp.MediaType != mediaTypeMCP {
+		t.Errorf("mcp child = %q/%q", mcp.Identifier, mcp.MediaType)
+	}
+}
+
+// TestBuildEntry_Ineligible covers every §3.6 path that produces no entry.
+func TestBuildEntry_Ineligible(t *testing.T) {
+	httpAPI := domain.AgentEndpoint{
+		Protocol:    domain.ProtocolHTTPAPI,
+		AgentURL:    "https://" + testHost + "/api",
+		MetadataURL: "https://" + testHost + "/openapi.json",
+	}
+	a2aNoMeta := domain.AgentEndpoint{
+		Protocol: domain.ProtocolA2A,
+		AgentURL: "https://" + testHost + "/a2a",
+	}
+	a2aCrossHost := domain.AgentEndpoint{
+		Protocol:    domain.ProtocolA2A,
+		AgentURL:    "https://" + testHost + "/a2a",
+		MetadataURL: "https://evil.example.net/.well-known/agent-card.json",
+	}
+
+	tests := []struct {
+		name       string
+		endpoints  []domain.AgentEndpoint
+		wantReason string
+	}{
+		{"http-api only", []domain.AgentEndpoint{httpAPI}, ReasonNoEligibleEndpoint},
+		{"a2a without metaDataUrl", []domain.AgentEndpoint{a2aNoMeta}, ReasonNoEligibleEndpoint},
+		{"a2a metaDataUrl fails policy", []domain.AgentEndpoint{a2aCrossHost}, ReasonNoEligibleEndpoint},
+		{"no endpoints at all", nil, ReasonNoEligibleEndpoint},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := newReg(t, tc.endpoints...)
+			_, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+			var ne *NotEligibleError
+			if !errors.As(err, &ne) {
+				t.Fatalf("want *NotEligibleError, got %v", err)
+			}
+			if ne.Reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", ne.Reason, tc.wantReason)
+			}
+			if ne.Error() == "" {
+				t.Error("NotEligibleError message must be non-empty")
+			}
+		})
+	}
+}
+
+// TestBuildEntry_MixedEndpoints_CollapsesToSingle verifies per-endpoint
+// gating: ineligible endpoints are simply absent, and one surviving
+// endpoint collapses back to the plain top-level form.
+func TestBuildEntry_MixedEndpoints_CollapsesToSingle(t *testing.T) {
+	httpAPI := domain.AgentEndpoint{
+		Protocol:    domain.ProtocolHTTPAPI,
+		AgentURL:    "https://" + testHost + "/api",
+		MetadataURL: "https://" + testHost + "/openapi.json",
+	}
+	mcpNoMeta := domain.AgentEndpoint{
+		Protocol: domain.ProtocolMCP,
+		AgentURL: "https://" + testHost + "/mcp",
+	}
+	reg := newReg(t, httpAPI, a2aEndpoint(), mcpNoMeta)
+
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.Data != nil {
+		t.Errorf("only one endpoint is eligible; must not nest")
+	}
+	if entry.MediaType != mediaTypeA2A {
+		t.Errorf("mediaType = %q, want a2a", entry.MediaType)
+	}
+}
+
+// TestBuildEntry_NoTLBase omits the badge URL and the attestation when no
+// TL base URL is configured, but still emits the manifest identity (§5.2).
+func TestBuildEntry_NoTLBase(t *testing.T) {
+	reg := newReg(t, a2aEndpoint())
+	entry, err := BuildEntry(reg, Options{}) // no TL base
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.Metadata.BadgeURL != "" {
+		t.Errorf("badgeUrl must be empty without TL base, got %q", entry.Metadata.BadgeURL)
+	}
+	if entry.TrustManifest == nil {
+		t.Fatalf("trust manifest must still carry identity")
+	}
+	if entry.TrustManifest.Identity != entry.Identifier {
+		t.Errorf("manifest identity must equal entry identifier")
+	}
+	if len(entry.TrustManifest.Attestations) != 0 {
+		t.Errorf("attestations must be omitted without TL base, got %+v", entry.TrustManifest.Attestations)
+	}
+	// Confirm omitempty drops both from the wire.
+	if js := mustJSON(t, entry); contains(js, "badgeUrl") || contains(js, "attestations") {
+		t.Errorf("badgeUrl/attestations must not appear in JSON: %s", js)
+	}
+}
+
+// TestBuildEntry_NilAndVersionless covers the Gate-1 and nil guards.
+func TestBuildEntry_NilAndVersionless(t *testing.T) {
+	t.Run("nil registration", func(t *testing.T) {
+		_, err := BuildEntry(nil, Options{})
+		var ne *NotEligibleError
+		if !errors.As(err, &ne) || ne.Reason != ReasonNoVersion {
+			t.Fatalf("want NO_VERSION NotEligibleError, got %v", err)
+		}
+	})
+	t.Run("zero ansName", func(t *testing.T) {
+		reg := &domain.AgentRegistration{AgentID: testAgentID, Endpoints: []domain.AgentEndpoint{a2aEndpoint()}}
+		_, err := BuildEntry(reg, Options{})
+		var ne *NotEligibleError
+		if !errors.As(err, &ne) || ne.Reason != ReasonNoVersion {
+			t.Fatalf("want NO_VERSION NotEligibleError, got %v", err)
+		}
+	})
+}
+
+// TestBuildEntry_Tags passes through and de-duplicates endpoint function
+// tags onto a single-protocol entry.
+func TestBuildEntry_Tags(t *testing.T) {
+	ep := a2aEndpoint()
+	ep.Functions = []domain.AgentFunction{
+		{ID: "f1", Name: "lookup", Tags: []string{"billing", "support"}},
+		{ID: "f2", Name: "refund", Tags: []string{"support", "payments"}},
+	}
+	reg := newReg(t, ep)
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	want := []string{"billing", "support", "payments"}
+	if mustJSON(t, entry.Tags) != mustJSON(t, want) {
+		t.Errorf("tags = %v, want %v (deduped, first-seen order)", entry.Tags, want)
+	}
+}
+
+// TestBuildEntry_SanitizesDisplayFields strips Cc/Cf runes from the
+// emitted display fields.
+func TestBuildEntry_SanitizesDisplayFields(t *testing.T) {
+	reg := newReg(t, func() domain.AgentEndpoint {
+		ep := a2aEndpoint()
+		ep.Functions = []domain.AgentFunction{{ID: "f", Name: "n", Tags: []string{"safe\u202etag"}}}
+		return ep
+	}())
+	reg.Details.DisplayName = "Acme\u202eSupport"             // bidi override
+	reg.Details.Description = "desc\u200bwith\ufeffzerowidth" // zero-width + BOM
+
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.DisplayName != "AcmeSupport" {
+		t.Errorf("displayName not sanitized: %q", entry.DisplayName)
+	}
+	if entry.Description != "descwithzerowidth" {
+		t.Errorf("description not sanitized: %q", entry.Description)
+	}
+	if len(entry.Tags) != 1 || entry.Tags[0] != "safetag" {
+		t.Errorf("tag not sanitized: %v", entry.Tags)
+	}
+}
+
+// TestBuildEntry_AllowInsecureURLs gates http metaDataUrl behind the dev
+// override.
+func TestBuildEntry_AllowInsecureURLs(t *testing.T) {
+	ep := a2aEndpoint()
+	ep.MetadataURL = "http://" + testHost + "/.well-known/agent-card.json"
+
+	if _, err := BuildEntry(newReg(t, ep), Options{TLPublicBaseURL: testTLBase}); err == nil {
+		t.Error("http metaDataUrl must be skipped without AllowInsecureURLs")
+	}
+	entry, err := BuildEntry(newReg(t, ep), Options{TLPublicBaseURL: testTLBase, AllowInsecureURLs: true})
+	if err != nil {
+		t.Fatalf("with AllowInsecureURLs: %v", err)
+	}
+	if entry.URL != ep.MetadataURL {
+		t.Errorf("url = %q, want %q", entry.URL, ep.MetadataURL)
+	}
+}
+
+// TestBuildEntry_ZeroTimestampOmitsUpdatedAt covers the rfc3339 zero
+// branch.
+func TestBuildEntry_ZeroTimestampOmitsUpdatedAt(t *testing.T) {
+	reg := newReg(t, a2aEndpoint())
+	reg.Details.RegistrationTimestamp = time.Time{}
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.UpdatedAt != "" {
+		t.Errorf("updatedAt must be empty for zero timestamp, got %q", entry.UpdatedAt)
+	}
+}
+
+// TestBuildEntry_RenewalTimestampWins confirms updatedAt tracks the latest
+// renewal when present.
+func TestBuildEntry_RenewalTimestampWins(t *testing.T) {
+	reg := newReg(t, a2aEndpoint())
+	renewal := time.Date(2026, 6, 14, 9, 0, 0, 0, time.UTC)
+	reg.Details.LastRenewalTimestamp = renewal
+	entry, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+	if err != nil {
+		t.Fatalf("BuildEntry: %v", err)
+	}
+	if entry.UpdatedAt != "2026-06-14T09:00:00Z" {
+		t.Errorf("updatedAt = %q, want renewal time", entry.UpdatedAt)
+	}
+}
+
+// TestBuildEntry_NotActive: a versioned, endpoint-eligible registration
+// that is not ACTIVE produces no entry — its SCITT receipt and TL badge do
+// not exist until the agent is sealed at activation.
+func TestBuildEntry_NotActive(t *testing.T) {
+	for _, st := range []domain.RegistrationStatus{
+		domain.StatusPendingValidation,
+		domain.StatusPendingDNS,
+		domain.StatusFailed,
+		domain.StatusRevoked,
+		domain.StatusDeprecated,
+	} {
+		reg := newReg(t, a2aEndpoint())
+		reg.Status = st
+		_, err := BuildEntry(reg, Options{TLPublicBaseURL: testTLBase})
+		var ne *NotEligibleError
+		if !errors.As(err, &ne) || ne.Reason != ReasonNotActive {
+			t.Errorf("status %s: want AGENT_NOT_ACTIVE NotEligibleError, got %v", st, err)
+		}
+	}
+}
+
+func TestDeriveLabel(t *testing.T) {
+	tests := []struct{ host, want string }{
+		{"ai-agent.acmecorp.com", "ai-agent"},
+		{"acmecorp.com", "acmecorp"},
+		{"AI-AGENT.ACMECORP.COM", "ai-agent"},
+		{"singlelabel", "singlelabel"},         // no-dot fallback
+		{".leadingdot.com", ".leadingdot.com"}, // IndexByte == 0 → whole host
+	}
+	for _, tc := range tests {
+		if got := deriveLabel(tc.host); got != tc.want {
+			t.Errorf("deriveLabel(%q) = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/catalog/generate_test.go
+++ b/internal/catalog/generate_test.go
@@ -158,7 +158,11 @@ func TestBuildEntry_MultiProtocol_Nested(t *testing.T) {
 	if a2a.Identifier != entry.Identifier+":a2a" {
 		t.Errorf("a2a child identifier = %q", a2a.Identifier)
 	}
-	if a2a.DisplayName != "Acme Support Agent (A2A)" {
+	// Children reuse the parent's name verbatim — a protocol suffix could
+	// push a maximum-length registered name past the published schema's
+	// 64-char displayName cap, and the :a2a/:mcp identifier + mediaType
+	// already discriminate the children.
+	if a2a.DisplayName != "Acme Support Agent" {
 		t.Errorf("a2a child displayName = %q", a2a.DisplayName)
 	}
 	if a2a.MediaType != mediaTypeA2A || a2a.URL != a2aEndpoint().MetadataURL {
@@ -404,22 +408,18 @@ func TestBuildEntry_NotActive(t *testing.T) {
 	}
 }
 
-// TestDeriveLabel pins the label rule to the ARD Finder's labelize
-// (internal/finder/project/urn.go): trim, collapse whitespace runs to
-// single hyphens, preserve case, empty in → empty out (the caller gates).
-func TestDeriveLabel(t *testing.T) {
-	tests := []struct{ displayName, want string }{
-		{"Acme Support Agent", "Acme-Support-Agent"},
-		{"demo-agent", "demo-agent"},
-		{"  spaced   out\tname ", "spaced-out-name"}, // runs collapse, edges trim
-		{"CasePreserved", "CasePreserved"},           // label case is publisher-owned
-		{"", ""},                                     // missing display name → no mintable label
-		{"   \t  ", ""},                              // whitespace-only → no mintable label
+// TestMintURN_SharedDerivation pins this package's URN seam to the shared
+// internal/ard implementation the ARD Finder also projects through: one
+// derivation, one lineage identifier per agent across both surfaces. The
+// full label semantics are pinned in internal/ard's own tests; this seam
+// test guards against the catalog ever reintroducing a local derivation.
+func TestMintURN_SharedDerivation(t *testing.T) {
+	got, ok := mintURN("AGENT.Example.com", "Acme  Support Agent")
+	if !ok || got != "urn:air:agent.example.com:agents:Acme-Support-Agent" {
+		t.Fatalf("mintURN = (%q, %v), want the shared ard derivation", got, ok)
 	}
-	for _, tc := range tests {
-		if got := deriveLabel(tc.displayName); got != tc.want {
-			t.Errorf("deriveLabel(%q) = %q, want %q", tc.displayName, got, tc.want)
-		}
+	if _, ok := mintURN("agent.example.com", "  "); ok {
+		t.Fatal("whitespace-only display name must not mint a URN")
 	}
 }
 

--- a/internal/catalog/generate_test.go
+++ b/internal/catalog/generate_test.go
@@ -89,7 +89,7 @@ func TestBuildEntry_SingleA2A_Golden(t *testing.T) {
 		t.Fatalf("BuildEntry: %v", err)
 	}
 
-	const want = `{"identifier":"urn:ai:ai-agent.acmecorp.com:agents:ai-agent",` +
+	const want = `{"identifier":"urn:air:ai-agent.acmecorp.com:agents:ai-agent",` +
 		`"displayName":"Acme Support Agent",` +
 		`"description":"Customer-support agent for Acme retail accounts.",` +
 		`"version":"2.1.0",` +
@@ -98,7 +98,7 @@ func TestBuildEntry_SingleA2A_Golden(t *testing.T) {
 		`"updatedAt":"2026-06-12T17:03:11Z",` +
 		`"publisher":{"identifier":"ai-agent.acmecorp.com","displayName":"ai-agent.acmecorp.com","identityType":"dns"},` +
 		`"metadata":{"ansName":"ans://v2.1.0.ai-agent.acmecorp.com","agentHost":"ai-agent.acmecorp.com","badgeUrl":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000"},` +
-		`"trustManifest":{"identity":"urn:ai:ai-agent.acmecorp.com:agents:ai-agent","attestations":[{"type":"ANS-Registration","uri":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt","mediaType":"application/scitt-receipt+cose"}]}}`
+		`"trustManifest":{"identity":"urn:air:ai-agent.acmecorp.com:agents:ai-agent","attestations":[{"type":"ANS-Registration","uri":"https://transparency-log.example.com/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt","mediaType":"application/scitt-receipt+cose"}]}}`
 
 	if got := mustJSON(t, entry); got != want {
 		t.Errorf("entry JSON mismatch:\n got: %s\nwant: %s", got, want)

--- a/internal/catalog/sanitize.go
+++ b/internal/catalog/sanitize.go
@@ -1,0 +1,69 @@
+package catalog
+
+import (
+	"strings"
+	"unicode"
+)
+
+// sanitizeText strips Unicode control (Cc) and format (Cf) runes from s.
+//
+// Catalog entries carry registrant-controlled strings (displayName,
+// description, tags, version, metadata values) that flow on to AI
+// orchestrators and into browser- and LLM-facing documents, so every
+// emitted string passes this one chokepoint (IMPL §3.8). The Cc/Cf classes
+// cover the steerable runes: the bidi override U+202E, the bidi isolates
+// U+2066–U+2069, the zero-width family (U+200B–U+200D, U+FEFF), and NUL.
+// Nothing in those classes survives.
+//
+// Plain printable text (including non-Latin scripts and emoji, which are
+// not Cc/Cf) passes through unchanged. The common path — a string with no
+// such runes — returns the input without allocating.
+func sanitizeText(s string) string {
+	if s == "" {
+		return s
+	}
+	if !strings.ContainsFunc(s, isControlOrFormat) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isControlOrFormat(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// isControlOrFormat reports whether r is a Unicode control (Cc) or format
+// (Cf) rune — the steerable classes sanitizeText removes.
+func isControlOrFormat(r rune) bool {
+	return unicode.Is(unicode.Cc, r) || unicode.Is(unicode.Cf, r)
+}
+
+// sanitizeTags sanitizes each tag, drops any that become empty, and
+// de-duplicates while preserving first-seen order. Returns nil when no tag
+// survives, so the caller can omitempty a missing Tags array cleanly.
+func sanitizeTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		clean := sanitizeText(t)
+		if clean == "" {
+			continue
+		}
+		if _, dup := seen[clean]; dup {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/catalog/sanitize_test.go
+++ b/internal/catalog/sanitize_test.go
@@ -1,0 +1,59 @@
+package catalog
+
+import "testing"
+
+func TestSanitizeText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"clean ascii unchanged", "Acme Support Agent", "Acme Support Agent"},
+		{"clean unicode letters unchanged", "café résumé", "café résumé"},
+		{"em dash unchanged", "a—b", "a—b"},
+		{"emoji unchanged", "agent \U0001F916 ok", "agent \U0001F916 ok"},
+		{"strips bidi override U+202E", "abc\u202edef", "abcdef"},
+		{"strips bidi isolates U+2066-2069", "a\u2066b\u2067c\u2068d\u2069e", "abcde"},
+		{"strips zero-width space/joiner", "a\u200bb\u200cc\u200dd", "abcd"},
+		{"strips BOM/zero-width-nbsp U+FEFF", "a\ufeffb", "ab"},
+		{"strips NUL", "a\x00b", "ab"},
+		{"strips C0 control", "a\x07b\x1bc", "abc"},
+		{"strips tab and newline (Cc)", "a\tb\nc", "abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeText(tc.in); got != tc.want {
+				t.Errorf("sanitizeText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeTags(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty slice", []string{}, nil},
+		{"dedupe preserves first-seen order", []string{"b", "a", "b", "c", "a"}, []string{"b", "a", "c"}},
+		{"drops tags that sanitize to empty", []string{"\u200b", "ok", "\x00"}, []string{"ok"}},
+		{"all empty after sanitize -> nil", []string{"\u202e", "\ufeff"}, nil},
+		{"sanitizes within a tag", []string{"sa\u202efe"}, []string{"safe"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeTags(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("sanitizeTags(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("sanitizeTags(%v) = %v, want %v", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/catalog/urlpolicy.go
+++ b/internal/catalog/urlpolicy.go
@@ -28,6 +28,17 @@ func validateEmittedURL(raw, agentHost string, allowInsecure bool) (string, bool
 	if raw == "" || agentHost == "" {
 		return "", false
 	}
+	// Reject — never strip — any control (Cc) or format (Cf) rune anywhere
+	// in the raw URL before parsing. url.Parse only rejects ASCII controls,
+	// so a bidi override or zero-width rune in the path would otherwise
+	// parse cleanly, pass the host pin, and ship verbatim into a document
+	// rendered in UIs and LLM contexts. Stripping would silently emit a
+	// different URL than the registrant declared; refusal keeps the
+	// endpoint out of the catalog instead. Mirrors the Finder's
+	// validateEmittedURL (internal/finder/project/sanitize.go).
+	if strings.ContainsFunc(raw, isControlOrFormat) {
+		return "", false
+	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return "", false

--- a/internal/catalog/urlpolicy.go
+++ b/internal/catalog/urlpolicy.go
@@ -1,0 +1,62 @@
+package catalog
+
+import (
+	"net/url"
+	"strings"
+)
+
+// validateEmittedURL enforces the emit-side URL policy (IMPL §3.8) on a
+// registrant-supplied URL before it leaves the RA as an entry's `url`. It
+// returns the URL to emit (verbatim — a passing URL is never rewritten)
+// and true, or "" and false when the URL violates the policy.
+//
+// The policy is fail-closed: a violating URL causes its endpoint to be
+// skipped (§3.6), never emitted, and no URL is ever built by string
+// concatenation that bypasses this check. A URL MUST be:
+//
+//   - absolute (carries a scheme);
+//   - https — or http only when allowInsecure is set (a dev-only override);
+//   - free of userinfo, query, and fragment;
+//   - hosted on agentHost: its host, port-stripped and case-insensitive,
+//     MUST equal agentHost. This keeps a poisoned entry from pointing a
+//     consumer at a metadata document on a host the agent does not own.
+//
+// The Transparency-Log badge and receipt URLs are RA-controlled and built
+// from already-validated config (PublicBaseURL), not registrant input, so
+// they do not pass through this agentHost-bound check.
+func validateEmittedURL(raw, agentHost string, allowInsecure bool) (string, bool) {
+	if raw == "" || agentHost == "" {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	if !u.IsAbs() {
+		return "", false
+	}
+	switch u.Scheme {
+	case "https":
+		// always allowed
+	case "http":
+		if !allowInsecure {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+	if u.User != nil {
+		return "", false
+	}
+	if u.RawQuery != "" || u.ForceQuery {
+		return "", false
+	}
+	if u.Fragment != "" || u.RawFragment != "" {
+		return "", false
+	}
+	host := strings.ToLower(u.Hostname()) // port-stripped
+	if host == "" || host != strings.ToLower(strings.TrimSpace(agentHost)) {
+		return "", false
+	}
+	return raw, true
+}

--- a/internal/catalog/urlpolicy_test.go
+++ b/internal/catalog/urlpolicy_test.go
@@ -28,6 +28,12 @@ func TestValidateEmittedURL(t *testing.T) {
 		{"empty raw rejected", "", host, false, false},
 		{"empty agentHost rejected", "https://ai-agent.acmecorp.com/card.json", "", false, false},
 		{"unparseable URL rejected", "https://ho\x00st/card.json", host, false, false},
+		// Cc/Cf runes are rejected anywhere in the raw URL BEFORE parsing:
+		// url.Parse only rejects ASCII controls, so a zero-width or bidi
+		// rune in the path would otherwise parse cleanly and pass the host
+		// pin. Rejection (never stripping) mirrors the Finder's policy.
+		{"zero-width rune in path rejected", "https://ai-agent.acmecorp.com/ca\u200brd.json", host, false, false},
+		{"bidi override in path rejected", "https://ai-agent.acmecorp.com/\u202ejson.card", host, false, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/catalog/urlpolicy_test.go
+++ b/internal/catalog/urlpolicy_test.go
@@ -1,0 +1,46 @@
+package catalog
+
+import "testing"
+
+func TestValidateEmittedURL(t *testing.T) {
+	const host = "ai-agent.acmecorp.com"
+
+	tests := []struct {
+		name          string
+		raw           string
+		host          string
+		allowInsecure bool
+		wantOK        bool
+	}{
+		{"valid https same host", "https://ai-agent.acmecorp.com/.well-known/agent-card.json", host, false, true},
+		{"valid https with path and port", "https://ai-agent.acmecorp.com:8443/card.json", host, false, true},
+		{"host match is case-insensitive", "https://AI-Agent.AcmeCorp.com/card.json", host, false, true},
+		{"http rejected without override", "http://ai-agent.acmecorp.com/card.json", host, false, false},
+		{"http allowed with override", "http://ai-agent.acmecorp.com/card.json", host, true, true},
+		{"non-http(s) scheme rejected", "ftp://ai-agent.acmecorp.com/card.json", host, true, false},
+		{"relative URL rejected", "/.well-known/agent-card.json", host, false, false},
+		{"userinfo rejected", "https://user:pass@ai-agent.acmecorp.com/card.json", host, false, false},
+		{"query rejected", "https://ai-agent.acmecorp.com/card.json?v=1", host, false, false},
+		{"force-query (trailing ?) rejected", "https://ai-agent.acmecorp.com/card.json?", host, false, false},
+		{"fragment rejected", "https://ai-agent.acmecorp.com/card.json#frag", host, false, false},
+		{"cross-host rejected", "https://evil.example.net/card.json", host, false, false},
+		{"empty host in URL rejected", "https:///card.json", host, false, false},
+		{"empty raw rejected", "", host, false, false},
+		{"empty agentHost rejected", "https://ai-agent.acmecorp.com/card.json", "", false, false},
+		{"unparseable URL rejected", "https://ho\x00st/card.json", host, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := validateEmittedURL(tc.raw, tc.host, tc.allowInsecure)
+			if ok != tc.wantOK {
+				t.Fatalf("validateEmittedURL(%q,%q,%v) ok = %v, want %v", tc.raw, tc.host, tc.allowInsecure, ok, tc.wantOK)
+			}
+			if ok && got != tc.raw {
+				t.Errorf("a passing URL must be emitted verbatim: got %q, want %q", got, tc.raw)
+			}
+			if !ok && got != "" {
+				t.Errorf("a failing URL must return empty string, got %q", got)
+			}
+		})
+	}
+}

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -306,6 +306,25 @@ func (r *AgentRegistration) Cancel(now time.Time) error {
 	return nil
 }
 
+// CancelForHostConflict cancels a still-pending registration because a
+// different owner won exclusive control of the FQDN (one-host-one-owner).
+// Unlike Cancel, it raises no event: a pre-activation registration was
+// never sealed in the Transparency Log, so its cancellation carries no TL
+// event (ANS-1 §4.4). Only PENDING registrations are cancellable; any
+// non-pending status (including an already-cancelled one) returns
+// CANNOT_CANCEL. The sole caller (cancelConflictingPendings) pre-filters
+// on IsPending(), so it never invokes this twice on the same row.
+func (r *AgentRegistration) CancelForHostConflict() error {
+	if !r.Status.IsPending() {
+		return NewInvalidStateError(
+			"CANNOT_CANCEL",
+			fmt.Sprintf("can only cancel pending registrations, current status: %s", r.Status),
+		)
+	}
+	r.Status = StatusRevoked
+	return nil
+}
+
 // Fail transitions a PENDING registration to FAILED.
 func (r *AgentRegistration) Fail() error {
 	if !r.Status.IsPending() {

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -217,6 +217,21 @@ func TestAgentRegistration_Cancel(t *testing.T) {
 	assert.Equal(t, StatusRevoked, pendingDNS.Status)
 }
 
+func TestAgentRegistration_CancelForHostConflict(t *testing.T) {
+	reg := newValidRegistration(t)
+	reg.ClearEvents()
+
+	// Cancels a pending registration WITHOUT raising a TL event — a
+	// pre-activation registration was never sealed (ANS-1 §4.4).
+	require.NoError(t, reg.CancelForHostConflict())
+	assert.Equal(t, StatusRevoked, reg.Status)
+	assert.Empty(t, reg.PendingEvents, "pre-activation cancellation must raise no event")
+
+	// Cannot cancel a non-pending registration.
+	reg.Status = StatusActive
+	assert.ErrorIs(t, reg.CancelForHostConflict(), ErrInvalidState)
+}
+
 func TestAgentRegistration_Fail(t *testing.T) {
 	reg := newValidRegistration(t)
 	require.NoError(t, reg.Fail())

--- a/internal/finder/project/urn.go
+++ b/internal/finder/project/urn.go
@@ -1,50 +1,24 @@
 package project
 
-import "strings"
-
-// urnNamespace is the fixed hierarchical segment between the publisher
-// host and the agent label in a Finder-minted URN. ANS registers
-// agents, so every Finder entry lives under the `agents` namespace.
-const urnNamespace = "agents"
+import "github.com/godaddy/ans/internal/ard"
 
 // mintURN builds the ARD discovery identifier for an Active entry
-// (ARDS §4.2.1):
+// (ARDS §4.2.1): urn:air:<agentHost>:agents:<label>.
 //
-//	urn:air:<agentHost>:agents:<label>
-//
-// The URN is a LINEAGE HANDLE, not a per-registration key: successive
-// versions of the same logical agent (same host + same display name)
-// deliberately share it. Per-registration uniqueness is carried in the
-// wrapper (AgentID/AnsName/LogID) and in metadata, never in the URN.
-// The intra-host label space (everything after the host) is the
-// publisher's to manage.
-//
-// agentHost is the attested host, already syntax-validated and bound to
-// the ansName by feed.EventItem.Validate, so it needs no re-validation
-// here. The label is the sanitized display name with internal
-// whitespace collapsed to single hyphens so the terminal URN segment is
-// a stable, parseable short name. An empty label (display name missing
-// or sanitized away to nothing) yields a false second result: the
-// caller Skips the event rather than substituting any fallback, because
-// a URN without a real terminal segment is not a usable discovery
-// handle.
+// The derivation lives in internal/ard — the single source shared with
+// the RA's published AI Catalog (internal/catalog), so search results
+// and the catalog hand consumers ONE lineage identifier per agent. See
+// ard.MintURN for the full semantics (lineage handle, host lowering,
+// label rules, no-label refusal). agentHost is the attested host,
+// already syntax-validated and bound to the ansName by
+// feed.EventItem.Validate; an empty label makes the caller Skip the
+// event rather than substitute a fallback.
 func mintURN(agentHost, sanitizedDisplayName string) (string, bool) {
-	label := labelize(sanitizedDisplayName)
-	if label == "" {
-		return "", false
-	}
-	return "urn:air:" + strings.ToLower(agentHost) + ":" + urnNamespace + ":" + label, true
+	return ard.MintURN(agentHost, sanitizedDisplayName)
 }
 
-// labelize turns a sanitized display name into a URN terminal segment:
-// trim, then collapse each run of whitespace to a single hyphen. It does
-// not change case (intra-host label space is publisher-owned) and does
-// not otherwise rewrite characters — sanitizeText has already removed
-// control and bidi runes upstream.
+// labelize is ard.Labelize — kept as a package alias because the
+// projection tests pin label behavior at this seam.
 func labelize(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return ""
-	}
-	return strings.Join(strings.Fields(s), "-")
+	return ard.Labelize(s)
 }

--- a/internal/ra/handler/catalog.go
+++ b/internal/ra/handler/catalog.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/godaddy/ans/internal/catalog"
+	"github.com/godaddy/ans/internal/domain"
+	"github.com/godaddy/ans/internal/ra/service"
+)
+
+// catalogDocumentMediaType is the AI Catalog document content type. A
+// bare CatalogEntry is plain application/json; a catalog *document*
+// (host-complete per-host file, and later the export) is this type.
+const catalogDocumentMediaType = "application/ai-catalog+json"
+
+// CatalogHandler serves the per-agent AI Catalog artifact (IMPL §6). Its
+// routes are owner-scoped (ReadOwnership middleware), not public: the bare
+// CatalogEntry is the registrant's own view of how their agent will appear
+// in a catalog. The public, crawlable surface is the population export
+// (a later slice) and the well-known per-host document an AHP publishes —
+// not these agent-keyed routes.
+type CatalogHandler struct {
+	svc *service.RegistrationService
+}
+
+// NewCatalogHandler constructs a CatalogHandler.
+func NewCatalogHandler(svc *service.RegistrationService) *CatalogHandler {
+	return &CatalogHandler{svc: svc}
+}
+
+// CatalogEntry handles GET /v2/ans/agents/{agentId}/catalog-entry. It
+// returns the agent's CatalogEntry (§3) as application/json, or 422
+// NOT_CATALOG_ELIGIBLE when the registration is versionless or carries no
+// A2A/MCP endpoint with a policy-passing metaDataUrl (§3.6). Ownership is
+// enforced by the ReadOwnership middleware, which 404s a registration the
+// caller does not own.
+func (h *CatalogHandler) CatalogEntry(w http.ResponseWriter, r *http.Request) {
+	agentID := chi.URLParam(r, "agentId")
+	res, err := h.svc.GetByAgentID(r.Context(), agentID)
+	if err != nil {
+		WriteError(w, err)
+		return
+	}
+	// GetByAgentID returns endpoints as a sibling slice; the catalog
+	// generator reads them off the aggregate.
+	res.Registration.Endpoints = res.Endpoints
+
+	entry, err := catalog.BuildEntry(res.Registration, catalog.Options{
+		TLPublicBaseURL: h.svc.TLPublicBaseURL(),
+	})
+	if err != nil {
+		var notEligible *catalog.NotEligibleError
+		if errors.As(err, &notEligible) {
+			WriteError(w, domain.NewValidationError("NOT_CATALOG_ELIGIBLE", notEligible.Error()))
+			return
+		}
+		WriteError(w, err)
+		return
+	}
+	WriteJSON(w, http.StatusOK, entry)
+}
+
+// HostCatalog handles GET /v2/ans/agents/{agentId}/ai-catalog. It returns
+// the per-host AI Catalog document (§4) for the agent's host — the file an
+// AHP publishes verbatim at /.well-known/ai-catalog.json. Owner-scoped
+// (ReadOwnership middleware): the caller proves ownership of the keying
+// agent, and the document then lists that owner's ACTIVE catalog-eligible
+// agents on the host. Scoping the body to the owner — not just the route
+// key — is what keeps one owner from seeing another owner's agents on a
+// shared host (HostRegistrations §). The response is
+// application/ai-catalog+json with an ETag, and honors If-None-Match with
+// 304 (§6.3).
+func (h *CatalogHandler) HostCatalog(w http.ResponseWriter, r *http.Request) {
+	agentID := chi.URLParam(r, "agentId")
+	res, err := h.svc.GetByAgentID(r.Context(), agentID)
+	if err != nil {
+		WriteError(w, err)
+		return
+	}
+	host := res.Registration.AnsName.AgentHost()
+
+	// ReadOwnership has verified the caller owns the keying agent, so its
+	// OwnerID is the authenticated owner — use it to scope the document.
+	regs, err := h.svc.HostRegistrations(r.Context(), res.Registration.OwnerID, host)
+	if err != nil {
+		WriteError(w, err)
+		return
+	}
+	doc := catalog.BuildHostDocument(host, regs, catalog.Options{
+		TLPublicBaseURL: h.svc.TLPublicBaseURL(),
+	})
+	writeCatalogDocument(w, r, doc)
+}
+
+// writeCatalogDocument serializes a catalog document once, derives a
+// strong ETag (SHA-256 of the exact bytes), and writes it as
+// application/ai-catalog+json. A matching If-None-Match short-circuits to
+// 304 Not Modified with no body (§6.3). The body is marshalled with the
+// standard library (HTML-escaping on, §3.8) — never the JCS marshaller.
+func writeCatalogDocument(w http.ResponseWriter, r *http.Request, doc catalog.Document) {
+	body, err := json.Marshal(doc)
+	if err != nil {
+		WriteError(w, domain.NewInternalError("CATALOG_MARSHAL", "marshal catalog document", err))
+		return
+	}
+	sum := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+
+	w.Header().Set("ETag", etag)
+	// Owner-scoped response: revalidate every time, never store in a
+	// shared cache. The ETag makes revalidation a cheap 304.
+	w.Header().Set("Cache-Control", "private, no-cache")
+
+	if ifNoneMatch(r, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", catalogDocumentMediaType)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// ifNoneMatch reports whether the request's If-None-Match header matches
+// etag (RFC 9110 §13.1.2): "*" matches anything, otherwise any of the
+// comma-separated entity tags equal to etag (weak comparison — the W/
+// prefix is ignored, which is correct for the cache-validation use here).
+func ifNoneMatch(r *http.Request, etag string) bool {
+	header := r.Header.Get("If-None-Match")
+	if header == "" {
+		return false
+	}
+	if strings.TrimSpace(header) == "*" {
+		return true
+	}
+	target := strings.TrimPrefix(etag, "W/")
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if strings.TrimPrefix(candidate, "W/") == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ra/handler/catalog.go
+++ b/internal/ra/handler/catalog.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
 
 	"github.com/godaddy/ans/internal/catalog"
 	"github.com/godaddy/ans/internal/domain"
@@ -27,12 +28,16 @@ const catalogDocumentMediaType = "application/ai-catalog+json"
 // (a later slice) and the well-known per-host document an AHP publishes —
 // not these agent-keyed routes.
 type CatalogHandler struct {
+	responder
 	svc *service.RegistrationService
 }
 
-// NewCatalogHandler constructs a CatalogHandler.
-func NewCatalogHandler(svc *service.RegistrationService) *CatalogHandler {
-	return &CatalogHandler{svc: svc}
+// NewCatalogHandler constructs a CatalogHandler. The logger feeds the
+// embedded responder: the RA has no request-log middleware and the
+// service layer does not log reads, so h.writeError is the one place a
+// non-domain 500's cause on these routes gets recorded.
+func NewCatalogHandler(svc *service.RegistrationService, logger zerolog.Logger) *CatalogHandler {
+	return &CatalogHandler{responder: newResponder(logger), svc: svc}
 }
 
 // CatalogEntry handles GET /v2/ans/agents/{agentId}/catalog-entry. It
@@ -45,7 +50,7 @@ func (h *CatalogHandler) CatalogEntry(w http.ResponseWriter, r *http.Request) {
 	agentID := chi.URLParam(r, "agentId")
 	res, err := h.svc.GetByAgentID(r.Context(), agentID)
 	if err != nil {
-		WriteError(w, err)
+		h.writeError(w, err)
 		return
 	}
 	// GetByAgentID returns endpoints as a sibling slice; the catalog
@@ -58,10 +63,10 @@ func (h *CatalogHandler) CatalogEntry(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var notEligible *catalog.NotEligibleError
 		if errors.As(err, &notEligible) {
-			WriteError(w, domain.NewValidationError("NOT_CATALOG_ELIGIBLE", notEligible.Error()))
+			h.writeError(w, domain.NewValidationError("NOT_CATALOG_ELIGIBLE", notEligible.Error()))
 			return
 		}
-		WriteError(w, err)
+		h.writeError(w, err)
 		return
 	}
 	WriteJSON(w, http.StatusOK, entry)
@@ -81,7 +86,7 @@ func (h *CatalogHandler) HostCatalog(w http.ResponseWriter, r *http.Request) {
 	agentID := chi.URLParam(r, "agentId")
 	res, err := h.svc.GetByAgentID(r.Context(), agentID)
 	if err != nil {
-		WriteError(w, err)
+		h.writeError(w, err)
 		return
 	}
 	host := res.Registration.AnsName.AgentHost()
@@ -90,13 +95,13 @@ func (h *CatalogHandler) HostCatalog(w http.ResponseWriter, r *http.Request) {
 	// OwnerID is the authenticated owner — use it to scope the document.
 	regs, err := h.svc.HostRegistrations(r.Context(), res.Registration.OwnerID, host)
 	if err != nil {
-		WriteError(w, err)
+		h.writeError(w, err)
 		return
 	}
 	doc := catalog.BuildHostDocument(host, regs, catalog.Options{
 		TLPublicBaseURL: h.svc.TLPublicBaseURL(),
 	})
-	writeCatalogDocument(w, r, doc)
+	h.writeCatalogDocument(w, r, doc)
 }
 
 // writeCatalogDocument serializes a catalog document once, derives a
@@ -104,10 +109,10 @@ func (h *CatalogHandler) HostCatalog(w http.ResponseWriter, r *http.Request) {
 // application/ai-catalog+json. A matching If-None-Match short-circuits to
 // 304 Not Modified with no body (§6.3). The body is marshalled with the
 // standard library (HTML-escaping on, §3.8) — never the JCS marshaller.
-func writeCatalogDocument(w http.ResponseWriter, r *http.Request, doc catalog.Document) {
+func (h *CatalogHandler) writeCatalogDocument(w http.ResponseWriter, r *http.Request, doc catalog.Document) {
 	body, err := json.Marshal(doc)
 	if err != nil {
-		WriteError(w, domain.NewInternalError("CATALOG_MARSHAL", "marshal catalog document", err))
+		h.writeError(w, domain.NewInternalError("CATALOG_MARSHAL", "marshal catalog document", err))
 		return
 	}
 	sum := sha256.Sum256(body)

--- a/internal/ra/handler/catalog_test.go
+++ b/internal/ra/handler/catalog_test.go
@@ -90,7 +90,7 @@ func TestHostCatalog_ActiveAgentAppears(t *testing.T) {
 	if len(doc.Entries) != 1 {
 		t.Fatalf("entries = %d, want 1 (the ACTIVE agent)", len(doc.Entries))
 	}
-	if doc.Entries[0].Identifier != "urn:air:"+host+":agents:ai-agent" {
+	if doc.Entries[0].Identifier != "urn:air:"+host+":agents:Catalog-Agent" {
 		t.Errorf("entry identifier = %q", doc.Entries[0].Identifier)
 	}
 }
@@ -208,8 +208,9 @@ func TestHostCatalog_HostComplete_MultipleVersions(t *testing.T) {
 	if !got["1.0.0"] || !got["2.0.0"] {
 		t.Errorf("want versions {1.0.0, 2.0.0}, got %v", got)
 	}
-	// Both versions share the one lineage handle (leftmost DNS label).
-	wantURN := "urn:air:" + host + ":agents:multi-version"
+	// Both versions share the one lineage handle: same display name →
+	// same labelized URN segment (the Finder-parity derivation).
+	wantURN := "urn:air:" + host + ":agents:Catalog-Agent"
 	for _, e := range doc.Entries {
 		if e.Identifier != wantURN {
 			t.Errorf("entry identifier = %q, want %q", e.Identifier, wantURN)
@@ -271,7 +272,7 @@ func TestCatalogEntry_EligibleReturns200(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &entry); err != nil {
 		t.Fatalf("parse entry: %v", err)
 	}
-	if entry.Identifier != "urn:air:ai-agent.acme.example.com:agents:ai-agent" {
+	if entry.Identifier != "urn:air:ai-agent.acme.example.com:agents:Catalog-Agent" {
 		t.Errorf("identifier = %q", entry.Identifier)
 	}
 	if entry.MediaType != "application/a2a-agent-card+json" {

--- a/internal/ra/handler/catalog_test.go
+++ b/internal/ra/handler/catalog_test.go
@@ -1,0 +1,365 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// registerCatalogEligible registers an agent with an A2A endpoint that
+// carries a same-host metaDataUrl, so it is catalog-eligible (versioned +
+// A2A/MCP + policy-passing metaDataUrl). Returns the new agentId.
+func (f *handlerFixture) registerCatalogEligible(t *testing.T, ownerID, host, version string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "Catalog Agent",
+		"agentDescription": "An agent with a metadata URL.",
+		"version":          version,
+		"agentHost":        host,
+		"endpoints": []map[string]any{
+			{
+				"agentUrl":    "https://" + host + "/a2a",
+				"metaDataUrl": "https://" + host + "/.well-known/agent-card.json",
+				"protocol":    "A2A",
+				"transports":  []string{"JSON-RPC"},
+				"functions": []map[string]any{
+					{"id": "fn1", "name": "lookup", "tags": []string{"support"}},
+				},
+			},
+		},
+		"identityCsrPEM": newTestCSR(t, "ans://v"+version+"."+host),
+		"serverCsrPEM":   newTestServerCSR(t, host),
+	})
+	rec := f.request(t, http.MethodPost, "/v2/ans/agents", bytes.NewReader(body), f.asOwner(ownerID))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("register %s: status=%d body=%s", host, rec.Code, rec.Body)
+	}
+	var resp struct {
+		AgentID string `json:"agentId"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.AgentID == "" {
+		t.Fatal("register returned empty agentId")
+	}
+	return resp.AgentID
+}
+
+// catalogDocResponse is a partial view of an AI Catalog document.
+type catalogDocResponse struct {
+	SpecVersion string `json:"specVersion"`
+	Host        *struct {
+		Identifier  string `json:"identifier"`
+		DisplayName string `json:"displayName"`
+	} `json:"host"`
+	Entries []struct {
+		Identifier string `json:"identifier"`
+		MediaType  string `json:"mediaType"`
+		Version    string `json:"version"`
+	} `json:"entries"`
+}
+
+func TestHostCatalog_ActiveAgentAppears(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "ai-agent.acme.example.com"
+	agentID := fx.registerCatalogEligible(t, "alice", host, "2.1.0")
+	fx.activateAgent(t, "alice", agentID)
+
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/ai-catalog", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/ai-catalog+json" {
+		t.Errorf("content-type = %q, want application/ai-catalog+json", ct)
+	}
+	if rec.Header().Get("ETag") == "" {
+		t.Error("ETag must be set on a catalog document")
+	}
+
+	var doc catalogDocResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("parse document: %v", err)
+	}
+	if doc.SpecVersion != "1.0" {
+		t.Errorf("specVersion = %q, want 1.0", doc.SpecVersion)
+	}
+	if doc.Host == nil || doc.Host.Identifier != host || doc.Host.DisplayName != host {
+		t.Errorf("host object = %+v, want identifier=displayName=%q", doc.Host, host)
+	}
+	if len(doc.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1 (the ACTIVE agent)", len(doc.Entries))
+	}
+	if doc.Entries[0].Identifier != "urn:ai:"+host+":agents:ai-agent" {
+		t.Errorf("entry identifier = %q", doc.Entries[0].Identifier)
+	}
+}
+
+func TestHostCatalog_ETagThenNotModified(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "ai-agent.acme.example.com"
+	agentID := fx.registerCatalogEligible(t, "alice", host, "2.1.0")
+	fx.activateAgent(t, "alice", agentID)
+
+	first := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/ai-catalog", nil, fx.asOwner("alice"))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first GET status=%d", first.Code)
+	}
+	etag := first.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("no ETag on first response")
+	}
+
+	// Conditional re-fetch with the ETag → 304, no body.
+	second := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/ai-catalog", nil, func(r *http.Request) {
+		fx.asOwner("alice")(r)
+		r.Header.Set("If-None-Match", etag)
+	})
+	if second.Code != http.StatusNotModified {
+		t.Fatalf("conditional GET status=%d, want 304", second.Code)
+	}
+	if second.Body.Len() != 0 {
+		t.Errorf("304 must have no body, got %q", second.Body.String())
+	}
+	if second.Header().Get("ETag") != etag {
+		t.Errorf("304 should echo the ETag")
+	}
+}
+
+func TestHostCatalog_IfNoneMatchWildcardAndNonMatch(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "ai-agent.acme.example.com"
+	agentID := fx.registerCatalogEligible(t, "alice", host, "2.1.0")
+	fx.activateAgent(t, "alice", agentID)
+	path := "/v2/ans/agents/" + agentID + "/ai-catalog"
+
+	// "*" matches any current representation → 304 (RFC 9110 §13.1.2).
+	star := fx.request(t, http.MethodGet, path, nil, func(r *http.Request) {
+		fx.asOwner("alice")(r)
+		r.Header.Set("If-None-Match", "*")
+	})
+	if star.Code != http.StatusNotModified {
+		t.Fatalf("If-None-Match: * status=%d, want 304", star.Code)
+	}
+
+	// A non-matching tag (among a list) → full 200 body.
+	noMatch := fx.request(t, http.MethodGet, path, nil, func(r *http.Request) {
+		fx.asOwner("alice")(r)
+		r.Header.Set("If-None-Match", `"nope", W/"also-nope"`)
+	})
+	if noMatch.Code != http.StatusOK {
+		t.Fatalf("non-matching If-None-Match status=%d, want 200", noMatch.Code)
+	}
+	if noMatch.Body.Len() == 0 {
+		t.Error("non-matching conditional GET must return the full body")
+	}
+}
+
+func TestHostCatalog_PendingAgentExcluded(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "pending-host.example.com"
+	// Eligible but never activated → PENDING → excluded from the
+	// well-known per-host document (§8). Document is still well-formed
+	// with an empty entries array.
+	agentID := fx.registerCatalogEligible(t, "alice", host, "1.0.0")
+
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/ai-catalog", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	var doc catalogDocResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &doc)
+	if doc.Host == nil || doc.SpecVersion != "1.0" {
+		t.Fatalf("document malformed: %s", rec.Body)
+	}
+	if len(doc.Entries) != 0 {
+		t.Errorf("PENDING agent must not appear in the per-host doc; entries=%d", len(doc.Entries))
+	}
+}
+
+// TestHostCatalog_HostComplete_MultipleVersions pins the core slice-2
+// behavior: two ACTIVE catalog-eligible versions of the same owner's agent
+// on one host BOTH appear in the per-host document.
+func TestHostCatalog_HostComplete_MultipleVersions(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "multi-version.example.com"
+
+	a1 := fx.registerCatalogEligible(t, "alice", host, "1.0.0")
+	fx.activateAgent(t, "alice", a1)
+	a2 := fx.registerCatalogEligible(t, "alice", host, "2.0.0")
+	fx.activateAgent(t, "alice", a2)
+
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+a1+"/ai-catalog", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	var doc catalogDocResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(doc.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2 (both ACTIVE versions on the host)", len(doc.Entries))
+	}
+	got := map[string]bool{doc.Entries[0].Version: true, doc.Entries[1].Version: true}
+	if !got["1.0.0"] || !got["2.0.0"] {
+		t.Errorf("want versions {1.0.0, 2.0.0}, got %v", got)
+	}
+	// Both versions share the one lineage handle (leftmost DNS label).
+	wantURN := "urn:ai:" + host + ":agents:multi-version"
+	for _, e := range doc.Entries {
+		if e.Identifier != wantURN {
+			t.Errorf("entry identifier = %q, want %q", e.Identifier, wantURN)
+		}
+	}
+}
+
+func TestHostCatalog_NotOwnedReturns404(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	agentID := fx.registerCatalogEligible(t, "alice", "ai-agent.acme.example.com", "2.1.0")
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/ai-catalog", nil, fx.asOwner("bob"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 for non-owner, got %d body=%s", rec.Code, rec.Body)
+	}
+}
+
+// catalogEntryResponse is a partial view of the bare CatalogEntry used for
+// assertions.
+type catalogEntryResponse struct {
+	Identifier  string   `json:"identifier"`
+	DisplayName string   `json:"displayName"`
+	Description string   `json:"description"`
+	Version     string   `json:"version"`
+	MediaType   string   `json:"mediaType"`
+	URL         string   `json:"url"`
+	Tags        []string `json:"tags"`
+	Publisher   *struct {
+		Identifier   string `json:"identifier"`
+		DisplayName  string `json:"displayName"`
+		IdentityType string `json:"identityType"`
+	} `json:"publisher"`
+	Metadata *struct {
+		AnsName   string `json:"ansName"`
+		AgentHost string `json:"agentHost"`
+	} `json:"metadata"`
+	TrustManifest *struct {
+		Identity string `json:"identity"`
+	} `json:"trustManifest"`
+}
+
+func TestCatalogEntry_EligibleReturns200(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	agentID := fx.registerCatalogEligible(t, "alice", "ai-agent.acme.example.com", "2.1.0")
+	// A catalog entry is published only once the agent is ACTIVE (sealed
+	// in the TL), so drive it through activation first.
+	fx.activateAgent(t, "alice", agentID)
+
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/catalog-entry", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+
+	var entry catalogEntryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &entry); err != nil {
+		t.Fatalf("parse entry: %v", err)
+	}
+	if entry.Identifier != "urn:ai:ai-agent.acme.example.com:agents:ai-agent" {
+		t.Errorf("identifier = %q", entry.Identifier)
+	}
+	if entry.MediaType != "application/a2a-agent-card+json" {
+		t.Errorf("mediaType = %q", entry.MediaType)
+	}
+	if entry.URL != "https://ai-agent.acme.example.com/.well-known/agent-card.json" {
+		t.Errorf("url = %q", entry.URL)
+	}
+	if entry.Version != "2.1.0" {
+		t.Errorf("version = %q", entry.Version)
+	}
+	if entry.Publisher == nil || entry.Publisher.IdentityType != "dns" {
+		t.Errorf("publisher = %+v", entry.Publisher)
+	}
+	if entry.Metadata == nil || entry.Metadata.AgentHost != "ai-agent.acme.example.com" {
+		t.Errorf("metadata = %+v", entry.Metadata)
+	}
+	// Trust-manifest identity MUST equal the entry identifier (§5.1).
+	if entry.TrustManifest == nil || entry.TrustManifest.Identity != entry.Identifier {
+		t.Errorf("trustManifest identity must match identifier; got %+v", entry.TrustManifest)
+	}
+	if len(entry.Tags) != 1 || entry.Tags[0] != "support" {
+		t.Errorf("tags = %v", entry.Tags)
+	}
+}
+
+func TestCatalogEntry_IneligibleReturns422(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	// ACTIVE agent whose only endpoint (MCP) has no metaDataUrl → eligible
+	// on status but not on endpoint → 422 NOT_CATALOG_ELIGIBLE. Activated
+	// so we exercise the endpoint gate, not the not-active gate.
+	agentID := fx.registerAgent(t, "alice", "no-meta.example.com", "1.0.0")
+	fx.activateAgent(t, "alice", agentID)
+
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/catalog-entry", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d body=%s", rec.Code, rec.Body)
+	}
+	var prob struct {
+		Code   string `json:"code"`
+		Status int    `json:"status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &prob); err != nil {
+		t.Fatalf("parse problem: %v", err)
+	}
+	if prob.Code != "NOT_CATALOG_ELIGIBLE" {
+		t.Errorf("code = %q, want NOT_CATALOG_ELIGIBLE", prob.Code)
+	}
+	if prob.Status != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", prob.Status)
+	}
+}
+
+// TestCatalogEntry_NotActiveReturns422 is the core guard: a catalog entry
+// is NOT available before the agent is set up. A registered-but-not-yet-
+// ACTIVE agent (no TL entry, so nothing for the trust manifest/badge to
+// link to) returns 422 rather than an entry pointing at a nonexistent
+// receipt.
+func TestCatalogEntry_NotActiveReturns422(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	// Eligible endpoint + version, but left PENDING (not activated).
+	agentID := fx.registerCatalogEligible(t, "alice", "pending-agent.example.com", "1.0.0")
+
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/catalog-entry", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("a pending agent must not have a catalog entry; status=%d body=%s, want 422", rec.Code, rec.Body)
+	}
+	var prob struct {
+		Code   string `json:"code"`
+		Detail string `json:"detail"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &prob)
+	if prob.Code != "NOT_CATALOG_ELIGIBLE" {
+		t.Errorf("code = %q, want NOT_CATALOG_ELIGIBLE", prob.Code)
+	}
+}
+
+func TestCatalogEntry_NotOwnedReturns404(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	agentID := fx.registerCatalogEligible(t, "alice", "ai-agent.acme.example.com", "2.1.0")
+
+	// Bob does not own Alice's agent → ReadOwnership 404s to hide
+	// existence.
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID+"/catalog-entry", nil, fx.asOwner("bob"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 for non-owner, got %d body=%s", rec.Code, rec.Body)
+	}
+}

--- a/internal/ra/handler/catalog_test.go
+++ b/internal/ra/handler/catalog_test.go
@@ -90,7 +90,7 @@ func TestHostCatalog_ActiveAgentAppears(t *testing.T) {
 	if len(doc.Entries) != 1 {
 		t.Fatalf("entries = %d, want 1 (the ACTIVE agent)", len(doc.Entries))
 	}
-	if doc.Entries[0].Identifier != "urn:ai:"+host+":agents:ai-agent" {
+	if doc.Entries[0].Identifier != "urn:air:"+host+":agents:ai-agent" {
 		t.Errorf("entry identifier = %q", doc.Entries[0].Identifier)
 	}
 }
@@ -209,7 +209,7 @@ func TestHostCatalog_HostComplete_MultipleVersions(t *testing.T) {
 		t.Errorf("want versions {1.0.0, 2.0.0}, got %v", got)
 	}
 	// Both versions share the one lineage handle (leftmost DNS label).
-	wantURN := "urn:ai:" + host + ":agents:multi-version"
+	wantURN := "urn:air:" + host + ":agents:multi-version"
 	for _, e := range doc.Entries {
 		if e.Identifier != wantURN {
 			t.Errorf("entry identifier = %q, want %q", e.Identifier, wantURN)
@@ -271,7 +271,7 @@ func TestCatalogEntry_EligibleReturns200(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &entry); err != nil {
 		t.Fatalf("parse entry: %v", err)
 	}
-	if entry.Identifier != "urn:ai:ai-agent.acme.example.com:agents:ai-agent" {
+	if entry.Identifier != "urn:air:ai-agent.acme.example.com:agents:ai-agent" {
 		t.Errorf("identifier = %q", entry.Identifier)
 	}
 	if entry.MediaType != "application/a2a-agent-card+json" {

--- a/internal/ra/handler/lifecycle_test.go
+++ b/internal/ra/handler/lifecycle_test.go
@@ -872,12 +872,11 @@ type handlerFixture struct {
 //
 // Once a registration goes live (ACTIVE/DEPRECATED) on an FQDN, that FQDN
 // belongs to its owner alone: a different owner may neither register nor
-// activate on it until no live registration remains. Enforced at every
-// progression step (register, verify-acme, verify-dns). The verify-dns
-// check is BEST-EFFORT against a concurrent pending-window race — it runs
-// before the inline seal and outside the activation transaction (see
-// preflightRegistrationConflicts) — so these tests pin the sequential
-// contract, not an atomic activation-time guarantee.
+// activate on it until no live registration remains. Checked at every
+// progression step (register, verify-acme, verify-dns) as a fast-fail,
+// and decided authoritatively by commitActivation's in-tx re-check —
+// these tests pin the sequential contract; the mid-seal race interleavings
+// are pinned by the service-level TestVerifyDNS_Rival* tests.
 
 // registerRaw POSTs a registration and returns the recorder without
 // asserting status — for the conflict paths where 409 is the expectation.
@@ -1071,7 +1070,7 @@ func newHandlerFixture(t *testing.T) *handlerFixture {
 	r.Post("/v2/ans/agents", regH.Register)
 	r.Get("/v2/ans/agents", lifeH.List)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}", lifeH.Detail)
-	catH := handler.NewCatalogHandler(svc)
+	catH := handler.NewCatalogHandler(svc, zerolog.Nop())
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}/catalog-entry", catH.CatalogEntry)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}/ai-catalog", catH.HostCatalog)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}/certificates/identity", lifeH.GetIdentityCerts)

--- a/internal/ra/handler/lifecycle_test.go
+++ b/internal/ra/handler/lifecycle_test.go
@@ -723,13 +723,15 @@ func TestVerifyDNS_ActivatesWhenRecordsMatch(t *testing.T) {
 		t.Errorf("eventType: got %q, want AGENT_REGISTERED", sealed[0])
 	}
 
-	// Activation seals inline, so the outbox must be empty.
+	// Activation seals inline, so nothing is claimable by the outbox
+	// worker — the only row it writes is the pre-delivered feed row
+	// (sent + logId at insert), which Claim never returns.
 	rows, err := fx.outbox.Claim(context.Background(), 100)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(rows) != 0 {
-		t.Fatalf("outbox rows: got %d, want 0 (activation seals inline)", len(rows))
+		t.Fatalf("claimable outbox rows: got %d, want 0 (activation seals inline)", len(rows))
 	}
 }
 
@@ -870,9 +872,12 @@ type handlerFixture struct {
 //
 // Once a registration goes live (ACTIVE/DEPRECATED) on an FQDN, that FQDN
 // belongs to its owner alone: a different owner may neither register nor
-// activate on it until no live registration remains. Enforced at
-// registration (entry gate) and re-checked atomically at activation
-// (verify-dns) to close the pending-window race.
+// activate on it until no live registration remains. Enforced at every
+// progression step (register, verify-acme, verify-dns). The verify-dns
+// check is BEST-EFFORT against a concurrent pending-window race — it runs
+// before the inline seal and outside the activation transaction (see
+// preflightRegistrationConflicts) — so these tests pin the sequential
+// contract, not an atomic activation-time guarantee.
 
 // registerRaw POSTs a registration and returns the recorder without
 // asserting status — for the conflict paths where 409 is the expectation.

--- a/internal/ra/handler/lifecycle_test.go
+++ b/internal/ra/handler/lifecycle_test.go
@@ -708,20 +708,62 @@ func TestVerifyDNS_ActivatesWhenRecordsMatch(t *testing.T) {
 		t.Fatalf("status: got %q want ACTIVE", resp.Status)
 	}
 
-	// Exactly one outbox row: a single terminal AGENT_REGISTERED
-	// event emitted at the PENDING_DNS → ACTIVE transition. The V1
-	// reference and production TL both use this single-terminal
+	// Exactly one sealed event: a single terminal AGENT_REGISTERED
+	// sealed INLINE at the PENDING_DNS → ACTIVE transition
+	// (seal-before-success). Activation does not report ACTIVE until
+	// the event is durable in the TL, so it never rides the outbox.
+	// The V1 reference and production TL both use this single-terminal
 	// model — no AGENT_REGISTRATION / DOMAIN_VALIDATION intermediate
 	// events exist on either lane.
+	sealed := fx.sealer.sealedTypes()
+	if len(sealed) != 1 {
+		t.Fatalf("sealed events: got %v, want 1 (single AGENT_REGISTERED terminal)", sealed)
+	}
+	if sealed[0] != "AGENT_REGISTERED" {
+		t.Errorf("eventType: got %q, want AGENT_REGISTERED", sealed[0])
+	}
+
+	// Activation seals inline, so the outbox must be empty.
 	rows, err := fx.outbox.Claim(context.Background(), 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 1 {
-		t.Fatalf("outbox rows: got %d, want 1 (single AGENT_REGISTERED terminal)", len(rows))
+	if len(rows) != 0 {
+		t.Fatalf("outbox rows: got %d, want 0 (activation seals inline)", len(rows))
 	}
-	if rows[0].EventType != "AGENT_REGISTERED" {
-		t.Errorf("eventType: got %q, want AGENT_REGISTERED", rows[0].EventType)
+}
+
+// TestVerifyDNS_SealFailure_Returns503 pins the seal-before-success
+// contract at the HTTP boundary. When the inline TL seal fails (TL
+// unreachable), verify-dns must surface 503 SERVICE_UNAVAILABLE and the
+// agent must stay PENDING_DNS — never reporting ACTIVE for an agent that
+// was never written to the log.
+func TestVerifyDNS_SealFailure_Returns503(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	agentID := fx.registerAgent(t, "alice", "agent.example.com", "1.0.0")
+	_ = fx.request(t, http.MethodPost, "/v2/ans/agents/"+agentID+"/verify-acme", nil, fx.asOwner("alice"))
+
+	// Arm the sealer to fail as the tlclient would when the TL is down.
+	fx.sealer.failErr = domain.NewUnavailableError("TL_UNAVAILABLE", "tl down")
+
+	rec := fx.request(t, http.MethodPost, "/v2/ans/agents/"+agentID+"/verify-dns", nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("verify-dns on seal failure: got %d, want 503; body=%s", rec.Code, rec.Body)
+	}
+
+	// Fail-closed: the agent must still read as PENDING_DNS, and nothing
+	// leaked onto the outbox.
+	det := fx.request(t, http.MethodGet, "/v2/ans/agents/"+agentID, nil, fx.asOwner("alice"))
+	var detResp struct {
+		AgentStatus string `json:"agentStatus"`
+	}
+	_ = json.Unmarshal(det.Body.Bytes(), &detResp)
+	if detResp.AgentStatus != "PENDING_DNS" {
+		t.Fatalf("agent must stay PENDING_DNS after a failed seal; got %q", detResp.AgentStatus)
+	}
+	if rows, _ := fx.outbox.Claim(context.Background(), 100); len(rows) != 0 {
+		t.Errorf("activation must not enqueue to the outbox; got %d rows", len(rows))
 	}
 }
 
@@ -751,22 +793,33 @@ func TestRevoke_TransitionsToRevokedAndEmitsEvent(t *testing.T) {
 		t.Errorf("reason: got %q", resp.Reason)
 	}
 
-	// After the register → verify-acme → verify-dns → revoke walk,
-	// the outbox should carry exactly two terminal events:
-	// AGENT_REGISTERED from the ACTIVE transition and AGENT_REVOKED
-	// from this revoke. Intermediate events don't exist.
-	rows, _ := fx.outbox.Claim(context.Background(), 100)
-	sawRegistered, sawRevoked := false, false
-	for _, row := range rows {
-		switch row.EventType {
-		case "AGENT_REGISTERED":
+	// After the register → verify-acme → verify-dns → revoke walk, the
+	// two terminal events land on different rails. AGENT_REGISTERED is
+	// sealed INLINE at the ACTIVE transition (seal-before-success), so
+	// it lives in the sealer, not the outbox. AGENT_REVOKED still rides
+	// the outbox: revoke is an idempotent terminal transition whose
+	// async delivery is safe — the agent is already REVOKED locally and
+	// stays visible until the log catches up. Intermediate events don't
+	// exist on either lane.
+	sawRegistered := false
+	for _, et := range fx.sealer.sealedTypes() {
+		if et == "AGENT_REGISTERED" {
 			sawRegistered = true
-		case "AGENT_REVOKED":
-			sawRevoked = true
 		}
 	}
 	if !sawRegistered {
-		t.Error("outbox missing AGENT_REGISTERED event")
+		t.Error("sealer missing AGENT_REGISTERED event")
+	}
+
+	rows, _ := fx.outbox.Claim(context.Background(), 100)
+	sawRevoked := false
+	for _, row := range rows {
+		if row.EventType == "AGENT_REGISTERED" {
+			t.Error("AGENT_REGISTERED must be sealed inline, not enqueued to the outbox")
+		}
+		if row.EventType == "AGENT_REVOKED" {
+			sawRevoked = true
+		}
 	}
 	if !sawRevoked {
 		t.Error("outbox missing AGENT_REVOKED event")
@@ -809,7 +862,144 @@ func TestRevoke_NotOwnedReturns403(t *testing.T) {
 type handlerFixture struct {
 	router chi.Router
 	outbox *sqlite.OutboxStore
+	sealer *recordingAgentSealer        // captures AGENT_REGISTERED sealed at activation
 	svc    *service.RegistrationService // exposed for direct-handler tests
+}
+
+// ----- FQDN exclusivity (one-host-one-owner) -----
+//
+// Once a registration goes live (ACTIVE/DEPRECATED) on an FQDN, that FQDN
+// belongs to its owner alone: a different owner may neither register nor
+// activate on it until no live registration remains. Enforced at
+// registration (entry gate) and re-checked atomically at activation
+// (verify-dns) to close the pending-window race.
+
+// registerRaw POSTs a registration and returns the recorder without
+// asserting status — for the conflict paths where 409 is the expectation.
+func (f *handlerFixture) registerRaw(t *testing.T, owner, host, version string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"agentDisplayName": "Exclusivity",
+		"version":          version,
+		"agentHost":        host,
+		"endpoints": []map[string]any{
+			{"agentUrl": "https://" + host + "/mcp", "protocol": "MCP", "transports": []string{"SSE"}},
+		},
+		"identityCsrPEM": newTestCSR(t, "ans://v"+version+"."+host),
+		"serverCsrPEM":   newTestServerCSR(t, host),
+	})
+	return f.request(t, http.MethodPost, "/v2/ans/agents", bytes.NewReader(body), f.asOwner(owner))
+}
+
+func problemCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var p struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &p)
+	return p.Code
+}
+
+func TestFQDNExclusivity_DifferentOwnerRegisterRejected(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "excl.example.com"
+	a := fx.registerAgent(t, "alice", host, "1.0.0")
+	fx.activateAgent(t, "alice", a)
+
+	rec := fx.registerRaw(t, "bob", host, "2.0.0")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("bob register on alice's active host: status=%d body=%s, want 409", rec.Code, rec.Body)
+	}
+	if c := problemCode(t, rec); c != "AGENT_HOST_TAKEN" {
+		t.Errorf("code = %q, want AGENT_HOST_TAKEN", c)
+	}
+}
+
+func TestFQDNExclusivity_SameOwnerMayAddVersion(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "excl-same.example.com"
+	a := fx.registerAgent(t, "alice", host, "1.0.0")
+	fx.activateAgent(t, "alice", a)
+
+	// The same owner may register another version while the first is
+	// ACTIVE (version coexistence, ANS-1 §7.1).
+	if rec := fx.registerRaw(t, "alice", host, "2.0.0"); rec.Code != http.StatusAccepted {
+		t.Fatalf("same owner adding a version: status=%d body=%s, want 202", rec.Code, rec.Body)
+	}
+}
+
+// TestFQDNExclusivity_LoserCanceledOnWinnerActivation is the scenario from
+// the requirement: A (who does not control the host) and B (who does) both
+// submit pending registrations — both allowed — and when B's registration
+// goes ACTIVE, A's pending registration is cancelled.
+func TestFQDNExclusivity_LoserCanceledOnWinnerActivation(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "excl-cancel.example.com"
+
+	// Both pending → both allowed (the host is not yet live).
+	loser := fx.registerAgent(t, "alice", host, "1.0.0")
+	winner := fx.registerAgent(t, "bob", host, "2.0.0")
+
+	// B finishes registration → goes ACTIVE, taking the host.
+	fx.activateAgent(t, "bob", winner)
+
+	// A's pending registration was cancelled by B's activation.
+	rec := fx.request(t, http.MethodGet, "/v2/ans/agents/"+loser, nil, fx.asOwner("alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("alice detail status=%d body=%s", rec.Code, rec.Body)
+	}
+	var detail struct {
+		AgentStatus string `json:"agentStatus"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &detail)
+	if detail.AgentStatus != "REVOKED" {
+		t.Errorf("loser status = %q, want REVOKED (cancelled when winner activated)", detail.AgentStatus)
+	}
+}
+
+// TestFQDNExclusivity_LoserRejectedAtEveryLevel confirms that once the host
+// is taken, the losing registration is rejected at verify-acme AND
+// verify-dns (not only at the final activation).
+func TestFQDNExclusivity_LoserRejectedAtEveryLevel(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "excl-levels.example.com"
+	loser := fx.registerAgent(t, "alice", host, "1.0.0")
+	winner := fx.registerAgent(t, "bob", host, "2.0.0")
+	fx.activateAgent(t, "bob", winner)
+
+	for _, step := range []string{"verify-acme", "verify-dns"} {
+		rec := fx.request(t, http.MethodPost, "/v2/ans/agents/"+loser+"/"+step, nil, fx.asOwner("alice"))
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("loser %s: status=%d body=%s, want 409", step, rec.Code, rec.Body)
+		}
+		if c := problemCode(t, rec); c != "AGENT_HOST_TAKEN" {
+			t.Errorf("loser %s code = %q, want AGENT_HOST_TAKEN", step, c)
+		}
+	}
+}
+
+func TestFQDNExclusivity_FreedAfterRevoke(t *testing.T) {
+	t.Parallel()
+	fx := newHandlerFixture(t)
+	host := "excl-freed.example.com"
+	a := fx.registerAgent(t, "alice", host, "1.0.0")
+	fx.activateAgent(t, "alice", a)
+
+	// Alice revokes → no live registration remains on the host.
+	rec := fx.request(t, http.MethodPost, "/v2/ans/agents/"+a+"/revoke",
+		bytes.NewReader([]byte(`{"reason":"CESSATION_OF_OPERATION","comments":"done"}`)), fx.asOwner("alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("alice revoke: status=%d body=%s", rec.Code, rec.Body)
+	}
+	// Bob may now take the freed host — and activate on it. Activating
+	// also exercises cancelConflictingPendings skipping alice's terminal
+	// (REVOKED) registration.
+	b := fx.registerAgent(t, "bob", host, "2.0.0")
+	fx.activateAgent(t, "bob", b)
 }
 
 func newHandlerFixture(t *testing.T) *handlerFixture {
@@ -856,6 +1046,7 @@ func newHandlerFixture(t *testing.T) *handlerFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sealer := &recordingAgentSealer{}
 	svc := service.NewRegistrationService(
 		agents, endpoints, certsStore, byoc, renewals, validator, identityCA, bus, outbox, db, discoveryReg,
 	).WithSigner(service.EventSigner{
@@ -863,7 +1054,8 @@ func newHandlerFixture(t *testing.T) *handlerFixture {
 		KeyID:      "ra-signer",
 		RaID:       "ra-test",
 	}).WithDNSVerifier(dns.NewNoopVerifier()).
-		WithServerCertificateIssuer(serverCA)
+		WithServerCertificateIssuer(serverCA).
+		WithAgentSealer(sealer)
 
 	r := chi.NewRouter()
 	regH := handler.NewRegistrationHandler(svc, zerolog.Nop())
@@ -874,6 +1066,9 @@ func newHandlerFixture(t *testing.T) *handlerFixture {
 	r.Post("/v2/ans/agents", regH.Register)
 	r.Get("/v2/ans/agents", lifeH.List)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}", lifeH.Detail)
+	catH := handler.NewCatalogHandler(svc)
+	r.With(readOwn).Get("/v2/ans/agents/{agentId}/catalog-entry", catH.CatalogEntry)
+	r.With(readOwn).Get("/v2/ans/agents/{agentId}/ai-catalog", catH.HostCatalog)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}/certificates/identity", lifeH.GetIdentityCerts)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}/certificates/server", lifeH.GetServerCerts)
 	r.With(readOwn).Get("/v2/ans/agents/{agentId}/csrs/{csrId}/status", lifeH.GetCSRStatus)
@@ -912,7 +1107,7 @@ func newHandlerFixture(t *testing.T) *handlerFixture {
 	r.With(writeOwn).Delete("/v1/agents/{agentId}/certificates/server/renewal", v1renH.CancelServerCertRenewal)
 	r.With(writeOwn).Post("/v1/agents/{agentId}/certificates/server/renewal/verify-acme", v1renH.VerifyRenewalACME)
 
-	return &handlerFixture{router: r, outbox: outbox, svc: svc}
+	return &handlerFixture{router: r, outbox: outbox, sealer: sealer, svc: svc}
 }
 
 // asOwner wraps a request with a synthetic Identity matching the

--- a/internal/ra/handler/sealer_test.go
+++ b/internal/ra/handler/sealer_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 )
 
@@ -24,11 +25,11 @@ type sealedAgentEvent struct {
 	InnerCanonical []byte
 }
 
-func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion string, innerCanonical []byte, _ string) error {
+func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion string, innerCanonical []byte, _ string) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.failErr != nil {
-		return r.failErr
+		return "", r.failErr
 	}
 	var meta struct {
 		EventType string `json:"eventType"`
@@ -39,7 +40,9 @@ func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion s
 		EventType:      meta.EventType,
 		InnerCanonical: append([]byte(nil), innerCanonical...),
 	})
-	return nil
+	// Deterministic fake of the TL ack's logId; the activation records it
+	// on the pre-delivered feed row.
+	return fmt.Sprintf("test-log-%d", len(r.events)), nil
 }
 
 // sealed returns a copy of the events sealed so far.

--- a/internal/ra/handler/sealer_test.go
+++ b/internal/ra/handler/sealer_test.go
@@ -1,0 +1,60 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+)
+
+// recordingAgentSealer is a test service.AgentEventSealer for the agent
+// activation seal-before-success path. By default it succeeds and records
+// each sealed event so a test can assert what verify-dns submitted to the
+// TL — the AGENT_REGISTERED event no longer rides the outbox. Set failErr
+// to exercise the fail-closed path (activation must then refuse to report
+// ACTIVE and the agent stays PENDING_DNS).
+type recordingAgentSealer struct {
+	mu      sync.Mutex
+	events  []sealedAgentEvent
+	failErr error
+}
+
+type sealedAgentEvent struct {
+	SchemaVersion  string
+	EventType      string
+	InnerCanonical []byte
+}
+
+func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion string, innerCanonical []byte, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failErr != nil {
+		return r.failErr
+	}
+	var meta struct {
+		EventType string `json:"eventType"`
+	}
+	_ = json.Unmarshal(innerCanonical, &meta)
+	r.events = append(r.events, sealedAgentEvent{
+		SchemaVersion:  schemaVersion,
+		EventType:      meta.EventType,
+		InnerCanonical: append([]byte(nil), innerCanonical...),
+	})
+	return nil
+}
+
+// sealed returns a copy of the events sealed so far.
+func (r *recordingAgentSealer) sealed() []sealedAgentEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]sealedAgentEvent(nil), r.events...)
+}
+
+// sealedTypes returns the eventType of each sealed event, in order.
+func (r *recordingAgentSealer) sealedTypes() []string {
+	sealed := r.sealed()
+	out := make([]string, 0, len(sealed))
+	for _, e := range sealed {
+		out = append(out, e.EventType)
+	}
+	return out
+}

--- a/internal/ra/handler/v1lifecycle_test.go
+++ b/internal/ra/handler/v1lifecycle_test.go
@@ -86,10 +86,12 @@ func TestV1VerifyDNS_EmitsAgentRegistered(t *testing.T) {
 	}
 
 	// AGENT_REGISTERED seals INLINE at the verify-dns ACTIVE transition
-	// (seal-before-success), stamped schema_version=V1 — not enqueued
-	// to the outbox. Earlier steps (register + verify-acme) must not
+	// (seal-before-success), stamped schema_version=V1 — never handed to
+	// the outbox WORKER. Earlier steps (register + verify-acme) must not
 	// have sealed anything, because V1 emits only on terminal
-	// transitions. The outbox must stay empty for this lifecycle.
+	// transitions. Claim must return nothing: the only outbox row this
+	// lifecycle writes is the pre-delivered feed row recorded at
+	// activation (sent + logId at insert), which is invisible to Claim.
 	var registered int
 	for _, s := range fx.sealer.sealed() {
 		if s.SchemaVersion != "V1" {
@@ -107,7 +109,7 @@ func TestV1VerifyDNS_EmitsAgentRegistered(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(rows) != 0 {
-		t.Errorf("activation seals inline; outbox must be empty, got %d rows", len(rows))
+		t.Errorf("activation seals inline; nothing must be claimable by the worker, got %d rows", len(rows))
 	}
 }
 

--- a/internal/ra/handler/v1lifecycle_test.go
+++ b/internal/ra/handler/v1lifecycle_test.go
@@ -85,28 +85,29 @@ func TestV1VerifyDNS_EmitsAgentRegistered(t *testing.T) {
 		t.Errorf("status: got %q, want ACTIVE", resp.Status)
 	}
 
-	// Outbox must contain EXACTLY ONE AGENT_REGISTERED V1 row — the
-	// one emitted at verify-dns ACTIVE transition. Earlier steps
-	// (register + verify-acme) must not have emitted, because V1
-	// emits only on terminal transitions.
-	rows, err := fx.outbox.Claim(context.Background(), 100)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// AGENT_REGISTERED seals INLINE at the verify-dns ACTIVE transition
+	// (seal-before-success), stamped schema_version=V1 — not enqueued
+	// to the outbox. Earlier steps (register + verify-acme) must not
+	// have sealed anything, because V1 emits only on terminal
+	// transitions. The outbox must stay empty for this lifecycle.
 	var registered int
-	for _, row := range rows {
-		if row.AgentID != agentID {
-			continue
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion != "V1" {
+			t.Errorf("V1 agent sealed event schema_version=%q, want V1", s.SchemaVersion)
 		}
-		if row.SchemaVersion != "V1" {
-			t.Errorf("V1 agent row schema_version=%q, want V1", row.SchemaVersion)
-		}
-		if row.EventType == "AGENT_REGISTERED" {
+		if s.EventType == "AGENT_REGISTERED" {
 			registered++
 		}
 	}
 	if registered != 1 {
-		t.Errorf("V1 lifecycle must emit exactly one AGENT_REGISTERED leaf; got %d", registered)
+		t.Errorf("V1 lifecycle must seal exactly one AGENT_REGISTERED leaf; got %d", registered)
+	}
+	rows, err := fx.outbox.Claim(context.Background(), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("activation seals inline; outbox must be empty, got %d rows", len(rows))
 	}
 }
 
@@ -133,27 +134,19 @@ func TestV1VerifyDNS_EmitsFullAttestations(t *testing.T) {
 		t.Fatalf("verify-dns: %d %s", ack.Code, ack.Body)
 	}
 
-	// Pull the emitted event from the outbox and drill into its
-	// attestation block.
-	rows, err := fx.outbox.Claim(context.Background(), 100)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var payloadJSON []byte
-	for _, row := range rows {
-		if row.AgentID == agentID && row.EventType == "AGENT_REGISTERED" {
-			payloadJSON = row.PayloadJSON
+	// AGENT_REGISTERED seals inline at activation; pull the sealed V1
+	// event and drill into its attestation block. The sealer records
+	// the JCS-canonical inner-event bytes the RA signed — the same
+	// bytes posted to the TL — so there is no {innerEventCanonical,
+	// producerSignature} outbox wrapper to unwrap here.
+	var innerCanonical []byte
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion == "V1" && s.EventType == "AGENT_REGISTERED" {
+			innerCanonical = s.InnerCanonical
 		}
 	}
-	if len(payloadJSON) == 0 {
-		t.Fatal("no AGENT_REGISTERED outbox row found")
-	}
-	// Payload wrapper: {innerEventCanonical, producerSignature}.
-	var payload struct {
-		InnerEventCanonical json.RawMessage `json:"innerEventCanonical"`
-	}
-	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
-		t.Fatalf("unmarshal payload: %v", err)
+	if len(innerCanonical) == 0 {
+		t.Fatal("no AGENT_REGISTERED sealed event found")
 	}
 	var inner struct {
 		EventType    string `json:"eventType"`
@@ -171,7 +164,7 @@ func TestV1VerifyDNS_EmitsFullAttestations(t *testing.T) {
 			} `json:"validIdentityCerts"`
 		} `json:"attestations"`
 	}
-	if err := json.Unmarshal(payload.InnerEventCanonical, &inner); err != nil {
+	if err := json.Unmarshal(innerCanonical, &inner); err != nil {
 		t.Fatalf("unmarshal inner event: %v", err)
 	}
 

--- a/internal/ra/service/activation_race_test.go
+++ b/internal/ra/service/activation_race_test.go
@@ -1,0 +1,275 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/godaddy/ans/internal/domain"
+	"github.com/godaddy/ans/internal/ra/service"
+)
+
+// These tests pin commitActivation's in-tx exclusivity decision — the
+// interleavings the pre-seal check cannot see because a rival commits
+// during the seal round trip. The sealer double's hook runs inside that
+// window (after the TL "ack", before this racer's transaction), exactly
+// where a real rival's commit lands under the store's single writer.
+
+// registerRival registers a second owner's registration on the fixture's
+// host (a different version keeps the ANS name unique) and drives it to
+// PENDING_DNS, returning its agentID.
+func registerRival(t *testing.T, fx *regFixture, ownerID, version string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	sv, err := domain.ParseSemVer(version)
+	if err != nil {
+		t.Fatalf("ParseSemVer(%q): %v", version, err)
+	}
+	ansName, err := domain.NewAnsName(sv, fx.req.AnsName.AgentHost())
+	if err != nil {
+		t.Fatalf("NewAnsName: %v", err)
+	}
+	req := fx.req
+	req.OwnerID = ownerID
+	req.AnsName = ansName
+	req.IdentityCSRPEM = testCSR(t, ansName.String())
+	req.ServerCsrPEM = testServerCSR(t, ansName.FQDN())
+
+	resp, err := fx.svc.RegisterAgent(ctx, req)
+	if err != nil {
+		t.Fatalf("register rival: %v", err)
+	}
+	if _, err := fx.svc.VerifyACME(ctx, resp.Registration.AgentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("rival verify-acme: %v", err)
+	}
+	return resp.Registration.AgentID
+}
+
+// driveToPendingDNS drives the fixture's own request to PENDING_DNS and
+// returns its agentID.
+func driveToPendingDNS(t *testing.T, fx *regFixture) string {
+	t.Helper()
+	ctx := context.Background()
+	resp, err := fx.svc.RegisterAgent(ctx, fx.req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := fx.svc.VerifyACME(ctx, resp.Registration.AgentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("verify-acme: %v", err)
+	}
+	return resp.Registration.AgentID
+}
+
+// mustHostTaken asserts err is the AGENT_HOST_TAKEN conflict.
+func mustHostTaken(t *testing.T, err error) {
+	t.Helper()
+	var de *domain.Error
+	if !errors.As(err, &de) || de.Code != "AGENT_HOST_TAKEN" {
+		t.Fatalf("want AGENT_HOST_TAKEN, got %v", err)
+	}
+}
+
+// TestVerifyDNS_RivalActivatedMidSeal_LoserAborts covers the two-owner
+// activation race: both pass the pre-seal check, the rival commits ACTIVE
+// while this racer is inside its seal round trip. commitActivation's
+// in-tx re-check must abort THIS racer with AGENT_HOST_TAKEN — never
+// commit a second ACTIVE holder (which would wedge the host: every later
+// call 409ing each owner against the other with no API path out). The
+// loser's already-sealed leaf is the accepted benign residue.
+func TestVerifyDNS_RivalActivatedMidSeal_LoserAborts(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	loserID := driveToPendingDNS(t, fx)
+	rivalID := registerRival(t, fx, "owner-2", "2.0.0")
+
+	// Inside the loser's seal round trip, the rival's activation commits.
+	fx.sealer.hook = func() {
+		fx.sealer.hook = nil // fire once — only for the loser's seal
+		rival, err := fx.agents.FindByAgentID(ctx, rivalID)
+		if err != nil {
+			t.Errorf("load rival: %v", err)
+			return
+		}
+		if err := rival.Activate(time.Now()); err != nil {
+			t.Errorf("activate rival: %v", err)
+			return
+		}
+		if err := fx.agents.Save(ctx, rival); err != nil {
+			t.Errorf("save rival: %v", err)
+		}
+	}
+
+	_, err := fx.svc.VerifyDNS(ctx, loserID, service.VerifyInput{})
+	mustHostTaken(t, err)
+
+	loser, err := fx.agents.FindByAgentID(ctx, loserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loser.Status != domain.StatusPendingDNS {
+		t.Fatalf("loser must stay PENDING_DNS after aborting, got %q", loser.Status)
+	}
+	rival, err := fx.agents.FindByAgentID(ctx, rivalID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rival.Status != domain.StatusActive {
+		t.Fatalf("rival must remain the sole ACTIVE holder, got %q", rival.Status)
+	}
+
+	// No wedge: the loser's retry gets the same clean 409 (the host is
+	// genuinely held), not a mutual-409 deadlock.
+	_, err = fx.svc.VerifyDNS(ctx, loserID, service.VerifyInput{})
+	mustHostTaken(t, err)
+}
+
+// TestVerifyDNS_ConflictCancelledMidSeal_NotResurrected covers the
+// resurrection hazard: the rival's activation conflict-cancels THIS
+// racer mid-seal (its row flips REVOKED); saving the stale in-memory
+// ACTIVE aggregate would silently resurrect it. commitActivation's
+// own-row guard must abort instead and leave the row REVOKED.
+func TestVerifyDNS_ConflictCancelledMidSeal_NotResurrected(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	loserID := driveToPendingDNS(t, fx)
+	rivalID := registerRival(t, fx, "owner-2", "2.0.0")
+
+	fx.sealer.hook = func() {
+		fx.sealer.hook = nil
+		// The rival's committed transaction: rival ACTIVE, loser
+		// conflict-cancelled.
+		rival, err := fx.agents.FindByAgentID(ctx, rivalID)
+		if err != nil {
+			t.Errorf("load rival: %v", err)
+			return
+		}
+		if err := rival.Activate(time.Now()); err != nil {
+			t.Errorf("activate rival: %v", err)
+			return
+		}
+		if err := fx.agents.Save(ctx, rival); err != nil {
+			t.Errorf("save rival: %v", err)
+			return
+		}
+		loser, err := fx.agents.FindByAgentID(ctx, loserID)
+		if err != nil {
+			t.Errorf("load loser: %v", err)
+			return
+		}
+		if err := loser.CancelForHostConflict(); err != nil {
+			t.Errorf("cancel loser: %v", err)
+			return
+		}
+		if err := fx.agents.Save(ctx, loser); err != nil {
+			t.Errorf("save loser: %v", err)
+		}
+	}
+
+	_, err := fx.svc.VerifyDNS(ctx, loserID, service.VerifyInput{})
+	mustHostTaken(t, err)
+
+	loser, err := fx.agents.FindByAgentID(ctx, loserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loser.Status != domain.StatusRevoked {
+		t.Fatalf("cancelled loser must stay REVOKED (no resurrection), got %q", loser.Status)
+	}
+}
+
+// TestVerifyDNS_ConflictCancelRevokesLoserCerts covers the credential
+// half of conflict-cancellation: a loser at PENDING_DNS already holds a
+// VALID identity certificate (signed at verify-acme), and losing the
+// host must revoke it — CA-side before the winner's transaction, store
+// rows inside it — exactly as the owner-initiated cancelPending path
+// does. Otherwise the loser keeps a live credential asserting an ANS
+// name on a host it lost, for up to its full term, with no API path to
+// fix it (Revoke's already-REVOKED branch returns early).
+func TestVerifyDNS_ConflictCancelRevokesLoserCerts(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	loserID := driveToPendingDNS(t, fx)
+	// Precondition: the loser holds a VALID identity cert.
+	preCerts, err := fx.certs.FindIdentityCertificatesByAgent(ctx, loserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preCerts) == 0 || preCerts[0].Status != domain.CertStatusValid {
+		t.Fatalf("precondition: loser must hold a VALID identity cert, got %+v", preCerts)
+	}
+
+	winnerID := registerRival(t, fx, "owner-2", "2.0.0")
+	if _, err := fx.svc.VerifyDNS(ctx, winnerID, service.VerifyInput{}); err != nil {
+		t.Fatalf("winner verify-dns: %v", err)
+	}
+
+	loser, err := fx.agents.FindByAgentID(ctx, loserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loser.Status != domain.StatusRevoked {
+		t.Fatalf("loser must be conflict-cancelled, got %q", loser.Status)
+	}
+	postCerts, err := fx.certs.FindIdentityCertificatesByAgent(ctx, loserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range postCerts {
+		if c.Status == domain.CertStatusValid {
+			t.Fatalf("loser certificate %s must not stay VALID after conflict-cancellation", c.CertificateRef)
+		}
+	}
+}
+
+// TestRevoke_IdempotentSweepsLingeringCerts covers the self-healing
+// repair: a REVOKED registration that somehow kept a VALID identity
+// cert (the conflict-cancellation window, or rows from before the flip
+// existed) is fixed by the idempotent revoke call rather than being
+// permanently unreachable behind the early return.
+func TestRevoke_IdempotentSweepsLingeringCerts(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	agentID := driveToPendingDNS(t, fx)
+
+	// Manufacture the broken state: registration REVOKED, cert left VALID.
+	reg, err := fx.agents.FindByAgentID(ctx, agentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.CancelForHostConflict(); err != nil {
+		t.Fatal(err)
+	}
+	if err := fx.agents.Save(ctx, reg); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := fx.svc.Revoke(ctx, agentID, service.RevokeInput{Reason: domain.RevocationCessationOfOperation})
+	if err != nil {
+		t.Fatalf("idempotent revoke must succeed and repair, got: %v", err)
+	}
+	if res.Registration.Status != domain.StatusRevoked {
+		t.Fatalf("status = %q, want REVOKED", res.Registration.Status)
+	}
+	certs, err := fx.certs.FindIdentityCertificatesByAgent(ctx, agentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(certs) == 0 {
+		t.Fatal("precondition failure: expected an identity cert to sweep")
+	}
+	for _, c := range certs {
+		if c.Status == domain.CertStatusValid {
+			t.Fatalf("idempotent revoke must sweep VALID certs; %s still VALID", c.CertificateRef)
+		}
+	}
+}

--- a/internal/ra/service/hostcatalog_test.go
+++ b/internal/ra/service/hostcatalog_test.go
@@ -1,0 +1,157 @@
+package service
+
+// White-box tests for HostRegistrations' owner scoping — the
+// defense-in-depth that backs the FQDN-exclusivity registration invariant.
+// The invariant (RegisterAgent + VerifyDNS) prevents two owners from ever
+// holding a live registration on one host via the API, but the catalog
+// read must not depend on that being enforced elsewhere: even if a
+// multi-owner host somehow existed (legacy data, a future invariant gap),
+// one owner's per-host document must never include another owner's agent.
+// Fakes let us construct exactly that otherwise-unreachable state.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/godaddy/ans/internal/domain"
+	"github.com/godaddy/ans/internal/port"
+)
+
+// fakeHostAgentStore implements port.AgentStore but only FindAllByAgentHost;
+// the embedded nil interface makes any other call panic (none are reached).
+type fakeHostAgentStore struct {
+	port.AgentStore
+	byHost map[string][]*domain.AgentRegistration
+}
+
+func (f *fakeHostAgentStore) FindAllByAgentHost(_ context.Context, host string) ([]*domain.AgentRegistration, error) {
+	return f.byHost[host], nil
+}
+
+// fakeEndpointStore implements port.EndpointStore but only FindByAgentIDs.
+type fakeEndpointStore struct {
+	port.EndpointStore
+	byID map[string]*domain.AgentEndpoints
+}
+
+func (f *fakeEndpointStore) FindByAgentIDs(_ context.Context, ids []string) (map[string]*domain.AgentEndpoints, error) {
+	out := make(map[string]*domain.AgentEndpoints, len(ids))
+	for _, id := range ids {
+		if e, ok := f.byID[id]; ok {
+			out[id] = e
+		}
+	}
+	return out, nil
+}
+
+func reg(agentID, ownerID, host string, status domain.RegistrationStatus) *domain.AgentRegistration {
+	sv, _ := domain.ParseSemVer("1.0.0")
+	ans, _ := domain.NewAnsName(sv, host)
+	return &domain.AgentRegistration{AgentID: agentID, OwnerID: ownerID, AnsName: ans, Status: status}
+}
+
+func TestHostRegistrations_ScopesToRequestingOwner(t *testing.T) {
+	const host = "shared.example.com"
+	aliceA := reg("a-1", "alice", host, domain.StatusActive)
+	bobA := reg("b-1", "bob", host, domain.StatusActive)
+
+	svc := &RegistrationService{
+		agents: &fakeHostAgentStore{byHost: map[string][]*domain.AgentRegistration{
+			host: {aliceA, bobA},
+		}},
+		endpoints: &fakeEndpointStore{byID: map[string]*domain.AgentEndpoints{
+			"a-1": {AgentID: "a-1", Endpoints: []domain.AgentEndpoint{{Protocol: domain.ProtocolMCP, AgentURL: "https://" + host + "/mcp"}}},
+			"b-1": {AgentID: "b-1", Endpoints: []domain.AgentEndpoint{{Protocol: domain.ProtocolA2A, AgentURL: "https://" + host + "/a2a"}}},
+		}},
+	}
+
+	got, err := svc.HostRegistrations(context.Background(), "alice", host)
+	if err != nil {
+		t.Fatalf("HostRegistrations: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("returned %d registrations, want 1 (alice's only — bob's must not surface)", len(got))
+	}
+	if got[0].AgentID != "a-1" || got[0].OwnerID != "alice" {
+		t.Errorf("returned %+v, want alice's a-1", got[0])
+	}
+	// Endpoints stamped onto the owner's registration.
+	if len(got[0].Endpoints) != 1 || got[0].Endpoints[0].Protocol != domain.ProtocolMCP {
+		t.Errorf("endpoints not stamped correctly: %+v", got[0].Endpoints)
+	}
+}
+
+func TestHostRegistrations_EmptyWhenOwnerHasNoneOnHost(t *testing.T) {
+	const host = "shared.example.com"
+	svc := &RegistrationService{
+		agents: &fakeHostAgentStore{byHost: map[string][]*domain.AgentRegistration{
+			host: {reg("b-1", "bob", host, domain.StatusActive)},
+		}},
+		endpoints: &fakeEndpointStore{},
+	}
+	got, err := svc.HostRegistrations(context.Background(), "alice", host)
+	if err != nil {
+		t.Fatalf("HostRegistrations: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("alice owns nothing on the host; want 0 registrations, got %d", len(got))
+	}
+}
+
+func TestHoldsHostExclusivity(t *testing.T) {
+	cases := map[domain.RegistrationStatus]bool{
+		domain.StatusActive:            true,
+		domain.StatusDeprecated:        true,
+		domain.StatusPendingValidation: false,
+		domain.StatusPendingDNS:        false,
+		domain.StatusRevoked:           false,
+		domain.StatusExpired:           false,
+		domain.StatusFailed:            false,
+	}
+	for st, want := range cases {
+		if got := holdsHostExclusivity(st); got != want {
+			t.Errorf("holdsHostExclusivity(%s) = %v, want %v", st, got, want)
+		}
+	}
+}
+
+func TestHostHeldByAnotherOwner(t *testing.T) {
+	const host = "h.example.com"
+	ctx := context.Background()
+	withRegs := func(regs ...*domain.AgentRegistration) *RegistrationService {
+		return &RegistrationService{agents: &fakeHostAgentStore{
+			byHost: map[string][]*domain.AgentRegistration{host: regs},
+		}}
+	}
+
+	tests := []struct {
+		name          string
+		regs          []*domain.AgentRegistration
+		ownerID       string
+		exceptAgentID string
+		want          bool
+	}{
+		{"different owner ACTIVE holds", []*domain.AgentRegistration{reg("b-1", "bob", host, domain.StatusActive)}, "alice", "", true},
+		{"different owner DEPRECATED holds", []*domain.AgentRegistration{reg("b-1", "bob", host, domain.StatusDeprecated)}, "alice", "", true},
+		{"different owner only pending/terminal does not hold", []*domain.AgentRegistration{
+			reg("b-1", "bob", host, domain.StatusPendingDNS),
+			reg("b-2", "bob", host, domain.StatusRevoked),
+		}, "alice", "", false},
+		{"same owner does not block self", []*domain.AgentRegistration{reg("a-1", "alice", host, domain.StatusActive)}, "alice", "", false},
+		// Load-bearing except case: a DIFFERENT owner's holding reg that
+		// would otherwise return true is skipped because it is the excepted
+		// agent — exercising the exceptAgentID branch, not the owner match.
+		{"exceptAgentID skips an otherwise-holding different-owner reg", []*domain.AgentRegistration{reg("b-1", "bob", host, domain.StatusActive)}, "alice", "b-1", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			held, err := withRegs(tc.regs...).hostHeldByAnotherOwner(ctx, host, tc.ownerID, tc.exceptAgentID)
+			if err != nil {
+				t.Fatalf("hostHeldByAnotherOwner: %v", err)
+			}
+			if held != tc.want {
+				t.Errorf("held = %v, want %v", held, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ra/service/lifecycle.go
+++ b/internal/ra/service/lifecycle.go
@@ -115,6 +115,51 @@ func (s *RegistrationService) GetByAgentID(ctx context.Context, agentID string) 
 	}, nil
 }
 
+// HostRegistrations returns the registrations on agentHost owned by
+// ownerID (any version, any status), each with its Endpoints populated,
+// for AI Catalog per-host document composition. Endpoints are bulk-loaded
+// in one roundtrip to avoid N+1.
+//
+// Scoping to ownerID is a security boundary, not a convenience. The
+// per-host document is meant to be host-complete (catalog §4) under the
+// ANS-1 §12.1 one-host-one-owner invariant — but this RA does not enforce
+// that invariant (registration uniqueness is keyed on the full versioned
+// ANS name, not the host), so two owners can hold different versions on
+// the same host. An owner-unscoped read would then disclose one owner's
+// registration metadata to another via this route. Filtering by owner
+// keeps the document host-complete for the requester (identical output in
+// the intended single-owner model) while never leaking a sibling owner's
+// agents.
+func (s *RegistrationService) HostRegistrations(ctx context.Context, ownerID, agentHost string) ([]*domain.AgentRegistration, error) {
+	all, err := s.agents.FindAllByAgentHost(ctx, agentHost)
+	if err != nil {
+		return nil, err
+	}
+	regs := make([]*domain.AgentRegistration, 0, len(all))
+	for _, r := range all {
+		if r.OwnerID == ownerID {
+			regs = append(regs, r)
+		}
+	}
+	if len(regs) == 0 {
+		return regs, nil
+	}
+	ids := make([]string, len(regs))
+	for i, r := range regs {
+		ids[i] = r.AgentID
+	}
+	eps, err := s.endpoints.FindByAgentIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range regs {
+		if e, ok := eps[r.AgentID]; ok && e != nil {
+			r.Endpoints = e.Endpoints
+		}
+	}
+	return regs, nil
+}
+
 // IdentityCertificates returns every identity certificate the RA has
 // issued for this agent — typically just the one from registration,
 // but rotations (Stage 5) can add more. Newest-first.
@@ -334,6 +379,15 @@ func (s *RegistrationService) VerifyACME(ctx context.Context, agentID string, in
 	now := s.clock()
 	reg, err := s.agents.FindByAgentID(ctx, agentID)
 	if err != nil {
+		return nil, err
+	}
+
+	// FQDN exclusivity, before the idempotency check: a registration that
+	// lost the host to another owner (and was cancelled at that owner's
+	// activation) must be rejected here rather than silently treated as
+	// "already validated". This is the at-every-level gate before
+	// verify-dns.
+	if err := s.ensureHostNotTakenByOther(ctx, reg); err != nil {
 		return nil, err
 	}
 
@@ -805,6 +859,13 @@ func (s *RegistrationService) VerifyDNS(ctx context.Context, agentID string, in 
 		return nil, err
 	}
 
+	// FQDN exclusivity gate: if a different owner already holds this host
+	// live, this registration lost the race and cannot activate — reject
+	// before the idempotency/precondition checks below.
+	if err := s.ensureHostNotTakenByOther(ctx, reg); err != nil {
+		return nil, err
+	}
+
 	// Precondition: PENDING_DNS is the only state verify-dns accepts.
 	// ACTIVE is idempotent (already done). Anything else is an error.
 	if reg.Status == domain.StatusActive {
@@ -886,45 +947,53 @@ func (s *RegistrationService) VerifyDNS(ctx context.Context, agentID string, in 
 		return &VerifyDNSResult{Registration: reg, Now: now, DNSMismatches: mismatches}, nil
 	}
 
-	// Transition to ACTIVE in-memory before entering the tx — Activate
-	// is a domain-aggregate state machine that can fail (preconditions
-	// on current status), and a precondition failure here shouldn't
-	// open and then immediately roll back a transaction.
+	// Transition to ACTIVE in-memory before any TL or DB work — Activate
+	// is a domain-aggregate state machine that can fail (preconditions on
+	// current status), and a precondition failure here shouldn't trigger a
+	// TL seal or open a transaction.
 	if err := reg.Activate(now); err != nil {
 		return nil, err
 	}
 
-	// AGENT_REGISTERED: the single terminal transition that marks
-	// the agent live in the log. Both V1 and V2 lanes emit this
-	// SAME `eventType` token (the V1 enum is authoritative), but in
-	// version-specific envelope shapes — V1 uses singleton +
-	// rotation-array + map-typed attestations, V2 uses unified
-	// `identityCerts[]` / `serverCerts[]` + typed
-	// `dnsRecordsProvisioned[]` per the documented deviation.
+	// Seal-before-success (ANS-1 §12.3: "the RA MUST NOT activate without a
+	// sealed event (step (d) is the point of no return)"). AGENT_REGISTERED
+	// is the single terminal transition that marks the agent live in the
+	// log; we submit it to the TL INLINE and report the agent ACTIVE only
+	// after the TL acknowledges the seal — mirroring the identity lane. A
+	// failed seal IS a failed activation: nothing is committed, the agent
+	// stays PENDING_DNS, and the operator retries verify-dns once the TL is
+	// reachable. This is what makes a downstream catalog entry's
+	// SCITT-receipt/badge links point at TL records that actually exist.
+	// (Both lanes emit the same eventType token in version-specific
+	// envelope shapes; the seal runs outside the tx so the network round
+	// trip never holds the SQLite write lock.)
+	if err := s.sealActivationEvent(ctx, reg, expected, perRecord, in.SchemaVersion, now); err != nil {
+		return nil, err
+	}
+
+	// Sealed: commit the ACTIVE transition and cancel any losing pending
+	// registrations on this host atomically. The AGENT_REGISTERED event is
+	// already durable in the TL, so — unlike the outbox path used by
+	// revocation — there is nothing to enqueue here.
 	//
-	// Build + sign the event before opening the tx so the producer
-	// signature (a KMS round-trip) doesn't hold the SQLite write
-	// lock open. Persistence of the agent's new status and the
-	// outbox row commit atomically inside uow.Run — without the tx,
-	// agent.Save committing without the outbox enqueue would mean
-	// an ACTIVE agent whose AGENT_REGISTERED event never makes it
-	// to the TL.
+	// The seal round trip above is a window a commit failure (SQLITE_BUSY,
+	// crash) can land in: the agent then stays PENDING_DNS and the operator
+	// retries verify-dns. The retry recomputes `now`, so its
+	// AGENT_REGISTERED leaf carries fresh timestamps and a fresh content
+	// hash — TL dedup will not match, appending a second AGENT_REGISTERED
+	// leaf. That is the intended benign residue, accepted exactly as on the
+	// identity lane: agent status keys on the ACTIVE row by agentId and
+	// read-side status derives from any terminal leaf, so the duplicate is
+	// invisible to verifiers and badges. It is not a dedup regression.
 	if err := s.uow.Run(ctx, func(txCtx context.Context) error {
 		if err := s.agents.Save(txCtx, reg); err != nil {
 			return err
 		}
-		if isV1Lane(in.SchemaVersion) {
-			v1Inner, err := s.buildAgentRegisteredV1Event(txCtx, reg, expected, now)
-			if err != nil {
-				return err
-			}
-			return s.enqueueTLEventV1(txCtx, string(eventv1.TypeAgentRegistered), reg, v1Inner, now)
-		}
-		inner, err := s.buildAgentRegisteredEvent(txCtx, reg, expected, perRecord, now)
-		if err != nil {
-			return err
-		}
-		return s.enqueueTLEvent(txCtx, string(event.TypeAgentRegistered), reg, inner, now)
+		// The winner now holds the FQDN exclusively: cancel any other
+		// owner's still-pending registrations on this host, atomically with
+		// this activation (the loser is cancelled the moment the winner
+		// goes live — not left to fail later at its own verify-dns).
+		return s.cancelConflictingPendings(txCtx, reg.FQDN(), reg.OwnerID)
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/ra/service/lifecycle.go
+++ b/internal/ra/service/lifecycle.go
@@ -972,41 +972,39 @@ func (s *RegistrationService) VerifyDNS(ctx context.Context, agentID string, in 
 		return nil, err
 	}
 
-	// Sealed: commit the ACTIVE transition, record the sealed event as a
-	// pre-delivered outbox row, and cancel any losing pending
-	// registrations on this host — atomically. The AGENT_REGISTERED event
-	// is already durable in the TL, so the worker never touches the row
-	// (Claim skips sent rows); it exists because the agent-events feed —
-	// the ARD Finder's ingest source — is a read model over DELIVERED
-	// outbox rows, and an inline-sealed event would otherwise never
-	// surface there. Committing it in the activation tx means "agent is
-	// ACTIVE" and "activation is feed-visible" are the same fact.
+	// Sealed: CA-side revocation for the losers this activation is about
+	// to conflict-cancel runs FIRST and outside the transaction (an
+	// external, idempotent side effect that cannot roll back — the same
+	// ordering cancelPending uses). The store flips happen in-tx below.
+	if err := s.revokeConflictLoserCertsAtCA(ctx, reg.FQDN(), reg.OwnerID); err != nil {
+		return nil, err
+	}
+
+	// Commit phase (commitActivation): under the store's single writer
+	// this is the authoritative exclusivity decision — it re-reads this
+	// row and the host's rows in-tx, aborts with AGENT_HOST_TAKEN if a
+	// rival activated (or conflict-cancelled us) during the seal round
+	// trip, conflict-cancels losing pendings (flipping their VALID
+	// identity certs), and commits ACTIVE together with the sealed
+	// event's pre-delivered outbox row. That row is what surfaces the
+	// activation on the agent-events feed — the ARD Finder's ingest
+	// source, a read model over DELIVERED outbox rows — so "agent is
+	// ACTIVE" and "activation is feed-visible" are the same fact; the
+	// worker never touches it (Claim skips sent rows).
 	//
-	// The seal round trip above is a window a commit failure (SQLITE_BUSY,
-	// crash) can land in: the agent then stays PENDING_DNS and the operator
-	// retries verify-dns. The retry recomputes `now`, so its
-	// AGENT_REGISTERED leaf carries fresh timestamps and a fresh content
-	// hash — TL dedup will not match, appending a second AGENT_REGISTERED
-	// leaf (and, on commit, a second feed row). That is the intended benign
-	// residue, accepted exactly as on the identity lane: agent status keys
-	// on the ACTIVE row by agentId, read-side status derives from any
-	// terminal leaf, and feed consumers apply events idempotently by
-	// agentId, so the duplicate is invisible to verifiers, badges, and
-	// discovery. It is not a dedup regression.
+	// The seal round trip above is a window a commit failure or a lost
+	// race can land in: the agent then stays PENDING_DNS (or REVOKED, if
+	// a rival cancelled it) and its already-sealed AGENT_REGISTERED leaf
+	// is orphaned. A retry recomputes `now`, so its leaf carries fresh
+	// timestamps and a fresh content hash — TL dedup will not match,
+	// appending a second leaf (and, on commit, a second feed row). That
+	// is the intended benign residue, accepted exactly as on the
+	// identity lane: agent status keys on the store row by agentId,
+	// read-side status derives from any terminal leaf, and feed
+	// consumers apply events idempotently by agentId, so the residue is
+	// invisible to verifiers, badges, and discovery.
 	if err := s.uow.Run(ctx, func(txCtx context.Context) error {
-		if err := s.agents.Save(txCtx, reg); err != nil {
-			return err
-		}
-		if _, err := s.outbox.RecordSealed(txCtx,
-			string(event.TypeAgentRegistered), reg.AgentID,
-			sealed.SchemaVersion, sealed.Payload, sealed.LogID); err != nil {
-			return err
-		}
-		// The winner now holds the FQDN exclusively: cancel any other
-		// owner's still-pending registrations on this host, atomically with
-		// this activation (the loser is cancelled the moment the winner
-		// goes live — not left to fail later at its own verify-dns).
-		return s.cancelConflictingPendings(txCtx, reg.FQDN(), reg.OwnerID)
+		return s.commitActivation(txCtx, reg, sealed)
 	}); err != nil {
 		return nil, err
 	}
@@ -1323,6 +1321,19 @@ func (s *RegistrationService) Revoke(ctx context.Context, agentID string, in Rev
 	// canonical `eventTime` is replayed byte-for-byte from the
 	// outbox per the project's outbox-replay invariant.
 	if reg.Status == domain.StatusRevoked {
+		// Self-healing sweep: a REVOKED registration must hold no VALID
+		// identity certificate. Conflict-cancellation flips certs in the
+		// same transaction, but a loser that slipped into the window
+		// between the winner's pre-tx CA revocation and its commit — or
+		// any row from before that flip existed — would otherwise keep a
+		// live credential forever, with this early return blocking every
+		// API path to fix it. Sweeping here makes the idempotent call
+		// the repair path. CESSATION_OF_OPERATION is the canonical
+		// reason for a registration that ceased pre-activation; the
+		// caller's reason is not used, so the sweep stays deterministic.
+		if err := s.sweepRevokedAgentCerts(ctx, reg.AgentID); err != nil {
+			return nil, err
+		}
 		return &RevokeResult{
 			Registration:       reg,
 			RevokedAt:          now,
@@ -1533,6 +1544,49 @@ func (s *RegistrationService) hydrateServerCert(ctx context.Context, reg *domain
 	if all, err := s.byoc.FindByAgentID(ctx, reg.AgentID); err == nil && len(all) > 0 {
 		reg.ServerCert = all[0]
 	}
+}
+
+// sweepRevokedAgentCerts flips any still-VALID identity certificate of
+// an already-REVOKED registration to REVOKED — CA first (idempotent,
+// outside the tx), then the store rows in one transaction. No-op when
+// every cert is already terminal, which is the common case; a hit means
+// a conflict-cancellation window or a pre-flip row left a live
+// credential behind, and the idempotent revoke call is the repair path.
+func (s *RegistrationService) sweepRevokedAgentCerts(ctx context.Context, agentID string) error {
+	certs, err := s.certs.FindIdentityCertificatesByAgent(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	hasValid := false
+	for _, c := range certs {
+		if c.Status == domain.CertStatusValid {
+			hasValid = true
+			break
+		}
+	}
+	if !hasValid {
+		return nil
+	}
+	if err := s.revokeIdentityCertsAtCA(ctx, certs, domain.RevocationCessationOfOperation); err != nil {
+		return err
+	}
+	if err := s.uow.Run(ctx, func(txCtx context.Context) error {
+		for _, c := range certs {
+			if c.Status == domain.CertStatusValid {
+				revoked := c.Revoke()
+				if err := s.certs.UpdateCertificateStatus(txCtx, &revoked); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	s.logger.Info().
+		Str("agentId", agentID).
+		Msg("swept lingering VALID identity certificates on a revoked registration")
+	return nil
 }
 
 // revokeIdentityCertsAtCA revokes every still-valid identity

--- a/internal/ra/service/lifecycle.go
+++ b/internal/ra/service/lifecycle.go
@@ -967,26 +967,39 @@ func (s *RegistrationService) VerifyDNS(ctx context.Context, agentID string, in 
 	// (Both lanes emit the same eventType token in version-specific
 	// envelope shapes; the seal runs outside the tx so the network round
 	// trip never holds the SQLite write lock.)
-	if err := s.sealActivationEvent(ctx, reg, expected, perRecord, in.SchemaVersion, now); err != nil {
+	sealed, err := s.sealActivationEvent(ctx, reg, expected, perRecord, in.SchemaVersion, now)
+	if err != nil {
 		return nil, err
 	}
 
-	// Sealed: commit the ACTIVE transition and cancel any losing pending
-	// registrations on this host atomically. The AGENT_REGISTERED event is
-	// already durable in the TL, so — unlike the outbox path used by
-	// revocation — there is nothing to enqueue here.
+	// Sealed: commit the ACTIVE transition, record the sealed event as a
+	// pre-delivered outbox row, and cancel any losing pending
+	// registrations on this host — atomically. The AGENT_REGISTERED event
+	// is already durable in the TL, so the worker never touches the row
+	// (Claim skips sent rows); it exists because the agent-events feed —
+	// the ARD Finder's ingest source — is a read model over DELIVERED
+	// outbox rows, and an inline-sealed event would otherwise never
+	// surface there. Committing it in the activation tx means "agent is
+	// ACTIVE" and "activation is feed-visible" are the same fact.
 	//
 	// The seal round trip above is a window a commit failure (SQLITE_BUSY,
 	// crash) can land in: the agent then stays PENDING_DNS and the operator
 	// retries verify-dns. The retry recomputes `now`, so its
 	// AGENT_REGISTERED leaf carries fresh timestamps and a fresh content
 	// hash — TL dedup will not match, appending a second AGENT_REGISTERED
-	// leaf. That is the intended benign residue, accepted exactly as on the
-	// identity lane: agent status keys on the ACTIVE row by agentId and
-	// read-side status derives from any terminal leaf, so the duplicate is
-	// invisible to verifiers and badges. It is not a dedup regression.
+	// leaf (and, on commit, a second feed row). That is the intended benign
+	// residue, accepted exactly as on the identity lane: agent status keys
+	// on the ACTIVE row by agentId, read-side status derives from any
+	// terminal leaf, and feed consumers apply events idempotently by
+	// agentId, so the duplicate is invisible to verifiers, badges, and
+	// discovery. It is not a dedup regression.
 	if err := s.uow.Run(ctx, func(txCtx context.Context) error {
 		if err := s.agents.Save(txCtx, reg); err != nil {
+			return err
+		}
+		if _, err := s.outbox.RecordSealed(txCtx,
+			string(event.TypeAgentRegistered), reg.AgentID,
+			sealed.SchemaVersion, sealed.Payload, sealed.LogID); err != nil {
 			return err
 		}
 		// The winner now holds the FQDN exclusively: cancel any other

--- a/internal/ra/service/lifecycle_test.go
+++ b/internal/ra/service/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/godaddy/ans/internal/adapter/dns"
 	"github.com/godaddy/ans/internal/domain"
 	"github.com/godaddy/ans/internal/ra/service"
 	event "github.com/godaddy/ans/internal/tl/event"
@@ -73,20 +74,15 @@ func TestVerifyDNS_NoIdentityCSR_V2EventEmptyIdentityCerts(t *testing.T) {
 		t.Fatalf("verify-dns: %v", err)
 	}
 
-	rows, err := fx.outboxStore.Claim(context.Background(), 10)
-	if err != nil {
-		t.Fatalf("Claim: %v", err)
+	// AGENT_REGISTERED is sealed inline at activation (seal-before-success),
+	// not enqueued to the outbox, so inspect what was sealed.
+	sealed := fx.sealer.sealed()
+	if len(sealed) == 0 {
+		t.Fatal("expected at least one sealed V2 event")
 	}
-	if len(rows) == 0 {
-		t.Fatal("expected at least one emitted V2 event")
-	}
-	for _, row := range rows {
-		var p service.OutboxPayload
-		if err := json.Unmarshal(row.PayloadJSON, &p); err != nil {
-			t.Fatalf("unmarshal OutboxPayload: %v", err)
-		}
+	for _, s := range sealed {
 		var ev event.Event
-		if err := json.Unmarshal(p.InnerEventCanonical, &ev); err != nil {
+		if err := json.Unmarshal(s.InnerCanonical, &ev); err != nil {
 			t.Fatalf("unmarshal inner V2 event: %v", err)
 		}
 		if ev.Attestations != nil && len(ev.Attestations.IdentityCerts) != 0 {
@@ -128,22 +124,15 @@ func TestVerifyDNS_NoIdentityCSR_V1EventEmptyIdentityCert(t *testing.T) {
 		t.Fatalf("V1 agent registered without an identity CSR must reach ACTIVE; got %q", got.Status)
 	}
 
-	rows, err := fx.outboxStore.Claim(context.Background(), 10)
-	if err != nil {
-		t.Fatalf("Claim: %v", err)
-	}
+	// AGENT_REGISTERED is sealed inline at activation, not enqueued.
 	sawV1 := false
-	for _, row := range rows {
-		if row.SchemaVersion != eventv1.SchemaVersion {
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion != eventv1.SchemaVersion {
 			continue
 		}
 		sawV1 = true
-		var p service.OutboxPayload
-		if err := json.Unmarshal(row.PayloadJSON, &p); err != nil {
-			t.Fatalf("unmarshal OutboxPayload: %v", err)
-		}
 		var ev eventv1.Event
-		if err := json.Unmarshal(p.InnerEventCanonical, &ev); err != nil {
+		if err := json.Unmarshal(s.InnerCanonical, &ev); err != nil {
 			t.Fatalf("unmarshal inner V1 event: %v", err)
 		}
 		if ev.Attestations != nil {
@@ -156,7 +145,7 @@ func TestVerifyDNS_NoIdentityCSR_V1EventEmptyIdentityCert(t *testing.T) {
 		}
 	}
 	if !sawV1 {
-		t.Fatal("expected a V1 AGENT_REGISTERED event in the outbox")
+		t.Fatal("expected a V1 AGENT_REGISTERED event to be sealed")
 	}
 }
 
@@ -196,5 +185,124 @@ func TestSubmitIdentityCSR_NoIdentityCSR_Rejected(t *testing.T) {
 	}
 	if de.Code != "IDENTITY_CSR_NOT_PERMITTED" {
 		t.Fatalf("expected code IDENTITY_CSR_NOT_PERMITTED; got %q", de.Code)
+	}
+}
+
+// TestVerifyDNS_SealFailure_FailsClosed pins the seal-before-success
+// contract for agent activation (ANS-1 §12.3: "the RA MUST NOT activate
+// without a sealed event (step (d) is the point of no return)"). When
+// the inline TL seal fails, verify-dns must NOT report ACTIVE: it
+// surfaces the seal error and leaves the agent PENDING_DNS so the
+// operator can retry once the TL is reachable. This is what guarantees a
+// downstream catalog entry's SCITT-receipt and badge links can only ever
+// point at a TL record that was actually written.
+func TestVerifyDNS_SealFailure_FailsClosed(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	resp, err := fx.svc.RegisterAgent(ctx, fx.req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	agentID := resp.Registration.AgentID
+	if _, err := fx.svc.VerifyACME(ctx, agentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("verify-acme: %v", err)
+	}
+
+	// Arm the sealer to fail as the tlclient would when the TL is
+	// unreachable (transient → TL_UNAVAILABLE).
+	fx.sealer.failErr = domain.NewUnavailableError("TL_UNAVAILABLE", "tl down")
+
+	var de *domain.Error
+	if _, err := fx.svc.VerifyDNS(ctx, agentID, service.VerifyInput{}); err == nil {
+		t.Fatal("verify-dns must fail when the activation seal fails; got nil error")
+	} else if !errors.As(err, &de) || de.Code != "TL_UNAVAILABLE" {
+		t.Fatalf("expected TL_UNAVAILABLE domain error; got %T: %v", err, err)
+	}
+
+	// Fail-closed: the persisted agent must still be PENDING_DNS. ACTIVE
+	// is the point of no return and must not be reached without a seal.
+	got, err := fx.agents.FindByAgentID(ctx, agentID)
+	if err != nil {
+		t.Fatalf("FindByAgentID: %v", err)
+	}
+	if got.Status != domain.StatusPendingDNS {
+		t.Fatalf("agent must stay PENDING_DNS after a failed seal; got %q", got.Status)
+	}
+
+	// Nothing was recorded as durably sealed, and activation must never
+	// fall back to the outbox.
+	if n := len(fx.sealer.sealed()); n != 0 {
+		t.Errorf("no event should be recorded as sealed on failure; got %d", n)
+	}
+	if rows, _ := fx.outboxStore.Claim(ctx, 100); len(rows) != 0 {
+		t.Errorf("activation must not enqueue to the outbox; got %d rows", len(rows))
+	}
+
+	// Retry succeeds once the TL recovers — proving the failure left the
+	// aggregate in a retryable PENDING_DNS state, not a wedged one.
+	fx.sealer.failErr = nil
+	if _, err := fx.svc.VerifyDNS(ctx, agentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("verify-dns retry after TL recovers: %v", err)
+	}
+	got, err = fx.agents.FindByAgentID(ctx, agentID)
+	if err != nil {
+		t.Fatalf("FindByAgentID after retry: %v", err)
+	}
+	if got.Status != domain.StatusActive {
+		t.Fatalf("agent must reach ACTIVE on retry; got %q", got.Status)
+	}
+	if n := len(fx.sealer.sealed()); n != 1 {
+		t.Errorf("retry must seal exactly one AGENT_REGISTERED; got %d sealed", n)
+	}
+}
+
+// TestVerifyDNS_NilSealer_FailsClosed covers the no-sealer-configured
+// branch of activation — the live fail-closed path when the RA runs with
+// the TL client disabled (cmd/ans-ra/main.go leaves the sealer nil and
+// only wires it when non-nil). With no sealer there is no "seal later"
+// mode: activation must report TL_UNAVAILABLE and leave the agent
+// PENDING_DNS rather than going ACTIVE without a sealed event. No signer
+// is wired here either — the nil-sealer guard short-circuits before any
+// event is built or signed.
+func TestVerifyDNS_NilSealer_FailsClosed(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	// Reuse the fixture's stores/CAs but build a service with NO agent
+	// sealer (and no signer) — mirroring a TL-disabled deployment. A DNS
+	// verifier is still wired so verify-acme's challenge gate passes and
+	// the flow reaches verify-dns, where the nil-sealer guard fires.
+	svc := service.NewRegistrationService(
+		fx.agents, fx.endpoints, fx.certs, fx.byoc, fx.renewals,
+		fx.validator, fx.identityCA, fx.bus, fx.outboxStore, fx.uow,
+		fx.discoveryReg,
+	).WithServerCertificateIssuer(fx.serverCA).
+		WithDNSVerifier(dns.NewNoopVerifier())
+
+	resp, err := svc.RegisterAgent(ctx, fx.req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	agentID := resp.Registration.AgentID
+	if _, err := svc.VerifyACME(ctx, agentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("verify-acme: %v", err)
+	}
+
+	var de *domain.Error
+	if _, err := svc.VerifyDNS(ctx, agentID, service.VerifyInput{}); err == nil {
+		t.Fatal("verify-dns must fail closed when no sealer is configured; got nil error")
+	} else if !errors.As(err, &de) || de.Code != "TL_UNAVAILABLE" {
+		t.Fatalf("expected TL_UNAVAILABLE domain error; got %T: %v", err, err)
+	}
+
+	got, err := fx.agents.FindByAgentID(ctx, agentID)
+	if err != nil {
+		t.Fatalf("FindByAgentID: %v", err)
+	}
+	if got.Status != domain.StatusPendingDNS {
+		t.Fatalf("agent must stay PENDING_DNS with no sealer configured; got %q", got.Status)
 	}
 }

--- a/internal/ra/service/lifecycle_test.go
+++ b/internal/ra/service/lifecycle_test.go
@@ -1,13 +1,16 @@
 package service_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/godaddy/ans/internal/adapter/dns"
+	"github.com/godaddy/ans/internal/adapter/store/sqlite"
 	"github.com/godaddy/ans/internal/domain"
+	"github.com/godaddy/ans/internal/port"
 	"github.com/godaddy/ans/internal/ra/service"
 	event "github.com/godaddy/ans/internal/tl/event"
 	eventv1 "github.com/godaddy/ans/internal/tl/event/v1"
@@ -304,5 +307,72 @@ func TestVerifyDNS_NilSealer_FailsClosed(t *testing.T) {
 	}
 	if got.Status != domain.StatusPendingDNS {
 		t.Fatalf("agent must stay PENDING_DNS with no sealer configured; got %q", got.Status)
+	}
+}
+
+// TestVerifyDNS_SealedActivationIsFeedVisible pins the contract between
+// seal-before-success and the ARD agent-events feed (GET
+// /v1/agents/events — the Finder's ingest source). The feed is a read
+// model over DELIVERED outbox rows (sent_at_ms + log_id set), and the
+// inline seal bypasses the outbox worker entirely, so activation must
+// record a PRE-DELIVERED row in the activation transaction: same
+// {innerEventCanonical, producerSignature} payload the TL verified,
+// stamped with the ack's logId. Without that row, an inline-sealed agent
+// would never appear on the feed and the Finder would never discover it.
+// The row must also be invisible to the worker (never claimable) — it
+// was already delivered by construction.
+func TestVerifyDNS_SealedActivationIsFeedVisible(t *testing.T) {
+	t.Parallel()
+	fx := newRegFixture(t)
+	ctx := context.Background()
+
+	resp, err := fx.svc.RegisterAgent(ctx, fx.req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	agentID := resp.Registration.AgentID
+	if _, err := fx.svc.VerifyACME(ctx, agentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("verify-acme: %v", err)
+	}
+	if _, err := fx.svc.VerifyDNS(ctx, agentID, service.VerifyInput{}); err != nil {
+		t.Fatalf("verify-dns: %v", err)
+	}
+
+	sealedEvents := fx.sealer.sealed()
+	if len(sealedEvents) != 1 {
+		t.Fatalf("expected exactly one sealed event; got %d", len(sealedEvents))
+	}
+
+	// The worker must never see the row: it is delivered at insert.
+	if rows, _ := fx.outboxStore.Claim(ctx, 100); len(rows) != 0 {
+		t.Fatalf("sealed activation must not be claimable by the outbox worker; got %d rows", len(rows))
+	}
+
+	// The feed must see exactly this activation, carrying the TL ack's
+	// logId and the exact payload bytes the TL verified.
+	feed := sqlite.NewFeedStore(fx.db, 0)
+	items, err := feed.ReadFeed(ctx, port.FeedQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("ReadFeed: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("feed rows: got %d, want 1 (the sealed AGENT_REGISTERED)", len(items))
+	}
+	row := items[0]
+	if row.EventType != "AGENT_REGISTERED" {
+		t.Errorf("feed eventType: got %q, want AGENT_REGISTERED", row.EventType)
+	}
+	if row.AgentID != agentID {
+		t.Errorf("feed agentId: got %q, want %q", row.AgentID, agentID)
+	}
+	if row.LogID != sealedEvents[0].LogID {
+		t.Errorf("feed logId: got %q, want the seal ack's %q", row.LogID, sealedEvents[0].LogID)
+	}
+	var payload service.OutboxPayload
+	if err := json.Unmarshal(row.PayloadJSON, &payload); err != nil {
+		t.Fatalf("unmarshal feed payload: %v", err)
+	}
+	if !bytes.Equal(payload.InnerEventCanonical, sealedEvents[0].InnerCanonical) {
+		t.Error("feed payload's innerEventCanonical must be byte-identical to the sealed event")
 	}
 }

--- a/internal/ra/service/order_flow_test.go
+++ b/internal/ra/service/order_flow_test.go
@@ -59,7 +59,8 @@ func TestVerifyDNS_TransientServerCertError_Aborts(t *testing.T) {
 		fx.agents, fx.endpoints, fx.certs, byoc, fx.renewals,
 		fx.validator, fx.identityCA, fx.bus, fx.outboxStore, fx.uow,
 		fx.discoveryReg,
-	).WithServerCertificateIssuer(fx.serverCA).WithDNSVerifier(dns.NewNoopVerifier())
+	).WithServerCertificateIssuer(fx.serverCA).WithDNSVerifier(dns.NewNoopVerifier()).
+		WithAgentSealer(fx.sealer)
 
 	// Register + verify-acme with the store healthy so the CSR-issued
 	// server cert is persisted and the agent reaches the pre-DNS state.
@@ -166,7 +167,7 @@ func rebuildWithIssuer(fx *regFixture, issuer port.ServerCertificateIssuer, dnsV
 		fx.agents, fx.endpoints, fx.certs, fx.byoc, fx.renewals,
 		fx.validator, fx.identityCA, fx.bus, fx.outboxStore, fx.uow,
 		fx.discoveryReg,
-	).WithServerCertificateIssuer(issuer)
+	).WithServerCertificateIssuer(issuer).WithAgentSealer(fx.sealer)
 	if dnsV != nil {
 		svc = svc.WithDNSVerifier(dnsV)
 	}
@@ -992,7 +993,8 @@ func TestGetServerCertRenewal_TransientServerCertError_Propagates(t *testing.T) 
 		fx.agents, fx.endpoints, fx.certs, byoc, fx.renewals,
 		fx.validator, fx.identityCA, fx.bus, fx.outboxStore, fx.uow,
 		fx.discoveryReg,
-	).WithServerCertificateIssuer(fx.serverCA).WithDNSVerifier(dns.NewNoopVerifier())
+	).WithServerCertificateIssuer(fx.serverCA).WithDNSVerifier(dns.NewNoopVerifier()).
+		WithAgentSealer(fx.sealer)
 
 	agentID := registerAndActivate(t, fx, svc)
 	// BYOC renewal completes synchronously, leaving a completed renewal
@@ -1176,35 +1178,29 @@ func (challengeBlindDNSVerifier) VerifyRecords(
 	return &port.VerificationResult{AllRequired: all, Results: results}, nil
 }
 
-// claimAgentRegistered claims the outbox and returns the canonical
-// inner-event bytes of the first AGENT_REGISTERED row carrying the
-// given schema version. Both lanes share the eventType token, so the
-// probe decode works for either envelope shape.
+// claimAgentRegistered returns the canonical inner-event bytes of the
+// first AGENT_REGISTERED event carrying the given schema version.
+// AGENT_REGISTERED is sealed INLINE at activation (seal-before-success),
+// so the event is read from the fixture's recording sealer, not the
+// outbox. Both lanes share the eventType token, so the probe decode
+// works for either envelope shape.
 func claimAgentRegistered(t *testing.T, fx *regFixture, schemaVersion string) []byte {
 	t.Helper()
-	rows, err := fx.outboxStore.Claim(context.Background(), 10)
-	if err != nil {
-		t.Fatalf("Claim: %v", err)
-	}
-	for _, row := range rows {
-		if row.SchemaVersion != schemaVersion {
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion != schemaVersion {
 			continue
-		}
-		var p service.OutboxPayload
-		if err := json.Unmarshal(row.PayloadJSON, &p); err != nil {
-			t.Fatalf("unmarshal OutboxPayload: %v", err)
 		}
 		var probe struct {
 			EventType string `json:"eventType"`
 		}
-		if err := json.Unmarshal(p.InnerEventCanonical, &probe); err != nil {
+		if err := json.Unmarshal(s.InnerCanonical, &probe); err != nil {
 			t.Fatalf("unmarshal inner event: %v", err)
 		}
 		if probe.EventType == string(event.TypeAgentRegistered) {
-			return p.InnerEventCanonical
+			return s.InnerCanonical
 		}
 	}
-	t.Fatalf("no AGENT_REGISTERED event with schema version %s in the outbox", schemaVersion)
+	t.Fatalf("no AGENT_REGISTERED event with schema version %s was sealed", schemaVersion)
 	return nil
 }
 

--- a/internal/ra/service/registration.go
+++ b/internal/ra/service/registration.go
@@ -6,10 +6,12 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	anscrypto "github.com/godaddy/ans/internal/crypto"
 	"github.com/godaddy/ans/internal/domain"
@@ -186,6 +188,11 @@ type RegistrationService struct {
 	// a signature — this is only valid for tests; production configs
 	// must wire a real signer.
 	signer *EventSigner
+	// logger records the activation seal round trip and conflict
+	// cancellations — the state transitions CLAUDE.md requires at INFO
+	// and the failures on-call greps for. Defaults to zerolog.Nop();
+	// production wires WithLogger.
+	logger zerolog.Logger
 	clock  func() time.Time
 }
 
@@ -254,6 +261,7 @@ func NewRegistrationService(
 		outbox:            outbox,
 		uow:               uow,
 		discoveryRegistry: discoveryRegistry,
+		logger:            zerolog.Nop(),
 		clock:             time.Now,
 		sealTimeout:       defaultSealTimeout,
 	}
@@ -265,6 +273,14 @@ func NewRegistrationService(
 // this; without it activation fails closed with TL_UNAVAILABLE.
 func (s *RegistrationService) WithAgentSealer(sealer AgentEventSealer) *RegistrationService {
 	s.agentSealer = sealer
+	return s
+}
+
+// WithLogger attaches the structured logger for the activation seal
+// round trip and conflict cancellations, tagged with the component per
+// repo convention. Mirrors IdentityService.WithLogger.
+func (s *RegistrationService) WithLogger(logger zerolog.Logger) *RegistrationService {
+	s.logger = logger.With().Str("component", "registration-service").Logger()
 	return s
 }
 
@@ -549,16 +565,16 @@ func (s *RegistrationService) resolveServerCertInput(
 // an existing one before any certificate work: the exact versioned ANS
 // name is already registered (ANS_NAME_TAKEN), or the FQDN is held live by
 // a different owner (AGENT_HOST_TAKEN — the one-host-one-owner rule). The
-// host rule is re-checked at every progression step (register, verify-acme,
-// verify-dns) via ensureHostNotTakenByOther, but it is BEST-EFFORT against
-// a concurrent pending-window race: two different owners each holding a
-// PENDING_DNS registration on the same FQDN can race verify-dns and both
-// reach ACTIVE, because the check runs before the inline seal and outside
-// the activation transaction (registration uniqueness is keyed on the full
-// versioned ANS name, not the host — see HostRegistrations). Fully closing
-// that race needs a pre-seal host claim (cf. the identity lane's nonce
-// claim); until then the owner-scoped catalog read contains the blast
-// radius. Do not describe this as atomic activation-time enforcement.
+// host rule is checked at every progression step (register, verify-acme,
+// verify-dns) via ensureHostNotTakenByOther as a cheap fast-fail; the
+// AUTHORITATIVE decision is commitActivation's in-tx re-check, which
+// under the store's single writer deterministically aborts whichever
+// racer commits second (and refuses to resurrect a row a rival
+// conflict-cancelled mid-seal). A racer that loses after sealing leaves
+// an orphaned AGENT_REGISTERED leaf — the same benign residue the
+// seal/commit crash window accepts. A pre-seal host claim (cf. the
+// identity lane's nonce claim) would avoid spending that seal at all and
+// can land as a later optimization; correctness does not depend on it.
 func (s *RegistrationService) preflightRegistrationConflicts(ctx context.Context, ansName domain.AnsName, ownerID string) error {
 	exists, err := s.agents.ExistsByAnsName(ctx, ansName)
 	if err != nil {
@@ -629,15 +645,17 @@ func (s *RegistrationService) ensureHostNotTakenByOther(ctx context.Context, reg
 	return nil
 }
 
-// cancelConflictingPendings cancels every still-pending registration on
-// agentHost owned by someone other than winnerOwnerID. It runs when a
-// registration activates: the winner now holds the FQDN exclusively, so
-// the losing pending registrations are cancelled outright (rather than
-// left to fail later at their own verify-dns). Pre-activation
-// cancellations carry no TL event (ANS-1 §4.4). Caller runs this inside
-// the activation transaction so winner-activates and losers-cancel commit
-// atomically.
-func (s *RegistrationService) cancelConflictingPendings(ctx context.Context, agentHost, winnerOwnerID string) error {
+// revokeConflictLoserCertsAtCA performs the CA-side identity-certificate
+// revocation for the registrations activation is about to conflict-cancel
+// (still-pending, other-owner rows on the winner's host). It runs BEFORE
+// the activation transaction, exactly like cancelPending's ordering: CA
+// revocation is an external side effect that cannot roll back, and the
+// port contract makes it idempotent, so a crash between here and the
+// commit heals on retry. The authoritative loser set is re-read inside
+// the transaction; a loser that appears only in the tiny window between
+// this read and the commit keeps its certs until Revoke's self-healing
+// sweep, which repairs exactly that state.
+func (s *RegistrationService) revokeConflictLoserCertsAtCA(ctx context.Context, agentHost, winnerOwnerID string) error {
 	regs, err := s.agents.FindAllByAgentHost(ctx, agentHost)
 	if err != nil {
 		return err
@@ -646,12 +664,100 @@ func (s *RegistrationService) cancelConflictingPendings(ctx context.Context, age
 		if r.OwnerID == winnerOwnerID || !r.Status.IsPending() {
 			continue
 		}
+		certs, err := s.certs.FindIdentityCertificatesByAgent(ctx, r.AgentID)
+		if err != nil {
+			return err
+		}
+		if err := s.revokeIdentityCertsAtCA(ctx, certs, domain.RevocationCessationOfOperation); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// commitActivation is the transactional commit phase of verify-dns,
+// entered only after the AGENT_REGISTERED leaf is sealed. Under the
+// store's single writer it is the authoritative exclusivity decision —
+// the pre-seal ensureHostNotTakenByOther check is a cheap fast-fail, but
+// a rival can commit during the seal round trip, so everything is
+// re-decided here on in-tx reads:
+//
+//   - Own-row guard: the registration must still be PENDING_DNS. If a
+//     rival's activation conflict-cancelled it mid-seal, saving the stale
+//     in-memory ACTIVE aggregate would silently resurrect a REVOKED row —
+//     abort with AGENT_HOST_TAKEN instead.
+//   - Rival guard: any other owner's row now holding the host
+//     (ACTIVE/DEPRECATED) means this activation lost the race — abort
+//     with AGENT_HOST_TAKEN. Without this, both racers would commit
+//     ACTIVE and every later call would 409 each owner against the
+//     other: the host wedged for both with no API path out.
+//   - Losers: every still-pending other-owner registration is
+//     conflict-cancelled (no TL event, ANS-1 §4.4 — never sealed) and its
+//     VALID identity certificates are flipped REVOKED alongside (the CA
+//     side already ran pre-tx; see revokeConflictLoserCertsAtCA).
+//
+// An aborted loser has already sealed its own AGENT_REGISTERED leaf;
+// that orphan is the same benign residue the seal/commit crash window
+// accepts — the agent it names never reports ACTIVE, and read-side
+// status keys on the store row.
+func (s *RegistrationService) commitActivation(txCtx context.Context, reg *domain.AgentRegistration, sealed *sealedActivation) error {
+	current, err := s.agents.FindByAgentID(txCtx, reg.AgentID)
+	if err != nil {
+		return err
+	}
+	if current.Status != domain.StatusPendingDNS {
+		return errHostTaken(reg.FQDN())
+	}
+
+	rows, err := s.agents.FindAllByAgentHost(txCtx, reg.FQDN())
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if r.AgentID == reg.AgentID || r.OwnerID == reg.OwnerID {
+			continue
+		}
+		if holdsHostExclusivity(r.Status) {
+			return errHostTaken(reg.FQDN())
+		}
+		if !r.Status.IsPending() {
+			continue
+		}
 		if err := r.CancelForHostConflict(); err != nil {
 			return err
 		}
-		if err := s.agents.Save(ctx, r); err != nil {
+		if err := s.agents.Save(txCtx, r); err != nil {
 			return err
 		}
+		certs, err := s.certs.FindIdentityCertificatesByAgent(txCtx, r.AgentID)
+		if err != nil {
+			return err
+		}
+		for _, c := range certs {
+			if c.Status == domain.CertStatusValid {
+				revoked := c.Revoke()
+				if err := s.certs.UpdateCertificateStatus(txCtx, &revoked); err != nil {
+					return err
+				}
+			}
+		}
+		// A state transition on ANOTHER owner's resource — the first
+		// thing support needs when that owner asks why their pending
+		// registration turned REVOKED.
+		s.logger.Info().
+			Str("loserAgentId", r.AgentID).
+			Str("winnerAgentId", reg.AgentID).
+			Str("fqdn", reg.FQDN()).
+			Msg("pending registration conflict-cancelled by rival activation")
+	}
+
+	if err := s.agents.Save(txCtx, reg); err != nil {
+		return err
+	}
+	if _, err := s.outbox.RecordSealed(txCtx,
+		string(event.TypeAgentRegistered), reg.AgentID,
+		sealed.SchemaVersion, sealed.Payload, sealed.LogID); err != nil {
+		return err
 	}
 	return nil
 }
@@ -724,10 +830,35 @@ func (s *RegistrationService) sealActivationEvent(
 
 	sealCtx, cancel := context.WithTimeout(ctx, s.sealTimeout)
 	defer cancel()
+	sealStart := s.clock()
 	logID, err := s.agentSealer.SealAgentEvent(sealCtx, schemaVer, innerCanonical, producerSig)
 	if err != nil {
+		// Transient (TL didn't confirm; activation retryable, nothing
+		// consumed) is an expected detour under a TL incident → WARN.
+		// Anything else means the RA produced an event the TL refuses —
+		// a pipeline bug operators must see → ERROR. The underlying
+		// transport cause is logged at the tlclient adapter boundary
+		// before the domain mapping strips it.
+		ev := s.logger.Error()
+		if errors.Is(err, domain.ErrUnavailable) {
+			ev = s.logger.Warn()
+		}
+		ev.Err(err).
+			Str("agentId", reg.AgentID).
+			Str("fqdn", reg.FQDN()).
+			Str("schemaVersion", schemaVer).
+			Msg("agent activation seal failed")
 		return nil, err
 	}
+	// Logged BEFORE the commit: if the commit then fails, this line is
+	// what ties the orphaned AGENT_REGISTERED leaf back to this RA.
+	s.logger.Info().
+		Str("agentId", reg.AgentID).
+		Str("fqdn", reg.FQDN()).
+		Str("schemaVersion", schemaVer).
+		Str("logId", logID).
+		Dur("sealDuration", s.clock().Sub(sealStart)).
+		Msg("agent activation event sealed")
 
 	// Persist exactly the bytes the TL verified — the same
 	// {innerEventCanonical, producerSignature} wrapper worker-delivered

--- a/internal/ra/service/registration.go
+++ b/internal/ra/service/registration.go
@@ -34,6 +34,13 @@ import (
 // would leak SQL details into the port.
 type OutboxEnqueuer interface {
 	Enqueue(ctx context.Context, eventType, agentID, schemaVersion string, payload []byte, earliestAttempt time.Time) (int64, error)
+	// RecordSealed inserts a row that is already delivered (sent + logId
+	// set at insert), invisible to the worker's Claim. Used by the inline
+	// activation seal so the sealed AGENT_REGISTERED still surfaces on the
+	// agent-events feed — a read model over delivered outbox rows — even
+	// though it never rides the worker. Runs inside the activation
+	// transaction via the context-threaded tx.
+	RecordSealed(ctx context.Context, eventType, agentID, schemaVersion string, payload []byte, logID string) (int64, error)
 }
 
 // RegisterRequest is the command input for RegisterAgent. It is the
@@ -186,12 +193,15 @@ type RegistrationService struct {
 // V1/V2 ingest lane and returns only after the TL acknowledges the seal.
 // It is the agent-lane analogue of IdentityEventSealer: used to seal
 // AGENT_REGISTERED inline at activation so an agent is reported ACTIVE
-// only once its leaf is durable in the Transparency Log. A failed seal is
-// a failed activation — nothing is committed and the agent stays
-// PENDING_DNS for the operator to retry. Implementations map failures to
-// domain error kinds (ErrUnavailable for transient).
+// only once its leaf is durable in the Transparency Log. On success it
+// returns the TL-assigned logId from the ack, which the activation
+// persists on a pre-delivered outbox row so the sealed event is visible
+// to the agent-events feed. A failed seal is a failed activation —
+// nothing is committed and the agent stays PENDING_DNS for the operator
+// to retry. Implementations map failures to domain error kinds
+// (ErrUnavailable for transient).
 type AgentEventSealer interface {
-	SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) error
+	SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) (logID string, err error)
 }
 
 // EventSigner bundles the dependencies the RA needs to produce a
@@ -647,11 +657,14 @@ func (s *RegistrationService) cancelConflictingPendings(ctx context.Context, age
 }
 
 // errHostTaken is the 409 returned when an FQDN is held by another owner.
+// "Live" mirrors holdsHostExclusivity: an ACTIVE registration or a
+// DEPRECATED one (superseded but still resolving) both hold the host, so
+// the message must not suggest that deprecating an agent frees the FQDN.
 func errHostTaken(agentHost string) error {
 	return domain.NewConflictError(
 		"AGENT_HOST_TAKEN",
-		fmt.Sprintf("agentHost %q has an active registration owned by another operator; "+
-			"it cannot be used until no active registration remains", agentHost),
+		fmt.Sprintf("agentHost %q has a live (ACTIVE or DEPRECATED) registration owned by another operator; "+
+			"it cannot be used until no live registration remains", agentHost),
 	)
 }
 
@@ -668,6 +681,19 @@ func (s *RegistrationService) signCanonical(ctx context.Context, innerCanonical 
 	)
 }
 
+// sealedActivation is what a successful inline activation seal leaves
+// behind for the commit phase: the lane tag, the exact OutboxPayload
+// bytes the TL verified (canonical inner event + producer signature),
+// and the TL-assigned logId from the ack. VerifyDNS persists these on a
+// pre-delivered outbox row inside the activation transaction so the
+// sealed event surfaces on the agent-events feed (the ARD Finder's
+// ingest source) atomically with the ACTIVE commit.
+type sealedActivation struct {
+	SchemaVersion string
+	Payload       []byte
+	LogID         string
+}
+
 // sealActivationEvent builds the AGENT_REGISTERED event for the lane,
 // signs it once, and submits it to the TL inline, returning only on the
 // seal acknowledgment — seal-before-success for activation (ANS-1 §12.3,
@@ -680,25 +706,40 @@ func (s *RegistrationService) sealActivationEvent(
 	ctx context.Context, reg *domain.AgentRegistration,
 	expected []domain.ExpectedDNSRecord, perRecord []port.RecordVerification,
 	schemaVersion string, now time.Time,
-) error {
+) (*sealedActivation, error) {
 	if s.agentSealer == nil {
-		return domain.NewUnavailableError("TL_UNAVAILABLE",
+		return nil, domain.NewUnavailableError("TL_UNAVAILABLE",
 			"agent sealing is not configured; activation cannot report success without a sealed event")
 	}
 
 	schemaVer, innerCanonical, err := s.buildActivationLeaf(ctx, reg, expected, perRecord, schemaVersion, now)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	producerSig, err := s.signCanonical(ctx, innerCanonical, now)
 	if err != nil {
-		return fmt.Errorf("sign agent event: %w", err)
+		return nil, fmt.Errorf("sign agent event: %w", err)
 	}
 
 	sealCtx, cancel := context.WithTimeout(ctx, s.sealTimeout)
 	defer cancel()
-	return s.agentSealer.SealAgentEvent(sealCtx, schemaVer, innerCanonical, producerSig)
+	logID, err := s.agentSealer.SealAgentEvent(sealCtx, schemaVer, innerCanonical, producerSig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Persist exactly the bytes the TL verified — the same
+	// {innerEventCanonical, producerSignature} wrapper worker-delivered
+	// rows carry, so the feed's projection parses both identically.
+	payload, err := json.Marshal(OutboxPayload{
+		InnerEventCanonical: json.RawMessage(innerCanonical),
+		ProducerSignature:   producerSig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sealed activation payload: %w", err)
+	}
+	return &sealedActivation{SchemaVersion: schemaVer, Payload: payload, LogID: logID}, nil
 }
 
 // buildActivationLeaf builds and JCS-canonicalizes the single terminal

--- a/internal/ra/service/registration.go
+++ b/internal/ra/service/registration.go
@@ -15,6 +15,7 @@ import (
 	"github.com/godaddy/ans/internal/domain"
 	"github.com/godaddy/ans/internal/port"
 	"github.com/godaddy/ans/internal/tl/event"
+	eventv1 "github.com/godaddy/ans/internal/tl/event/v1"
 )
 
 // OutboxEnqueuer is the subset of the SQLite OutboxStore the
@@ -155,12 +156,42 @@ type RegistrationService struct {
 	// when nil, HTTP-01 challenges simply never verify and the gate
 	// relies on DNS-01. Production configs wire the default adapter.
 	httpChallenge port.HTTPChallengeVerifier
+	// tlPublicBaseURL is the externally-reachable Transparency Log URL
+	// (e.g. "https://tl.example.org") consumed by the AI Catalog surface:
+	// catalog entries embed the agent's TL badge URL and SCITT-receipt
+	// attestation URI built from it. DNS-record emission no longer reads
+	// it — the discovery-profile registry carries its own copy.
+	tlPublicBaseURL string
+	// agentSealer submits the AGENT_REGISTERED event to the TL inline at
+	// activation and returns only on the TL's acknowledgment —
+	// seal-before-success (ANS-1 §12.3: the RA MUST NOT activate without a
+	// sealed event). When nil, activation fails closed with TL_UNAVAILABLE;
+	// there is no "seal later" mode for the ACTIVE transition. (Revocation
+	// still rides the outbox.)
+	agentSealer AgentEventSealer
+	// sealTimeout bounds the inline activation seal round trip. Fixed at
+	// defaultSealTimeout (the identity lane's 5s budget) by design — agent
+	// activation shares that lane's timeout posture, so there is no
+	// per-instance setter; it stays well under the HTTP router timeout.
+	sealTimeout time.Duration
 	// signer is the KeyManager + keyID + raID tuple used to sign
 	// outbox events. When nil, events are still persisted but without
 	// a signature — this is only valid for tests; production configs
 	// must wire a real signer.
 	signer *EventSigner
 	clock  func() time.Time
+}
+
+// AgentEventSealer submits one producer-signed agent event to the TL's
+// V1/V2 ingest lane and returns only after the TL acknowledges the seal.
+// It is the agent-lane analogue of IdentityEventSealer: used to seal
+// AGENT_REGISTERED inline at activation so an agent is reported ACTIVE
+// only once its leaf is durable in the Transparency Log. A failed seal is
+// a failed activation — nothing is committed and the agent stays
+// PENDING_DNS for the operator to retry. Implementations map failures to
+// domain error kinds (ErrUnavailable for transient).
+type AgentEventSealer interface {
+	SealAgentEvent(ctx context.Context, schemaVersion string, innerCanonical []byte, producerSig string) error
 }
 
 // EventSigner bundles the dependencies the RA needs to produce a
@@ -214,7 +245,31 @@ func NewRegistrationService(
 		uow:               uow,
 		discoveryRegistry: discoveryRegistry,
 		clock:             time.Now,
+		sealTimeout:       defaultSealTimeout,
 	}
+}
+
+// WithAgentSealer attaches the synchronous TL sealer used to seal
+// AGENT_REGISTERED at activation (verify-dns) before the agent is reported
+// ACTIVE — seal-before-success (ANS-1 §12.3). Production builds must call
+// this; without it activation fails closed with TL_UNAVAILABLE.
+func (s *RegistrationService) WithAgentSealer(sealer AgentEventSealer) *RegistrationService {
+	s.agentSealer = sealer
+	return s
+}
+
+// WithTLPublicBaseURL sets the externally-reachable TL base URL the AI
+// Catalog surface embeds in badge URLs and SCITT-receipt attestation URIs.
+// DNS-record emission does not read this — the discovery-profile registry
+// carries its own copy of the URL.
+func (s *RegistrationService) WithTLPublicBaseURL(publicBaseURL string) *RegistrationService {
+	s.tlPublicBaseURL = publicBaseURL
+	return s
+}
+
+// TLPublicBaseURL returns the configured public TL base URL.
+func (s *RegistrationService) TLPublicBaseURL() string {
+	return s.tlPublicBaseURL
 }
 
 // WithSigner attaches a KeyManager-backed event signer. Production
@@ -262,22 +317,20 @@ func (s *RegistrationService) WithDNSVerifier(v port.DNSVerifier) *RegistrationS
 //  5. Issue the identity certificate and store it.
 //  6. Persist the registration aggregate in a single transaction
 //     together with its endpoints, CSR, and BYOC cert.
-//  7. Enqueue an AgentRegistered event in the outbox (same transaction).
-//  8. Publish domain events in-process for local handlers.
-//  9. Return the registration + required DNS records + CA chain.
+//  7. Publish domain events in-process for local handlers (after commit).
+//  8. Return the registration + required DNS records + CA chain.
+//
+// Registration emits NO Transparency-Log event: it creates a PENDING
+// aggregate that has not proven domain control yet. The single terminal
+// AGENT_REGISTERED leaf is sealed INLINE at activation (verify-dns,
+// seal-before-success) — never enqueued here.
 func (s *RegistrationService) RegisterAgent(ctx context.Context, req RegisterRequest) (*RegisterResponse, error) {
 	now := s.clock()
 
-	// Uniqueness check before heavy work.
-	exists, err := s.agents.ExistsByAnsName(ctx, req.AnsName)
-	if err != nil {
+	// Conflict preflight before heavy cert work: exact-name uniqueness
+	// and FQDN exclusivity (one-host-one-owner).
+	if err := s.preflightRegistrationConflicts(ctx, req.AnsName, req.OwnerID); err != nil {
 		return nil, err
-	}
-	if exists {
-		return nil, domain.NewConflictError(
-			"ANS_NAME_TAKEN",
-			fmt.Sprintf("ANS name %q is already registered", req.AnsName),
-		)
 	}
 
 	// Validate identity CSR shape (optional) BEFORE the server-cert
@@ -480,6 +533,205 @@ func (s *RegistrationService) resolveServerCertInput(
 	}
 	srvCSR := domain.NewServerCSR(uuid.NewString(), req.ServerCsrPEM, now)
 	return serverCertInput{serverCSR: &srvCSR, order: order}, nil
+}
+
+// preflightRegistrationConflicts rejects a registration that collides with
+// an existing one before any certificate work: the exact versioned ANS
+// name is already registered (ANS_NAME_TAKEN), or the FQDN is held live by
+// a different owner (AGENT_HOST_TAKEN — the one-host-one-owner rule). The
+// host rule is re-checked at every progression step (register, verify-acme,
+// verify-dns) via ensureHostNotTakenByOther, but it is BEST-EFFORT against
+// a concurrent pending-window race: two different owners each holding a
+// PENDING_DNS registration on the same FQDN can race verify-dns and both
+// reach ACTIVE, because the check runs before the inline seal and outside
+// the activation transaction (registration uniqueness is keyed on the full
+// versioned ANS name, not the host — see HostRegistrations). Fully closing
+// that race needs a pre-seal host claim (cf. the identity lane's nonce
+// claim); until then the owner-scoped catalog read contains the blast
+// radius. Do not describe this as atomic activation-time enforcement.
+func (s *RegistrationService) preflightRegistrationConflicts(ctx context.Context, ansName domain.AnsName, ownerID string) error {
+	exists, err := s.agents.ExistsByAnsName(ctx, ansName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return domain.NewConflictError(
+			"ANS_NAME_TAKEN",
+			fmt.Sprintf("ANS name %q is already registered", ansName),
+		)
+	}
+	held, err := s.hostHeldByAnotherOwner(ctx, ansName.FQDN(), ownerID, "")
+	if err != nil {
+		return err
+	}
+	if held {
+		return errHostTaken(ansName.FQDN())
+	}
+	return nil
+}
+
+// holdsHostExclusivity reports whether a registration in status st holds
+// its FQDN exclusively for its owner. A registration that has gone ACTIVE
+// and not yet reached a terminal state still operates on the host —
+// outright ACTIVE, or DEPRECATED (superseded but still resolving during a
+// version migration, ANS-1 §7.1) — so a different owner may not register
+// or activate on that host while any such registration exists. Pending and
+// terminal states (REVOKED / EXPIRED / FAILED) do not hold the host.
+func holdsHostExclusivity(st domain.RegistrationStatus) bool {
+	return st == domain.StatusActive || st == domain.StatusDeprecated
+}
+
+// hostHeldByAnotherOwner reports whether agentHost carries an
+// exclusivity-holding registration (holdsHostExclusivity) owned by an
+// operator other than ownerID, ignoring the registration identified by
+// exceptAgentID ("" ignores none). It enforces the rule that once a
+// registration goes live on an FQDN, that FQDN belongs to its owner alone
+// until no live registration remains.
+func (s *RegistrationService) hostHeldByAnotherOwner(ctx context.Context, agentHost, ownerID, exceptAgentID string) (bool, error) {
+	regs, err := s.agents.FindAllByAgentHost(ctx, agentHost)
+	if err != nil {
+		return false, err
+	}
+	for _, r := range regs {
+		if r.AgentID == exceptAgentID {
+			continue
+		}
+		if r.OwnerID != ownerID && holdsHostExclusivity(r.Status) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ensureHostNotTakenByOther rejects an operation that would advance reg
+// toward ACTIVE when a different owner already holds the FQDN live. Called
+// at every progression step (register, verify-acme, verify-dns) so a
+// registration that has lost the host is rejected at every level, not only
+// at the final activation.
+func (s *RegistrationService) ensureHostNotTakenByOther(ctx context.Context, reg *domain.AgentRegistration) error {
+	held, err := s.hostHeldByAnotherOwner(ctx, reg.FQDN(), reg.OwnerID, reg.AgentID)
+	if err != nil {
+		return err
+	}
+	if held {
+		return errHostTaken(reg.FQDN())
+	}
+	return nil
+}
+
+// cancelConflictingPendings cancels every still-pending registration on
+// agentHost owned by someone other than winnerOwnerID. It runs when a
+// registration activates: the winner now holds the FQDN exclusively, so
+// the losing pending registrations are cancelled outright (rather than
+// left to fail later at their own verify-dns). Pre-activation
+// cancellations carry no TL event (ANS-1 §4.4). Caller runs this inside
+// the activation transaction so winner-activates and losers-cancel commit
+// atomically.
+func (s *RegistrationService) cancelConflictingPendings(ctx context.Context, agentHost, winnerOwnerID string) error {
+	regs, err := s.agents.FindAllByAgentHost(ctx, agentHost)
+	if err != nil {
+		return err
+	}
+	for _, r := range regs {
+		if r.OwnerID == winnerOwnerID || !r.Status.IsPending() {
+			continue
+		}
+		if err := r.CancelForHostConflict(); err != nil {
+			return err
+		}
+		if err := s.agents.Save(ctx, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// errHostTaken is the 409 returned when an FQDN is held by another owner.
+func errHostTaken(agentHost string) error {
+	return domain.NewConflictError(
+		"AGENT_HOST_TAKEN",
+		fmt.Sprintf("agentHost %q has an active registration owned by another operator; "+
+			"it cannot be used until no active registration remains", agentHost),
+	)
+}
+
+// signCanonical produces the producer's detached JWS over the canonical
+// inner-event bytes. Returns "" when no signer is configured (tests only).
+func (s *RegistrationService) signCanonical(ctx context.Context, innerCanonical []byte, now time.Time) (string, error) {
+	if s.signer == nil {
+		return "", nil
+	}
+	return anscrypto.SignDetachedJWS(
+		ctx, s.signer.KeyManager, s.signer.KeyID,
+		anscrypto.JWSProtectedHeader{Typ: "JWT", Timestamp: now.Unix(), RAID: s.signer.RaID},
+		innerCanonical,
+	)
+}
+
+// sealActivationEvent builds the AGENT_REGISTERED event for the lane,
+// signs it once, and submits it to the TL inline, returning only on the
+// seal acknowledgment — seal-before-success for activation (ANS-1 §12.3,
+// mirroring the identity lane). A failed seal is a failed activation:
+// nothing is committed and the agent stays PENDING_DNS for the operator to
+// retry. A nil sealer fails closed with TL_UNAVAILABLE — there is no "seal
+// later" mode for the ACTIVE transition. expected/perRecord feed the
+// version-specific attestation block.
+func (s *RegistrationService) sealActivationEvent(
+	ctx context.Context, reg *domain.AgentRegistration,
+	expected []domain.ExpectedDNSRecord, perRecord []port.RecordVerification,
+	schemaVersion string, now time.Time,
+) error {
+	if s.agentSealer == nil {
+		return domain.NewUnavailableError("TL_UNAVAILABLE",
+			"agent sealing is not configured; activation cannot report success without a sealed event")
+	}
+
+	schemaVer, innerCanonical, err := s.buildActivationLeaf(ctx, reg, expected, perRecord, schemaVersion, now)
+	if err != nil {
+		return err
+	}
+
+	producerSig, err := s.signCanonical(ctx, innerCanonical, now)
+	if err != nil {
+		return fmt.Errorf("sign agent event: %w", err)
+	}
+
+	sealCtx, cancel := context.WithTimeout(ctx, s.sealTimeout)
+	defer cancel()
+	return s.agentSealer.SealAgentEvent(sealCtx, schemaVer, innerCanonical, producerSig)
+}
+
+// buildActivationLeaf builds and JCS-canonicalizes the single terminal
+// AGENT_REGISTERED leaf for the requested lane, returning the
+// schema-version tag and the canonical bytes the RA will sign and seal.
+// The two lanes diverge only in the event builder and canonicalizer; the
+// sign-and-seal tail in sealActivationEvent is shared.
+func (s *RegistrationService) buildActivationLeaf(
+	ctx context.Context, reg *domain.AgentRegistration,
+	expected []domain.ExpectedDNSRecord, perRecord []port.RecordVerification,
+	schemaVersion string, now time.Time,
+) (string, []byte, error) {
+	if isV1Lane(schemaVersion) {
+		inner, err := s.buildAgentRegisteredV1Event(ctx, reg, expected, now)
+		if err != nil {
+			return "", nil, err
+		}
+		canonical, err := eventv1.CanonicalizeEvent(inner)
+		if err != nil {
+			return "", nil, fmt.Errorf("canonicalize V1 agent event: %w", err)
+		}
+		return eventv1.SchemaVersion, canonical, nil
+	}
+
+	inner, err := s.buildAgentRegisteredEvent(ctx, reg, expected, perRecord, now)
+	if err != nil {
+		return "", nil, err
+	}
+	canonical, err := event.CanonicalizeEvent(inner)
+	if err != nil {
+		return "", nil, fmt.Errorf("canonicalize agent event: %w", err)
+	}
+	return event.SchemaVersion, canonical, nil
 }
 
 // baseInnerEvent populates the fields every event carries about its

--- a/internal/ra/service/registration_test.go
+++ b/internal/ra/service/registration_test.go
@@ -242,6 +242,10 @@ func (failingOutbox) Enqueue(_ context.Context, _, _, _ string, _ []byte, _ time
 	return 0, errors.New("simulated outbox failure")
 }
 
+func (failingOutbox) RecordSealed(_ context.Context, _, _, _ string, _ []byte, _ string) (int64, error) {
+	return 0, errors.New("simulated outbox failure")
+}
+
 // anyAgentID looks up the agentID for the given ANS name. Helpers
 // only — the AnsName is unique per fixture, so the lookup is
 // deterministic.
@@ -259,6 +263,7 @@ func anyAgentID(t *testing.T, fx *regFixture, ans domain.AnsName) string {
 type regFixture struct {
 	svc          *service.RegistrationService
 	req          service.RegisterRequest
+	db           *sqlite.DB
 	outboxStore  *sqlite.OutboxStore
 	sealer       *recordingAgentSealer
 	uow          port.UnitOfWork
@@ -354,6 +359,7 @@ func newRegFixture(t *testing.T) *regFixture {
 
 	return &regFixture{
 		svc:          svc,
+		db:           db,
 		outboxStore:  outbox,
 		sealer:       sealer,
 		uow:          db,

--- a/internal/ra/service/registration_test.go
+++ b/internal/ra/service/registration_test.go
@@ -260,6 +260,7 @@ type regFixture struct {
 	svc          *service.RegistrationService
 	req          service.RegisterRequest
 	outboxStore  *sqlite.OutboxStore
+	sealer       *recordingAgentSealer
 	uow          port.UnitOfWork
 	agents       port.AgentStore
 	endpoints    port.EndpointStore
@@ -331,6 +332,7 @@ func newRegFixture(t *testing.T) *regFixture {
 		t.Fatal(err)
 	}
 
+	sealer := &recordingAgentSealer{}
 	svc := service.NewRegistrationService(
 		agents, endpoints, certsStore, byoc, renewals, validator, identityCA, bus, outbox, db, discoveryReg,
 	).WithSigner(service.EventSigner{
@@ -340,7 +342,8 @@ func newRegFixture(t *testing.T) *regFixture {
 	}).WithServerCertificateIssuer(serverCA).
 		// The challenge gate is unconditional; the noop verifier plays
 		// the quickstart role (accepts any published state).
-		WithDNSVerifier(dns.NewNoopVerifier())
+		WithDNSVerifier(dns.NewNoopVerifier()).
+		WithAgentSealer(sealer)
 
 	// Build a valid identity CSR whose URI SAN matches the ANS name
 	// and a server CSR whose DNS SAN matches the FQDN.
@@ -352,6 +355,7 @@ func newRegFixture(t *testing.T) *regFixture {
 	return &regFixture{
 		svc:          svc,
 		outboxStore:  outbox,
+		sealer:       sealer,
 		uow:          db,
 		agents:       agents,
 		endpoints:    endpoints,

--- a/internal/ra/service/sealer_test.go
+++ b/internal/ra/service/sealer_test.go
@@ -1,0 +1,44 @@
+package service_test
+
+import (
+	"context"
+	"sync"
+)
+
+// recordingAgentSealer is a test AgentEventSealer for the agent activation
+// seal-before-success path. By default it succeeds and records each sealed
+// event so a test can assert what verify-dns submitted to the TL (the
+// AGENT_REGISTERED event no longer rides the outbox). Set failErr to drive
+// the fail-closed path (activation must then refuse to report ACTIVE).
+type recordingAgentSealer struct {
+	mu      sync.Mutex
+	events  []sealedAgentEvent
+	failErr error
+}
+
+type sealedAgentEvent struct {
+	SchemaVersion  string
+	InnerCanonical []byte
+	ProducerSig    string
+}
+
+func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion string, innerCanonical []byte, producerSig string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failErr != nil {
+		return r.failErr
+	}
+	r.events = append(r.events, sealedAgentEvent{
+		SchemaVersion:  schemaVersion,
+		InnerCanonical: append([]byte(nil), innerCanonical...),
+		ProducerSig:    producerSig,
+	})
+	return nil
+}
+
+// sealed returns a copy of the events sealed so far.
+func (r *recordingAgentSealer) sealed() []sealedAgentEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]sealedAgentEvent(nil), r.events...)
+}

--- a/internal/ra/service/sealer_test.go
+++ b/internal/ra/service/sealer_test.go
@@ -18,6 +18,11 @@ type recordingAgentSealer struct {
 	mu      sync.Mutex
 	events  []sealedAgentEvent
 	failErr error
+	// hook, when set, runs inside the seal round trip (after the TL
+	// "ack", before the caller's commit phase) — the window a rival
+	// writer can land in. Race tests use it to commit conflicting store
+	// state mid-seal, mirroring the identity lane's recordingSealer.hook.
+	hook func()
 }
 
 type sealedAgentEvent struct {
@@ -40,6 +45,9 @@ func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion s
 		ProducerSig:    producerSig,
 		LogID:          logID,
 	})
+	if r.hook != nil {
+		r.hook()
+	}
 	return logID, nil
 }
 

--- a/internal/ra/service/sealer_test.go
+++ b/internal/ra/service/sealer_test.go
@@ -2,14 +2,18 @@ package service_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 )
 
 // recordingAgentSealer is a test AgentEventSealer for the agent activation
-// seal-before-success path. By default it succeeds and records each sealed
+// seal-before-success path. By default it succeeds, records each sealed
 // event so a test can assert what verify-dns submitted to the TL (the
-// AGENT_REGISTERED event no longer rides the outbox). Set failErr to drive
-// the fail-closed path (activation must then refuse to report ACTIVE).
+// AGENT_REGISTERED event no longer rides the outbox worker), and returns a
+// deterministic per-event logId ("test-log-1", "test-log-2", …) mirroring
+// the TL ack — the activation persists it on the pre-delivered feed row.
+// Set failErr to drive the fail-closed path (activation must then refuse
+// to report ACTIVE).
 type recordingAgentSealer struct {
 	mu      sync.Mutex
 	events  []sealedAgentEvent
@@ -20,20 +24,23 @@ type sealedAgentEvent struct {
 	SchemaVersion  string
 	InnerCanonical []byte
 	ProducerSig    string
+	LogID          string
 }
 
-func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion string, innerCanonical []byte, producerSig string) error {
+func (r *recordingAgentSealer) SealAgentEvent(_ context.Context, schemaVersion string, innerCanonical []byte, producerSig string) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.failErr != nil {
-		return r.failErr
+		return "", r.failErr
 	}
+	logID := fmt.Sprintf("test-log-%d", len(r.events)+1)
 	r.events = append(r.events, sealedAgentEvent{
 		SchemaVersion:  schemaVersion,
 		InnerCanonical: append([]byte(nil), innerCanonical...),
 		ProducerSig:    producerSig,
+		LogID:          logID,
 	})
-	return nil
+	return logID, nil
 }
 
 // sealed returns a copy of the events sealed so far.

--- a/scripts/demo/ai-catalog.sh
+++ b/scripts/demo/ai-catalog.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Produce and validate the host-complete AI Catalog document — the literal
+# ai-catalog.json an Agent-Host Provider (AHP) republishes verbatim at
+# https://{agentHost}/.well-known/ai-catalog.json (IMPL §4).
+#
+# catalog.sh exercises the per-agent catalog-ENTRY (one building block,
+# served as application/json). THIS script exercises the per-host
+# DOCUMENT, whose defining property is that it is HOST-COMPLETE: it carries
+# one CatalogEntry for EVERY catalog-eligible agent on the host — and
+# nothing else. To prove that, it builds a single host with a deliberately
+# mixed population (all same owner — one host belongs to one owner):
+#
+#   v1.0.0  MCP  + metaDataUrl    eligible, ACTIVE    -> IN the document
+#   v2.0.0  A2A  + metaDataUrl    eligible, ACTIVE    -> IN the document
+#   v3.0.0  HTTP-API (no card)    ACTIVE, ineligible  -> ABSENT (no artifact type)
+#   v4.0.0  MCP  + metaDataUrl    eligible, PENDING   -> ABSENT (not sealed in the TL)
+#   + an eligible ACTIVE agent on a DIFFERENT host    -> ABSENT (host scope)
+#
+# The resulting document must therefore list EXACTLY the two ACTIVE
+# eligible versions, carry specVersion "1.0" + a host object, sort
+# deterministically (identifier then version) for a stable ETag, and be
+# byte-identical no matter which of the host's agentIds is used to fetch it
+# (the route is an agent-scoped alias for the whole host). It is saved to
+# data/demo/ai-catalog.json so you can open the actual file an AHP serves.
+#
+# NOTE (serving model): IMPL §6 models the catalog routes as PUBLIC and
+# unauthenticated (every field is already TL- or DNS-visible). This RA
+# deployment owner-scopes them (ReadOwnership), so the fetch below carries
+# the owner's bearer token. A public deployment would drop that header; the
+# document assertions are otherwise identical. ANS never serves the
+# /.well-known path itself — it generates the bytes; the AHP publishes them.
+#
+# Usage:
+#   scripts/demo/start.sh        # bring up ans-ra + ans-tl first
+#   scripts/demo/ai-catalog.sh   # then run this
+#
+# Prerequisites: curl, jq, openssl (same as the other demo scripts).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+require_cmd curl
+require_cmd jq
+require_cmd openssl
+
+if ! curl -sSf "$RA_URL/v2/admin/ready" >/dev/null 2>&1; then
+  fail "ans-ra isn't reachable at $RA_URL — run scripts/demo/start.sh first"
+fi
+
+# reg_eligible HOST VERSION PROTOCOL — register an agent whose single
+# endpoint declares a metaDataUrl card (catalog-eligible). Sets
+# REG_AGENT_ID. PROTOCOL is MCP or A2A.
+reg_eligible() {
+  local host="$1" ver="$2" proto="$3" ans="ans://v$2.$1" path meta
+  case "$proto" in
+    MCP) path="/mcp"; meta="https://$host/.well-known/mcp/server-card.json" ;;
+    A2A) path="/a2a"; meta="https://$host/.well-known/agent-card.json" ;;
+    *)   fail "reg_eligible: unsupported protocol $proto" ;;
+  esac
+  gen_csrs "$host" "$ans"
+  local body
+  body=$(jq -n --arg host "$host" --arg ver "$ver" --arg url "https://$host$path" \
+    --arg meta "$meta" --arg proto "$proto" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
+    agentDisplayName: ("Catalog " + $proto + " v" + $ver),
+    version: $ver,
+    agentHost: $host,
+    endpoints: [{ agentUrl: $url, metaDataUrl: $meta, protocol: $proto }],
+    identityCsrPEM: $idc,
+    serverCsrPEM: $sc
+  }')
+  cat_req POST /v2/ans/agents "$body"
+  assert_status 202 "register $proto v$ver on $host"
+  REG_AGENT_ID=$(printf '%s' "$CAT_BODY" | jq -r '.agentId // empty')
+  [ -n "$REG_AGENT_ID" ] || fail "no agentId for $proto v$ver on $host"
+}
+
+# reg_ineligible HOST VERSION — register an HTTP-API agent (no catalog
+# artifact type, no metaDataUrl): activates fine, but is never catalogued.
+# Sets REG_AGENT_ID.
+reg_ineligible() {
+  local host="$1" ver="$2" ans="ans://v$2.$1"
+  gen_csrs "$host" "$ans"
+  local body
+  body=$(jq -n --arg host "$host" --arg ver "$ver" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
+    agentDisplayName: ("Catalog HTTP v" + $ver),
+    version: $ver,
+    agentHost: $host,
+    endpoints: [{ agentUrl: ("https://" + $host + "/api"), protocol: "HTTP_API" }],
+    identityCsrPEM: $idc,
+    serverCsrPEM: $sc
+  }')
+  cat_req POST /v2/ans/agents "$body"
+  assert_status 202 "register HTTP-API v$ver on $host"
+  REG_AGENT_ID=$(printf '%s' "$CAT_BODY" | jq -r '.agentId // empty')
+  [ -n "$REG_AGENT_ID" ] || fail "no agentId for HTTP-API v$ver on $host"
+}
+
+RAND="$(openssl rand -hex 4)"
+HOST="catalog-host-$RAND.example.com"
+LABEL="${HOST%%.*}"
+URN="urn:ai:$HOST:agents:$LABEL"
+OTHER="catalog-other-$RAND.example.com"
+
+# ──────────────────────────────────────────────────────────────────
+# 1. Build a mixed agent population on ONE host
+# ──────────────────────────────────────────────────────────────────
+header "1. Build a mixed agent population on a single host: $HOST"
+
+reg_eligible "$HOST" "1.0.0" MCP; A1="$REG_AGENT_ID"; cat_activate "$A1"
+reg_eligible "$HOST" "2.0.0" A2A; A2="$REG_AGENT_ID"; cat_activate "$A2"
+reg_ineligible "$HOST" "3.0.0";  A3="$REG_AGENT_ID"; cat_activate "$A3"
+reg_eligible "$HOST" "4.0.0" MCP; A4="$REG_AGENT_ID"   # left PENDING on purpose
+ok "v1.0.0 (MCP) + v2.0.0 (A2A): ACTIVE & eligible"
+ok "v3.0.0 (HTTP-API): ACTIVE but ineligible; v4.0.0 (MCP): eligible but PENDING"
+
+header "1b. An eligible ACTIVE agent on a DIFFERENT host (must NOT leak in)"
+reg_eligible "$OTHER" "1.0.0" MCP; AX="$REG_AGENT_ID"; cat_activate "$AX"
+
+# ──────────────────────────────────────────────────────────────────
+# 2. Fetch the host-complete ai-catalog.json and validate its shape
+# ──────────────────────────────────────────────────────────────────
+header "2. GET /v2/ans/agents/$A1/ai-catalog  → save the ai-catalog.json"
+AICAT="$DATA/ai-catalog.json"
+cat_doc "$A1" "$AICAT"
+[ "$CAT_DOC_STATUS" = "200" ] || fail "ai-catalog GET: expected 200, got $CAT_DOC_STATUS"
+pretty_json <"$AICAT" >&2
+
+[ "$CAT_DOC_CTYPE" = "application/ai-catalog+json" ] \
+  || fail "Content-Type: got '$CAT_DOC_CTYPE', want application/ai-catalog+json"
+ok "served as application/ai-catalog+json"
+[ -n "$CAT_DOC_ETAG" ] || fail "no ETag header on the document"
+ETAG1="$CAT_DOC_ETAG"
+ok "strong ETag present: $ETAG1"
+
+DOC=$(cat "$AICAT")
+cassert "specVersion is \"1.0\""                                  "$DOC" '.specVersion == "1.0"'
+cassert "host object: identifier == displayName == agentHost"     "$DOC" ".host.identifier == \"$HOST\" and .host.displayName == \"$HOST\""
+cassert "entries serializes as an array (never null)"             "$DOC" '(.entries | type) == "array"'
+cassert "host-complete: EXACTLY the 2 ACTIVE eligible versions"   "$DOC" '(.entries | length) == 2'
+cassert "both entries carry the host's version-spanning URN"      "$DOC" "[.entries[].identifier] == [\"$URN\", \"$URN\"]"
+cassert "sorted (identifier, version): v1.0.0 before v2.0.0"      "$DOC" '[.entries[].version] == ["1.0.0", "2.0.0"]'
+cassert "v1.0.0 entry is the MCP server card"                     "$DOC" '.entries[0].mediaType == "application/mcp-server-card+json"'
+cassert "v2.0.0 entry is the A2A agent card"                      "$DOC" '.entries[1].mediaType == "application/a2a-agent-card+json"'
+cassert "every entry is anchored on this agentHost"               "$DOC" "all(.entries[]; .metadata.agentHost == \"$HOST\")"
+cassert "ineligible v3.0.0 (HTTP-API) is absent"                  "$DOC" '([.entries[].version] | index("3.0.0")) == null'
+cassert "pending v4.0.0 is absent (not sealed in the TL)"         "$DOC" '([.entries[].version] | index("4.0.0")) == null'
+cassert "a different host's agent never leaks in"                 "$DOC" "all(.entries[]; .metadata.agentHost != \"$OTHER\")"
+
+# ──────────────────────────────────────────────────────────────────
+# 3. Agent-scoped alias: any agentId on the host returns the WHOLE host
+# ──────────────────────────────────────────────────────────────────
+header "3. Host-complete alias: fetch via v2.0.0's agentId → same document"
+AICAT_VIA_A2="$DATA/ai-catalog.via-a2.json"
+cat_doc "$A2" "$AICAT_VIA_A2"
+[ "$CAT_DOC_STATUS" = "200" ] || fail "ai-catalog via A2: expected 200, got $CAT_DOC_STATUS"
+if diff -q "$AICAT" "$AICAT_VIA_A2" >/dev/null; then
+  ok "byte-identical whether fetched via v1.0.0's or v2.0.0's agentId"
+else
+  fail "document differs by which agentId fetched it — not host-complete"
+fi
+[ "$CAT_DOC_ETAG" = "$ETAG1" ] || fail "ETag differs by agentId ($CAT_DOC_ETAG vs $ETAG1)"
+ok "identical ETag across agentIds: $ETAG1"
+
+# ──────────────────────────────────────────────────────────────────
+# 4. Deterministic bytes + cheap AHP poll (ETag / 304)
+# ──────────────────────────────────────────────────────────────────
+header "4. Re-derivation is deterministic; conditional GET returns 304"
+cat_doc "$A1" "$DATA/ai-catalog.refetch.json"
+[ "$CAT_DOC_ETAG" = "$ETAG1" ] || fail "ETag not stable across re-derivation ($CAT_DOC_ETAG vs $ETAG1)"
+ok "ETag stable across re-derivation (deterministic JCS-sorted bytes)"
+cat_doc_inm "$A1" "$ETAG1"
+[ "$CAT_DOC_STATUS" = "304" ] || fail "If-None-Match did not yield 304 (got $CAT_DOC_STATUS)"
+ok "If-None-Match returned 304 Not Modified (AHP polls cheaply)"
+
+# ----- summary -----
+header "ai-catalog.json ready"
+printf "  host        %s\n" "$HOST" >&2
+printf "  entries     %s (v1.0.0 MCP, v2.0.0 A2A — host-complete)\n" "$(jq '.entries | length' "$AICAT")" >&2
+printf "  ETag        %s\n" "$ETAG1" >&2
+printf "  saved to    %s\n" "$AICAT" >&2
+printf "\n" >&2
+printf "  An Agent-Host Provider republishes this file verbatim at:\n" >&2
+printf "    https://%s/.well-known/ai-catalog.json\n" "$HOST" >&2

--- a/scripts/demo/ai-catalog.sh
+++ b/scripts/demo/ai-catalog.sh
@@ -100,7 +100,7 @@ reg_ineligible() {
 RAND="$(openssl rand -hex 4)"
 HOST="catalog-host-$RAND.example.com"
 LABEL="${HOST%%.*}"
-URN="urn:ai:$HOST:agents:$LABEL"
+URN="urn:air:$HOST:agents:$LABEL"
 OTHER="catalog-other-$RAND.example.com"
 
 # ──────────────────────────────────────────────────────────────────

--- a/scripts/demo/ai-catalog.sh
+++ b/scripts/demo/ai-catalog.sh
@@ -61,9 +61,12 @@ reg_eligible() {
   esac
   gen_csrs "$host" "$ans"
   local body
+  # All versions of this host's agent share ONE display name: the URN
+  # label is the labelized display name (Finder-parity derivation), and a
+  # shared name is what makes successive versions share the lineage URN.
   body=$(jq -n --arg host "$host" --arg ver "$ver" --arg url "https://$host$path" \
     --arg meta "$meta" --arg proto "$proto" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
-    agentDisplayName: ("Catalog " + $proto + " v" + $ver),
+    agentDisplayName: "Catalog Demo Agent",
     version: $ver,
     agentHost: $host,
     endpoints: [{ agentUrl: $url, metaDataUrl: $meta, protocol: $proto }],
@@ -99,7 +102,9 @@ reg_ineligible() {
 
 RAND="$(openssl rand -hex 4)"
 HOST="catalog-host-$RAND.example.com"
-LABEL="${HOST%%.*}"
+# URN label = labelized display name ("Catalog Demo Agent"), shared by
+# every version reg_eligible registers — the Finder-parity derivation.
+LABEL="Catalog-Demo-Agent"
 URN="urn:air:$HOST:agents:$LABEL"
 OTHER="catalog-other-$RAND.example.com"
 

--- a/scripts/demo/catalog.sh
+++ b/scripts/demo/catalog.sh
@@ -8,7 +8,7 @@
 #
 #   1. Eligible single-protocol (MCP + metaDataUrl), activated
 #        → GET .../catalog-entry returns the bare entry (200), with the
-#          urn:ai lineage handle, the ANS-Registration SCITT-receipt
+#          urn:air lineage handle, the ANS-Registration SCITT-receipt
 #          attestation, and {ansName,agentHost,badgeUrl} metadata.
 #   2. Eligible multi-protocol (A2A + MCP, both with metaDataUrl), activated
 #        → one nested outer entry (mediaType application/ai-catalog+json)
@@ -48,7 +48,7 @@ RAND="$(openssl rand -hex 4)"
 header "1. Eligible single-protocol agent (MCP + metaDataUrl)"
 H1="catalog-single-$RAND.example.com"
 ANS1="ans://v1.0.0.$H1"
-URN1="urn:ai:$H1:agents:${H1%%.*}"
+URN1="urn:air:$H1:agents:${H1%%.*}"
 META1="https://$H1/.well-known/mcp/server-card.json"
 gen_csrs "$H1" "$ANS1"
 REQ1=$(jq -n --arg host "$H1" --arg meta "$META1" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
@@ -77,7 +77,7 @@ header "1b. GET /v2/ans/agents/$A1/catalog-entry"
 cat_req GET "/v2/ans/agents/$A1/catalog-entry"
 assert_status 200 "catalog-entry single"
 E1="$CAT_BODY"
-cassert "identifier is the urn:ai lineage handle (leftmost DNS label)" "$E1" ".identifier == \"$URN1\""
+cassert "identifier is the urn:air lineage handle (leftmost DNS label)" "$E1" ".identifier == \"$URN1\""
 cassert "mediaType is the card type for MCP"                          "$E1" '.mediaType == "application/mcp-server-card+json"'
 cassert "exactly one of url|data (single -> url)"                     "$E1" '(.url|type=="string") and (has("data")|not)'
 cassert "url is the declared metaDataUrl"                             "$E1" ".url == \"$META1\""
@@ -94,7 +94,7 @@ cassert "ANS-Registration SCITT-receipt attestation (no digest)"      "$E1" \
 header "2. Eligible multi-protocol agent (A2A + MCP) -> nested entry"
 H2="catalog-multi-$RAND.example.com"
 ANS2="ans://v1.0.0.$H2"
-URN2="urn:ai:$H2:agents:${H2%%.*}"
+URN2="urn:air:$H2:agents:${H2%%.*}"
 gen_csrs "$H2" "$ANS2"
 REQ2=$(jq -n --arg host "$H2" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
   agentDisplayName: "Catalog Multi",

--- a/scripts/demo/catalog.sh
+++ b/scripts/demo/catalog.sh
@@ -48,7 +48,9 @@ RAND="$(openssl rand -hex 4)"
 header "1. Eligible single-protocol agent (MCP + metaDataUrl)"
 H1="catalog-single-$RAND.example.com"
 ANS1="ans://v1.0.0.$H1"
-URN1="urn:air:$H1:agents:${H1%%.*}"
+# URN label = labelized display name ("Catalog Single" → "Catalog-Single"),
+# the same derivation the ARD Finder mints from feed events.
+URN1="urn:air:$H1:agents:Catalog-Single"
 META1="https://$H1/.well-known/mcp/server-card.json"
 gen_csrs "$H1" "$ANS1"
 REQ1=$(jq -n --arg host "$H1" --arg meta "$META1" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
@@ -77,7 +79,7 @@ header "1b. GET /v2/ans/agents/$A1/catalog-entry"
 cat_req GET "/v2/ans/agents/$A1/catalog-entry"
 assert_status 200 "catalog-entry single"
 E1="$CAT_BODY"
-cassert "identifier is the urn:air lineage handle (leftmost DNS label)" "$E1" ".identifier == \"$URN1\""
+cassert "identifier is the urn:air lineage handle (labelized display name)" "$E1" ".identifier == \"$URN1\""
 cassert "mediaType is the card type for MCP"                          "$E1" '.mediaType == "application/mcp-server-card+json"'
 cassert "exactly one of url|data (single -> url)"                     "$E1" '(.url|type=="string") and (has("data")|not)'
 cassert "url is the declared metaDataUrl"                             "$E1" ".url == \"$META1\""
@@ -94,7 +96,7 @@ cassert "ANS-Registration SCITT-receipt attestation (no digest)"      "$E1" \
 header "2. Eligible multi-protocol agent (A2A + MCP) -> nested entry"
 H2="catalog-multi-$RAND.example.com"
 ANS2="ans://v1.0.0.$H2"
-URN2="urn:air:$H2:agents:${H2%%.*}"
+URN2="urn:air:$H2:agents:Catalog-Multi"
 gen_csrs "$H2" "$ANS2"
 REQ2=$(jq -n --arg host "$H2" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
   agentDisplayName: "Catalog Multi",

--- a/scripts/demo/catalog.sh
+++ b/scripts/demo/catalog.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Walk the AI Catalog generation scenarios end-to-end against a running
+# RA. Every byte is derived from the registration aggregate. A catalog
+# entry is published only AFTER the agent is ACTIVE — its SCITT-receipt
+# attestation and TL badge link to Transparency-Log records that exist only
+# once the agent is sealed at activation — so each agent is driven to ACTIVE
+# before its catalog-entry is fetched.
+#
+#   1. Eligible single-protocol (MCP + metaDataUrl), activated
+#        → GET .../catalog-entry returns the bare entry (200), with the
+#          urn:ai lineage handle, the ANS-Registration SCITT-receipt
+#          attestation, and {ansName,agentHost,badgeUrl} metadata.
+#   2. Eligible multi-protocol (A2A + MCP, both with metaDataUrl), activated
+#        → one nested outer entry (mediaType application/ai-catalog+json)
+#          whose inline data holds one lean child per protocol.
+#   3. Ineligible (HTTP-API endpoint, no catalog artifact type), activated
+#        → GET .../catalog-entry returns 422 NOT_CATALOG_ELIGIBLE.
+#   Plus: the registration 202 carries NO catalog data (it lives behind the
+#   catalog routes), and a pending agent has no catalog entry.
+#
+# Usage:
+#   scripts/demo/start.sh            # bring up ans-ra + ans-tl first
+#   scripts/demo/catalog.sh          # then run this
+#
+# Prerequisites: curl, jq, openssl (same as the other demo scripts).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+require_cmd curl
+require_cmd jq
+require_cmd openssl
+
+if ! curl -sSf "$RA_URL/v2/admin/ready" >/dev/null 2>&1; then
+  fail "ans-ra isn't reachable at $RA_URL — run scripts/demo/start.sh first"
+fi
+
+# Catalog helpers (cat_req, assert_status, cassert, cat_activate, gen_csrs)
+# live in common.sh — shared with ai-catalog.sh.
+
+RAND="$(openssl rand -hex 4)"
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 1 — eligible single-protocol (MCP)
+# ──────────────────────────────────────────────────────────────────
+header "1. Eligible single-protocol agent (MCP + metaDataUrl)"
+H1="catalog-single-$RAND.example.com"
+ANS1="ans://v1.0.0.$H1"
+URN1="urn:ai:$H1:agents:${H1%%.*}"
+META1="https://$H1/.well-known/mcp/server-card.json"
+gen_csrs "$H1" "$ANS1"
+REQ1=$(jq -n --arg host "$H1" --arg meta "$META1" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
+  agentDisplayName: "Catalog Single",
+  agentDescription: "single-protocol catalog demo",
+  version: "1.0.0",
+  agentHost: $host,
+  endpoints: [{ agentUrl: ("https://" + $host + "/mcp"), metaDataUrl: $meta, protocol: "MCP", transports: ["SSE"] }],
+  identityCsrPEM: $idc,
+  serverCsrPEM: $sc
+}')
+header "1a. POST /v2/ans/agents  (eligible single-protocol)"
+cat_req POST /v2/ans/agents "$REQ1"
+assert_status 202 "register single"
+A1=$(printf '%s' "$CAT_BODY" | jq -r '.agentId // empty')
+[ -n "$A1" ] || fail "no agentId for single-protocol agent"
+# The registration path is UNCHANGED: the 202 carries no catalog data
+# (no catalogEntry/catalogEntryReason, no catalog links). The catalog is
+# derived from existing data and lives behind its own routes (1b below).
+cassert "registration 202 carries no catalog data" "$CAT_BODY" \
+  '(has("catalogEntry")|not) and (has("catalogEntryReason")|not) and ([.links[]?.rel] | (index("catalog-entry")==null) and (index("ai-catalog")==null))'
+
+cat_activate "$A1"
+
+header "1b. GET /v2/ans/agents/$A1/catalog-entry"
+cat_req GET "/v2/ans/agents/$A1/catalog-entry"
+assert_status 200 "catalog-entry single"
+E1="$CAT_BODY"
+cassert "identifier is the urn:ai lineage handle (leftmost DNS label)" "$E1" ".identifier == \"$URN1\""
+cassert "mediaType is the card type for MCP"                          "$E1" '.mediaType == "application/mcp-server-card+json"'
+cassert "exactly one of url|data (single -> url)"                     "$E1" '(.url|type=="string") and (has("data")|not)'
+cassert "url is the declared metaDataUrl"                             "$E1" ".url == \"$META1\""
+cassert "publisher is DNS-anchored on the agentHost"                  "$E1" ".publisher.identifier == \"$H1\" and .publisher.identityType == \"dns\""
+cassert "metadata = {ansName, agentHost, badgeUrl}, no logId"         "$E1" \
+  ".metadata.ansName == \"$ANS1\" and .metadata.agentHost == \"$H1\" and .metadata.badgeUrl == \"$TL_PUBLIC_URL/v1/agents/$A1\" and (.metadata|has(\"logId\")|not)"
+cassert "trustManifest.identity equals the entry identifier"          "$E1" '.trustManifest.identity == .identifier'
+cassert "ANS-Registration SCITT-receipt attestation (no digest)"      "$E1" \
+  ".trustManifest.attestations[0].type == \"ANS-Registration\" and .trustManifest.attestations[0].mediaType == \"application/scitt-receipt+cose\" and .trustManifest.attestations[0].uri == \"$TL_PUBLIC_URL/v1/agents/$A1/receipt\" and (.trustManifest.attestations[0]|has(\"digest\")|not)"
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 2 — eligible multi-protocol (A2A + MCP) → nested entry
+# ──────────────────────────────────────────────────────────────────
+header "2. Eligible multi-protocol agent (A2A + MCP) -> nested entry"
+H2="catalog-multi-$RAND.example.com"
+ANS2="ans://v1.0.0.$H2"
+URN2="urn:ai:$H2:agents:${H2%%.*}"
+gen_csrs "$H2" "$ANS2"
+REQ2=$(jq -n --arg host "$H2" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
+  agentDisplayName: "Catalog Multi",
+  version: "1.0.0",
+  agentHost: $host,
+  endpoints: [
+    { agentUrl: ("https://" + $host + "/a2a"), metaDataUrl: ("https://" + $host + "/.well-known/agent-card.json"), protocol: "A2A" },
+    { agentUrl: ("https://" + $host + "/mcp"), metaDataUrl: ("https://" + $host + "/.well-known/mcp/server-card.json"), protocol: "MCP" }
+  ],
+  identityCsrPEM: $idc,
+  serverCsrPEM: $sc
+}')
+header "2a. POST /v2/ans/agents  (eligible multi-protocol)"
+cat_req POST /v2/ans/agents "$REQ2"
+assert_status 202 "register multi"
+A2=$(printf '%s' "$CAT_BODY" | jq -r '.agentId // empty')
+[ -n "$A2" ] || fail "no agentId for multi-protocol agent"
+
+cat_activate "$A2"
+
+header "2b. GET /v2/ans/agents/$A2/catalog-entry"
+cat_req GET "/v2/ans/agents/$A2/catalog-entry"
+assert_status 200 "catalog-entry multi"
+E2="$CAT_BODY"
+cassert "outer entry is a nested catalog (mediaType ai-catalog+json)" "$E2" '.mediaType == "application/ai-catalog+json"'
+cassert "outer entry uses data, not url"                             "$E2" '(has("url")|not) and (.data|type=="object")'
+cassert "nested catalog is specVersion 1.0 with two children"        "$E2" '.data.specVersion == "1.0" and (.data.entries|length == 2)'
+cassert "first child is the A2A leaf (id :a2a)"                      "$E2" \
+  '.data.entries[0].identifier == (.identifier + ":a2a") and .data.entries[0].mediaType == "application/a2a-agent-card+json" and (.data.entries[0].url|type=="string")'
+cassert "second child is the MCP leaf (id :mcp)"                     "$E2" \
+  '.data.entries[1].identifier == (.identifier + ":mcp") and .data.entries[1].mediaType == "application/mcp-server-card+json"'
+cassert "the trust manifest sits on the OUTER entry"                "$E2" ".trustManifest.identity == \"$URN2\""
+cassert "children stay lean (no nested trust manifest)"             "$E2" '(.data.entries[0]|has("trustManifest")|not)'
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 3 — ineligible (HTTP-API, no catalog artifact type)
+# ──────────────────────────────────────────────────────────────────
+header "3. Ineligible agent (HTTP-API endpoint -> no catalog artifact)"
+H3="catalog-none-$RAND.example.com"
+ANS3="ans://v1.0.0.$H3"
+gen_csrs "$H3" "$ANS3"
+REQ3=$(jq -n --arg host "$H3" --arg idc "$IDENTITY_CSR_PEM" --arg sc "$SERVER_CSR_PEM" '{
+  agentDisplayName: "Catalog None",
+  version: "1.0.0",
+  agentHost: $host,
+  endpoints: [{ agentUrl: ("https://" + $host + "/api"), protocol: "HTTP_API" }],
+  identityCsrPEM: $idc,
+  serverCsrPEM: $sc
+}')
+header "3a. POST /v2/ans/agents  (ineligible)"
+cat_req POST /v2/ans/agents "$REQ3"
+assert_status 202 "register ineligible"
+A3=$(printf '%s' "$CAT_BODY" | jq -r '.agentId // empty')
+[ -n "$A3" ] || fail "no agentId for ineligible agent"
+
+cat_activate "$A3"
+
+header "3b. GET /v2/ans/agents/$A3/catalog-entry  (expect 422 — ACTIVE but HTTP-API only)"
+cat_req GET "/v2/ans/agents/$A3/catalog-entry"
+assert_status 422 "catalog-entry ineligible"
+cassert "RFC 7807 problem carries code NOT_CATALOG_ELIGIBLE" "$CAT_BODY" '.code == "NOT_CATALOG_ELIGIBLE" and .status == 422'
+ok "ineligible registration correctly produces no catalog entry"
+
+# ----- summary -----
+header "AI Catalog scenarios complete"
+printf "  single (MCP)        %s  -> %s\n" "$A1" "$URN1" >&2
+printf "  multi  (A2A+MCP)    %s  -> %s (nested)\n" "$A2" "$URN2" >&2
+printf "  ineligible (HTTP)   %s  -> 422 NOT_CATALOG_ELIGIBLE\n" "$A3" >&2

--- a/scripts/demo/common.sh
+++ b/scripts/demo/common.sh
@@ -16,6 +16,16 @@
 #                                  callers can capture via $( ... ).
 #   wait_ready URL               — poll until /v2/admin/ready returns 200
 #   require_cmd CMD              — fail with a clear error if CMD is missing
+#
+# AI Catalog helpers (shared by catalog.sh + ai-catalog.sh):
+#   cat_req METHOD PATH [BODY]   — request; sets CAT_STATUS + CAT_BODY
+#   assert_status WANT LABEL     — assert the last cat_req's status
+#   cassert LABEL JSON FILTER    — assert a jq boolean filter over JSON
+#   cat_activate AGENT_ID        — verify-acme → verify-dns → ACTIVE
+#   gen_csrs HOST ANS_NAME       — emit IDENTITY_CSR_PEM + SERVER_CSR_PEM
+#   cat_doc AGENT_ID OUTFILE     — GET host-complete ai-catalog document;
+#                                  sets CAT_DOC_STATUS/CTYPE/ETAG, body→file
+#   cat_doc_inm AGENT_ID ETAG    — conditional GET; sets CAT_DOC_STATUS (304)
 
 set -euo pipefail
 
@@ -32,6 +42,11 @@ fi
 RA_URL="${RA_URL:-http://localhost:18080}"
 TL_URL="${TL_URL:-http://localhost:18081}"
 FINDER_URL="${FINDER_URL:-http://localhost:18082}"
+# The RA's externally-reachable TL base (config tl-client.public-base-url,
+# which MUST be https). The AI Catalog entry's badgeUrl + SCITT-receipt
+# attestation URI are built from this — same host:port as TL_URL in the
+# demo, https scheme. Mirrors config/defaults.go's PublicBaseURL default.
+TL_PUBLIC_URL="${TL_PUBLIC_URL:-https://localhost:18081}"
 RA_API_KEY="${RA_API_KEY:-ans-dev-key-change-me}"
 # ANS SDKs send `Authorization: sso-key <apiKey>:<apiSecret>` — the
 # reference RA's format. The demo RA accepts both `Bearer` (the
@@ -352,6 +367,139 @@ assert_tl_identity_audit() {
       "$TL_URL/v1/identities/$identity_id/audit" 2>/dev/null || true)
   done
   fail "checkpoint never covered identity $identity_id's leaves in ${timeout}s (records=${count}, with proof=${withproof:-0}; want $expected)"
+}
+
+# ──────────────────────────────────────────────────────────────────
+# AI Catalog demo helpers (shared by catalog.sh and ai-catalog.sh)
+# ──────────────────────────────────────────────────────────────────
+
+# cat_req METHOD PATH [BODY] — issue an RA request and set CAT_STATUS +
+# CAT_BODY in THIS shell. Unlike curl_json (whose LAST_HTTP_STATUS is lost
+# when the call is captured in a $(...) subshell), this keeps body and
+# status together so a caller can assert both — exactly what the catalog
+# routes' 200-vs-422 paths need.
+cat_req() {
+  local method="$1" path="$2" body="${3:-}" tmp
+  tmp=$(mktemp)
+  if [ -n "$body" ]; then
+    CAT_STATUS=$(curl -sS -X "$method" \
+      -H "Authorization: Bearer $RA_API_KEY" \
+      -H "Content-Type: application/json" \
+      --data "$body" -o "$tmp" -w '%{http_code}' "$RA_URL$path" || true)
+  else
+    CAT_STATUS=$(curl -sS -X "$method" \
+      -H "Authorization: Bearer $RA_API_KEY" \
+      -o "$tmp" -w '%{http_code}' "$RA_URL$path" || true)
+  fi
+  CAT_BODY=$(cat "$tmp")
+  rm -f "$tmp"
+  local color="$C_GREEN"
+  [ "${CAT_STATUS:-0}" -ge 400 ] && color="$C_YELLOW"
+  printf "${C_DIM}→ %s %s${C_RESET}  ${color}← %s${C_RESET}\n" "$method" "$path" "$CAT_STATUS" >&2
+  printf '%s' "$CAT_BODY" | pretty_json >&2
+}
+
+# assert_status WANT LABEL — fail unless the last cat_req returned WANT.
+assert_status() {
+  [ "${CAT_STATUS:-}" = "$1" ] || fail "$2: expected HTTP $1, got ${CAT_STATUS:-<none>}"
+}
+
+# cassert LABEL JSON JQ_FILTER — fail unless the jq boolean filter is
+# true against JSON. Keeps the per-field assertions terse and readable.
+cassert() {
+  local label="$1" json="$2" filter="$3"
+  if printf '%s' "$json" | jq -e "$filter" >/dev/null 2>&1; then
+    ok "$label"
+  else
+    printf '%s' "$json" | pretty_json >&2
+    fail "assertion failed: $label  (filter: $filter)"
+  fi
+}
+
+# cat_activate AGENT_ID — drive an agent to ACTIVE (verify-acme →
+# verify-dns). The demo's noop DNS verifier accepts any state, so both
+# steps succeed. A catalog entry exists only once the agent is ACTIVE.
+cat_activate() {
+  local id="$1"
+  cat_req POST "/v2/ans/agents/$id/verify-acme"
+  assert_status 202 "verify-acme $id"
+  cat_req POST "/v2/ans/agents/$id/verify-dns"
+  assert_status 202 "verify-dns $id"
+  ok "agent $id is ACTIVE"
+}
+
+# gen_csrs HOST ANS_NAME — generate an identity CSR (URI SAN = ANS name)
+# and a server CSR (DNS SAN = host), exporting IDENTITY_CSR_PEM and
+# SERVER_CSR_PEM. Mirrors register.sh.
+gen_csrs() {
+  local host="$1" ans="$2"
+  local dir="$DATA/csr-catalog/$host"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  cat >"$dir/identity.cnf" <<CNF
+[req]
+distinguished_name = req_dn
+req_extensions     = v3_req
+prompt             = no
+[req_dn]
+CN = $ans
+[v3_req]
+subjectAltName = URI:$ans
+CNF
+  openssl ecparam -name prime256v1 -genkey -noout -out "$dir/identity.key" 2>/dev/null
+  openssl req -new -key "$dir/identity.key" -config "$dir/identity.cnf" -out "$dir/identity.csr" 2>/dev/null
+  IDENTITY_CSR_PEM=$(cat "$dir/identity.csr")
+
+  cat >"$dir/server.cnf" <<CNF
+[req]
+distinguished_name = req_dn
+req_extensions     = v3_req
+prompt             = no
+[req_dn]
+CN = $host
+[v3_req]
+subjectAltName = DNS:$host
+CNF
+  openssl ecparam -name prime256v1 -genkey -noout -out "$dir/server.key" 2>/dev/null
+  openssl req -new -key "$dir/server.key" -config "$dir/server.cnf" -out "$dir/server.csr" 2>/dev/null
+  SERVER_CSR_PEM=$(cat "$dir/server.csr")
+}
+
+# cat_doc AGENT_ID OUTFILE — GET the host-complete AI Catalog document for
+# the host AGENT_ID belongs to, writing the body to OUTFILE and setting
+# CAT_DOC_STATUS, CAT_DOC_CTYPE, and CAT_DOC_ETAG from the response headers.
+# This is the literal ai-catalog.json an Agent-Host Provider republishes
+# verbatim at https://{agentHost}/.well-known/ai-catalog.json.
+#
+# Fetched as the authenticated owner: this RA deployment owner-scopes the
+# catalog routes (ReadOwnership), whereas IMPL §6 models them as public.
+# A public deployment would simply drop the Authorization header; every
+# document assertion below is otherwise identical.
+cat_doc() {
+  local id="$1" outfile="$2" hdr
+  hdr=$(mktemp)
+  CAT_DOC_STATUS=$(curl -sS -H "Authorization: Bearer $RA_API_KEY" \
+    -D "$hdr" -o "$outfile" -w '%{http_code}' \
+    "$RA_URL/v2/ans/agents/$id/ai-catalog" || true)
+  # Guard the grep so a missing header yields an empty var rather than
+  # tripping `set -o pipefail` (a non-200 response may omit ETag).
+  CAT_DOC_CTYPE=$({ grep -i '^content-type:' "$hdr" || true; } | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r')
+  CAT_DOC_ETAG=$({ grep -i '^etag:' "$hdr" || true; } | sed -E 's/^[Ee][Tt][Aa][Gg]:[[:space:]]*//' | tr -d '\r')
+  rm -f "$hdr"
+  local color="$C_GREEN"
+  [ "${CAT_DOC_STATUS:-0}" -ge 400 ] && color="$C_YELLOW"
+  printf "${C_DIM}→ GET /v2/ans/agents/%s/ai-catalog${C_RESET}  ${color}← %s${C_RESET}\n" "$id" "$CAT_DOC_STATUS" >&2
+}
+
+# cat_doc_inm AGENT_ID ETAG — conditional GET with If-None-Match; sets
+# CAT_DOC_STATUS (304 when the document is byte-identical to ETAG). Lets an
+# AHP poll the refresh target cheaply.
+cat_doc_inm() {
+  local id="$1" etag="$2"
+  CAT_DOC_STATUS=$(curl -sS -H "Authorization: Bearer $RA_API_KEY" \
+    -H "If-None-Match: $etag" -o /dev/null -w '%{http_code}' \
+    "$RA_URL/v2/ans/agents/$id/ai-catalog" || true)
+  printf "${C_DIM}→ GET /v2/ans/agents/%s/ai-catalog  (If-None-Match)${C_RESET}  ← %s\n" "$id" "$CAT_DOC_STATUS" >&2
 }
 
 # wait_ready URL [TIMEOUT_SECONDS]

--- a/scripts/demo/run-lifecycle-v1.sh
+++ b/scripts/demo/run-lifecycle-v1.sh
@@ -7,10 +7,10 @@
 #   2. GET    /v1/agents/{id}                                    (detail, PENDING_VALIDATION — challenges[] only, no dnsRecords yet)
 #   3. POST   /v1/agents/{id}/verify-acme                        (→ PENDING_DNS; no V1 TL emit; issues identity + server certs)
 #   4. GET    /v1/agents/{id}                                    (detail, PENDING_DNS — production dnsRecords with real TLSA fingerprint)
-#   5. POST   /v1/agents/{id}/verify-dns                         (→ ACTIVE; emits V1 AGENT_REGISTERED)
+#   5. POST   /v1/agents/{id}/verify-dns                         (→ ACTIVE; seals V1 AGENT_REGISTERED inline)
 #   6. GET    /v1/agents/{id}                                    (detail, now ACTIVE)
 #   7. GET    /v1/agents/{id}/certificates/identity              (issued cert)
-#   8. Wait for the outbox worker to push the one V1 event to the TL
+#   8. Confirm the inline-sealed V1 AGENT_REGISTERED leaf is durable in the TL
 #   9. GET    TL /v1/agents/{id}/audit                           (shape: schemaVersion=V1)
 #  10. GET    TL /v1/agents/{id}                                 (badge: schemaVersion=V1)
 #  11. POST   /v1/agents/{id}/revoke                             (emits V1 AGENT_REVOKED)
@@ -19,11 +19,15 @@
 #   - V1 emits NO TL leaf at register or verify-acme — only on
 #     verify-dns (terminal AGENT_REGISTERED) and revoke (terminal
 #     AGENT_REVOKED).
+#   - verify-dns seals AGENT_REGISTERED INLINE (seal-before-success):
+#     the RA reports ACTIVE only after the TL acknowledges the leaf.
+#     Revoke still rides the outbox worker (async terminal delivery).
 #   - Badge/audit responses carry `schemaVersion: "V1"` so SDK
 #     parsers pick the V1 envelope shape.
-#   - The TL's `/v1/internal/agents/event` ingest route receives the
-#     V1 envelopes (not `/v2/...`) because the outbox worker routes
-#     per-row by schema_version.
+#   - Both rails target the TL's `/v1/internal/agents/event` ingest
+#     route (not `/v2/...`): the inline sealer stamps schemaVersion=V1
+#     for AGENT_REGISTERED, and the outbox worker routes the
+#     AGENT_REVOKED row by its schema_version column.
 #
 # Usage:
 #   scripts/demo/run-lifecycle-v1.sh                            # random host, version 1.0.0
@@ -183,7 +187,7 @@ curl_json GET "/v1/agents/$AGENT_ID" >/dev/null
 # V1 invariant: the FIRST TL leaf V1 agents ever receive is
 # AGENT_REGISTERED, emitted exactly here. (V2 equivalent emits
 # AGENT_ACTIVE.)
-header "5. POST /v1/agents/$AGENT_ID/verify-dns  (→ ACTIVE; emits V1 AGENT_REGISTERED)"
+header "5. POST /v1/agents/$AGENT_ID/verify-dns  (→ ACTIVE; seals V1 AGENT_REGISTERED inline)"
 if [ -n "${ANS_DNS_ZONE:-}" ] && [ -x "$BIN/ans-dns" ]; then
   note "installing agent records into $ANS_DNS_ZONE via ans-dns"
   "$BIN/ans-dns" install --zone "$ANS_DNS_ZONE" --api-key "$RA_API_KEY" "$RA_URL" "$AGENT_ID"
@@ -201,15 +205,18 @@ curl_json GET "/v1/agents/$AGENT_ID" >/dev/null
 header "7. GET /v1/agents/$AGENT_ID/certificates/identity"
 curl_json GET "/v1/agents/$AGENT_ID/certificates/identity" >/dev/null
 
-# ----- 8. Wait for outbox worker -----
+# ----- 8. Confirm the inline-sealed V1 AGENT_REGISTERED leaf -----
 #
-# V1 differs from V2 here: V2 writes 3 outbox rows across a register
-# → verify-acme → verify-dns lifecycle. V1 writes ONE row — only the
-# terminal AGENT_REGISTERED on verify-dns ACTIVE. This step proves
-# the "V1 lifecycle emits exactly one leaf" invariant end-to-end.
-header "8. Wait for outbox worker to push 1 V1 event to the TL"
+# The single terminal AGENT_REGISTERED leaf is sealed INLINE at the
+# verify-dns ACTIVE transition (seal-before-success) on both lanes —
+# verify-dns above only returned ACTIVE because the TL acknowledged
+# the seal, so the leaf is already durable here. This poll is a
+# confirmation (succeeds on the first try, modulo audit-projection
+# lag), and it proves the "V1 lifecycle seals exactly one leaf"
+# invariant end-to-end: no register/verify-acme leaf, just this one.
+header "8. Confirm the inline-sealed V1 AGENT_REGISTERED leaf is durable in the TL"
 poll_tl_audit "$AGENT_ID" 1 30
-ok "TL received the single V1 AGENT_REGISTERED event"
+ok "TL has the single V1 AGENT_REGISTERED leaf (sealed inline at activation)"
 
 # ----- 9. V1 audit (schemaVersion=V1) -----
 #

--- a/scripts/demo/run-lifecycle.sh
+++ b/scripts/demo/run-lifecycle.sh
@@ -10,7 +10,7 @@
 #   6. GET    /v2/ans/agents/{id}                               (detail, now ACTIVE)
 #   7. GET    /v2/ans/agents?status=ALL                         (list mine)
 #   8. GET    /v2/ans/agents/{id}/certificates/identity         (issued cert)
-#   9. Wait for the outbox worker to push events to the TL
+#   9. Confirm the inline-sealed AGENT_REGISTERED leaf is durable in the TL
 #  10. GET    TL /v1/agents/{id}/audit                          (history)
 #  11. GET    TL /v1/agents/{id}                                (badge)
 #  12. GET    TL /root-keys                                     (verifier PEMs)
@@ -162,9 +162,10 @@ REG_REQ=$(jq -n \
     version:          $version,
     agentHost:        $host,
     endpoints: [{
-      agentUrl:   ("https://" + $host + "/mcp"),
-      protocol:   "MCP",
-      transports: ["SSE"]
+      agentUrl:    ("https://" + $host + "/mcp"),
+      metaDataUrl: ("https://" + $host + "/.well-known/mcp/server-card.json"),
+      protocol:    "MCP",
+      transports:  ["SSE"]
     }],
     identityCsrPEM: $csr,
     serverCsrPEM:   $srvCsr
@@ -254,17 +255,19 @@ curl_json GET "/v2/ans/agents?status=ALL" >/dev/null
 header "8. GET /v2/ans/agents/$AGENT_ID/certificates/identity"
 curl_json GET "/v2/ans/agents/$AGENT_ID/certificates/identity" >/dev/null
 
-# ----- 9. Wait for outbox worker -----
+# ----- 9. Confirm the inline-sealed AGENT_REGISTERED leaf -----
 #
-# The single terminal AGENT_REGISTERED event fires at verify-dns
-# ACTIVE transition — matching the reference TL and production's
-# one-leaf-per-lifecycle model. The outbox worker polls on
-# cfg.tl-client.poll-interval (default 2s) and POSTs it to the TL.
-# Wait for the leaf to show up on the audit endpoint before
-# continuing, keeping the demo deterministic without "sleep enough".
-header "9. Wait for outbox worker to push the AGENT_REGISTERED event to the TL"
+# The single terminal AGENT_REGISTERED event is sealed INLINE at the
+# verify-dns ACTIVE transition (seal-before-success): verify-dns only
+# returned ACTIVE above because the TL already acknowledged the seal,
+# so — unlike revocation, which still rides the outbox worker — the
+# leaf is durable in the log by the time we get here. This poll is a
+# confirmation, not a wait: it should succeed on the first try (the
+# audit materialized view may lag the seal by a beat, so we still poll
+# to keep the demo deterministic rather than racing the projection).
+header "9. Confirm the inline-sealed AGENT_REGISTERED leaf is durable in the TL"
 poll_tl_audit "$AGENT_ID" 1 30
-ok "TL received the AGENT_REGISTERED leaf"
+ok "TL has the AGENT_REGISTERED leaf (sealed inline at activation)"
 
 # ----- 10. TL audit -----
 header "10. TL: GET /v1/agents/$AGENT_ID/audit"
@@ -421,6 +424,76 @@ BADGE_WITH_WHO=$(curl_tl GET "/v1/agents/$AGENT_ID")
 WHO_VALUE=$(printf '%s' "$BADGE_WITH_WHO" | jq -r '.identities[0].value // empty')
 [ "$WHO_VALUE" = "$IDENTITY_DID" ] || fail "badge identities[] join missing (got: $WHO_VALUE)"
 ok "one hop answers \"who is behind this agent\": $WHO_VALUE (VERIFIED)"
+
+# ----- 20. AI Catalog entry -----
+#
+# The catalog entry is a derived, owner-scoped view of how this agent
+# appears to an external AI Catalog / ARD registry. Its trust manifest
+# points at the SAME SCITT receipt the demo fetched at step 13 — proving
+# the catalog references a real, resolvable inclusion proof, not a
+# fabricated URL. badgeUrl + the attestation URI use the RA's configured
+# public TL base ($TL_PUBLIC_URL); in this demo that is the same host:port
+# as the TL, https scheme.
+header "20. GET /v2/ans/agents/$AGENT_ID/catalog-entry  (AI Catalog record)"
+# curl_json runs in a command-substitution subshell, so its
+# LAST_HTTP_STATUS does not reach this shell — the strict jq shape
+# assertion below is the guard: a 422/error body has no matching
+# .identifier and fails it.
+CAT_ENTRY=$(curl_json GET "/v2/ans/agents/$AGENT_ID/catalog-entry")
+want_urn="urn:ai:${AGENT_HOST}:agents:${AGENT_HOST%%.*}"
+want_receipt="${TL_PUBLIC_URL}/v1/agents/${AGENT_ID}/receipt"
+want_badge="${TL_PUBLIC_URL}/v1/agents/${AGENT_ID}"
+printf '%s' "$CAT_ENTRY" | jq -e \
+  --arg urn "$want_urn" --arg rcpt "$want_receipt" --arg badge "$want_badge" '
+    .identifier == $urn
+    and .mediaType == "application/mcp-server-card+json"
+    and (.url | type) == "string"
+    and (has("data") | not)
+    and .trustManifest.identity == $urn
+    and .trustManifest.attestations[0].type == "ANS-Registration"
+    and .trustManifest.attestations[0].mediaType == "application/scitt-receipt+cose"
+    and .trustManifest.attestations[0].uri == $rcpt
+    and .metadata.agentHost == "'"$AGENT_HOST"'"
+    and .metadata.badgeUrl == $badge
+  ' >/dev/null || fail "catalog entry shape/URLs did not match expectations"
+ok "catalog entry well-formed; attestation URI = $want_receipt"
+# The catalog advertises the receipt at the path the demo already fetched
+# live over http at step 13 (same agentId, same path; https public base).
+ok "that receipt path is live on the TL (step 13 retrieved its COSE bytes → $RECEIPT_FILE)"
+
+# ----- 21. Host-complete AI Catalog document -----
+#
+# The per-host document is what the AHP publishes verbatim at
+# /.well-known/ai-catalog.json. It lists every ACTIVE catalog-eligible
+# agent on the host (this one). It is served as application/ai-catalog+json
+# with a strong ETag; a conditional re-fetch returns 304, so AHPs poll
+# cheaply. Uses curl directly (not curl_json) to read response headers.
+header "21. GET /v2/ans/agents/$AGENT_ID/ai-catalog  (host-complete AI Catalog document)"
+AICAT_HDR="$DATA/ai-catalog.hdr"
+AICAT_BODY="$DATA/ai-catalog.json"
+printf "${C_DIM}→ GET %s/v2/ans/agents/%s/ai-catalog${C_RESET}\n" "$RA_URL" "$AGENT_ID" >&2
+aicat_status=$(curl -sS -H "Authorization: Bearer $RA_API_KEY" \
+  -D "$AICAT_HDR" -o "$AICAT_BODY" -w '%{http_code}' \
+  "$RA_URL/v2/ans/agents/$AGENT_ID/ai-catalog")
+[ "$aicat_status" = "200" ] || fail "ai-catalog: expected 200, got $aicat_status"
+pretty_json <"$AICAT_BODY" >&2
+grep -iq '^content-type:[[:space:]]*application/ai-catalog+json' "$AICAT_HDR" \
+  || fail "ai-catalog: Content-Type is not application/ai-catalog+json"
+ETAG=$(grep -i '^etag:' "$AICAT_HDR" | sed -E 's/^[Ee][Tt][Aa][Gg]:[[:space:]]*//' | tr -d '\r')
+[ -n "$ETAG" ] || fail "ai-catalog: no ETag header"
+jq -e --arg urn "$want_urn" --arg host "$AGENT_HOST" '
+  .specVersion == "1.0"
+  and .host.identifier == $host
+  and .host.displayName == $host
+  and ((.entries | map(.identifier) | index($urn)) != null)
+' "$AICAT_BODY" >/dev/null || fail "ai-catalog: document shape wrong or this agent's entry missing"
+ok "host-complete document lists this ACTIVE agent (ETag $ETAG)"
+# Conditional re-fetch with the ETag → 304 Not Modified (cheap AHP poll).
+aicat_304=$(curl -sS -H "Authorization: Bearer $RA_API_KEY" \
+  -H "If-None-Match: $ETAG" -o /dev/null -w '%{http_code}' \
+  "$RA_URL/v2/ans/agents/$AGENT_ID/ai-catalog")
+[ "$aicat_304" = "304" ] || fail "ai-catalog: If-None-Match did not yield 304 (got $aicat_304)"
+ok "conditional GET (If-None-Match) returned 304 Not Modified"
 
 # ----- summary -----
 header "Lifecycle complete (both sides)"

--- a/scripts/demo/run-lifecycle.sh
+++ b/scripts/demo/run-lifecycle.sh
@@ -440,7 +440,7 @@ header "20. GET /v2/ans/agents/$AGENT_ID/catalog-entry  (AI Catalog record)"
 # assertion below is the guard: a 422/error body has no matching
 # .identifier and fails it.
 CAT_ENTRY=$(curl_json GET "/v2/ans/agents/$AGENT_ID/catalog-entry")
-want_urn="urn:ai:${AGENT_HOST}:agents:${AGENT_HOST%%.*}"
+want_urn="urn:air:${AGENT_HOST}:agents:${AGENT_HOST%%.*}"
 want_receipt="${TL_PUBLIC_URL}/v1/agents/${AGENT_ID}/receipt"
 want_badge="${TL_PUBLIC_URL}/v1/agents/${AGENT_ID}"
 printf '%s' "$CAT_ENTRY" | jq -e \

--- a/scripts/demo/run-lifecycle.sh
+++ b/scripts/demo/run-lifecycle.sh
@@ -440,7 +440,10 @@ header "20. GET /v2/ans/agents/$AGENT_ID/catalog-entry  (AI Catalog record)"
 # assertion below is the guard: a 422/error body has no matching
 # .identifier and fails it.
 CAT_ENTRY=$(curl_json GET "/v2/ans/agents/$AGENT_ID/catalog-entry")
-want_urn="urn:air:${AGENT_HOST}:agents:${AGENT_HOST%%.*}"
+# URN label = labelized display name ("demo-agent", registered in step 1) —
+# the SAME identifier the Finder surfaced in step 15, proving search and
+# the published catalog hand consumers one lineage handle.
+want_urn="urn:air:${AGENT_HOST}:agents:demo-agent"
 want_receipt="${TL_PUBLIC_URL}/v1/agents/${AGENT_ID}/receipt"
 want_badge="${TL_PUBLIC_URL}/v1/agents/${AGENT_ID}"
 printf '%s' "$CAT_ENTRY" | jq -e \

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -2134,9 +2134,9 @@ components:
           type: string
           description: |
             Stable, version-spanning lineage handle
-            `urn:ai:{agentHost}:agents:{label}`, where `{label}` is the
+            `urn:air:{agentHost}:agents:{label}`, where `{label}` is the
             leftmost DNS label of agentHost. Never the per-version agentId.
-          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+          example: urn:air:ai-agent.acmecorp.com:agents:ai-agent
         displayName:
           type: string
           maxLength: 64
@@ -2288,7 +2288,7 @@ components:
       properties:
         identity:
           type: string
-          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+          example: urn:air:ai-agent.acmecorp.com:agents:ai-agent
         attestations:
           type: array
           description: |

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -320,9 +320,9 @@ paths:
             operator; the FQDN belongs to that owner until no live
             registration remains).
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: Invalid registration request
           content:
@@ -424,21 +424,21 @@ paths:
         '401':
           description: Authentication failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '403':
           description: Authorization failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '404':
           description: Agent not found or not owned by caller
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: |
             Registration is not catalog-eligible: not ACTIVE (no
@@ -446,15 +446,15 @@ paths:
             A2A/MCP endpoint with a policy-passing metaDataUrl. `code` is
             `NOT_CATALOG_ELIGIBLE`; `detail` names the specific gate.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '500':
           description: Internal server error
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
 
   /ans/agents/{agentId}/ai-catalog:
     get:
@@ -511,27 +511,27 @@ paths:
         '401':
           description: Authentication failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '403':
           description: Authorization failed
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '404':
           description: Agent not found or not owned by caller
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '500':
           description: Internal server error
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
 
   # ──────────────────────────────────────────────────────────────────
   # Registration Validation
@@ -579,9 +579,9 @@ paths:
             live (it activated first). This registration lost the host and
             was cancelled; it can no longer progress.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: Validation failed
           content:
@@ -647,9 +647,9 @@ paths:
             window. The FQDN belongs to that owner until no live
             registration remains, so this activation is refused.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
         '422':
           description: DNS records not found or incorrect
           content:
@@ -669,9 +669,9 @@ paths:
             `PENDING_DNS` and nothing is committed; retry verify-dns once
             the TL is reachable.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/Problem'
 
   # ──────────────────────────────────────────────────────────────────
   # Revocation
@@ -2772,6 +2772,38 @@ components:
         - type
         - title
         - status
+
+    Problem:
+      type: object
+      description: |
+        RFC 7807 Problem Details — the actual error shape every RA failure
+        path emits, served as `application/problem+json`. Clients read
+        `code` for programmatic handling and `detail` for the
+        human-readable explanation.
+
+        (The legacy `ErrorResponse` schema below is retained only for the
+        pre-existing routes still declared against it; new routes point
+        here. Migrating the remaining declarations is tracked separately.)
+      properties:
+        type:
+          type: string
+          description: URI reference identifying the problem type.
+        title:
+          type: string
+          description: Short, human-readable summary of the problem type.
+        status:
+          type: integer
+          description: HTTP status code.
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+        code:
+          type: string
+          description: Stable, machine-readable error code for programmatic handling.
+      required:
+        - title
+        - status
+        - code
 
     ErrorResponse:
       type: object

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -2135,8 +2135,12 @@ components:
           description: |
             Stable, version-spanning lineage handle
             `urn:air:{agentHost}:agents:{label}`, where `{label}` is the
-            leftmost DNS label of agentHost. Never the per-version agentId.
-          example: urn:air:ai-agent.acmecorp.com:agents:ai-agent
+            agent's display name with whitespace runs collapsed to single
+            hyphens — the same derivation the ARD discovery service (the
+            Finder) mints from feed events, so search results and the
+            published catalog carry one identifier per agent. Never the
+            per-version agentId.
+          example: urn:air:ai-agent.acmecorp.com:agents:Support-Assistant
         displayName:
           type: string
           maxLength: 64

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -312,7 +312,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
-          description: Agent ID or ANSName already exists
+          description: |
+            Conflict. `code` distinguishes the cause:
+            `ANS_NAME_TAKEN` (this exact versioned ANS name is already
+            registered) or `AGENT_HOST_TAKEN` (the FQDN has a live —
+            ACTIVE or DEPRECATED — registration owned by a different
+            operator; the FQDN belongs to that owner until no live
+            registration remains).
           content:
             application/json:
               schema:
@@ -350,6 +356,158 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentDetails'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Agent not found or not owned by caller
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ──────────────────────────────────────────────────────────────────
+  # AI Catalog (producer-generated discovery artifact)
+  # ──────────────────────────────────────────────────────────────────
+  /ans/agents/{agentId}/catalog-entry:
+    get:
+      tags:
+        - Management
+      summary: Get the agent's AI Catalog entry
+      description: |
+        Returns the agent's AI Catalog `CatalogEntry` — the producer-side
+        record an external AI Catalog / ARD registry ingests. The entry is
+        derived entirely from the registration aggregate (display name,
+        version, endpoints, Transparency-Log badge/receipt URLs); nothing is
+        sealed or fetched, and it is regenerated on lifecycle events.
+
+        **Owner-scoped, read-only.** Returns 404 if the authenticated caller
+        does not own the agent (existence is hidden). This route is the
+        registrant's own view of how their agent appears in a catalog; it is
+        not the public, crawlable surface.
+
+        **Eligibility:** an entry is produced only for an **ACTIVE**
+        registration (the entry's SCITT-receipt attestation and TL badge
+        link to Transparency-Log records that exist only once the agent is
+        sealed at activation — a pending agent has nothing to link to) that
+        is versioned and has at least one A2A or MCP endpoint whose
+        `metaDataUrl` is present and passes the emit-side URL policy
+        (absolute https, no userinfo/query/fragment, host == agentHost).
+        Otherwise the route returns 422 `NOT_CATALOG_ELIGIBLE` (the `detail`
+        names the specific gate: not active, versionless, or no eligible
+        endpoint).
+      operationId: getCatalogEntry
+      parameters:
+        - $ref: '#/components/parameters/AgentIdPath'
+      responses:
+        '200':
+          description: The agent's CatalogEntry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalogEntry'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Agent not found or not owned by caller
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: |
+            Registration is not catalog-eligible: not ACTIVE (no
+            Transparency-Log entry to link to yet), versionless, or no
+            A2A/MCP endpoint with a policy-passing metaDataUrl. `code` is
+            `NOT_CATALOG_ELIGIBLE`; `detail` names the specific gate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ans/agents/{agentId}/ai-catalog:
+    get:
+      tags:
+        - Management
+      summary: Get the host-complete AI Catalog document
+      description: |
+        Returns the host-complete AI Catalog **document** for the agent's
+        host — the file an Agent Hosting Platform publishes verbatim at
+        `/.well-known/ai-catalog.json`. It contains one `CatalogEntry` for
+        every **ACTIVE**, catalog-eligible agent registered on that host
+        (deprecated and revoked registrations are pruned from the
+        well-known file; the population export keeps them, marked).
+
+        **Owner-scoped, read-only.** Returns 404 if the authenticated
+        caller does not own the agent (existence is hidden). The caller
+        proves ownership of the keying agent; the document then lists that
+        owner's ACTIVE catalog-eligible agents on the host (the body is
+        scoped to the owner, not just the route key, so a shared host never
+        discloses one owner's agents to another). This is the registrant's
+        refresh target — not a public, crawlable surface.
+
+        **Caching:** the response carries a strong `ETag` (SHA-256 of the
+        body). A conditional request with a matching `If-None-Match`
+        receives `304 Not Modified`.
+      operationId: getHostCatalog
+      parameters:
+        - $ref: '#/components/parameters/AgentIdPath'
+      responses:
+        '200':
+          description: The host-complete AI Catalog document
+          headers:
+            ETag:
+              description: Strong validator (SHA-256 of the document body)
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
+          content:
+            application/ai-catalog+json:
+              schema:
+                $ref: '#/components/schemas/CatalogDocument'
+        '304':
+          description: Not modified (If-None-Match matched the current ETag)
+          headers:
+            ETag:
+              description: Strong validator (SHA-256 of the document body)
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
         '401':
           description: Authentication failed
           content:
@@ -415,6 +573,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            `AGENT_HOST_TAKEN` — a different operator now holds this FQDN
+            live (it activated first). This registration lost the host and
+            was cancelled; it can no longer progress.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation failed
           content:
@@ -436,12 +603,21 @@ paths:
       description: |
         Verifies that all required DNS records have been configured correctly.
         This is the final step for external domain registration.
+
+        **Seal-before-success:** activation does not report `ACTIVE` until
+        the agent's single terminal `AGENT_REGISTERED` event has been
+        sealed in the Transparency Log. The RA submits the event to the TL
+        INLINE and only then commits the ACTIVE transition; if the TL is
+        unavailable the call fails 503 `TL_UNAVAILABLE` (retryable — the
+        agent stays `PENDING_DNS` and nothing is committed). This is what
+        guarantees a catalog entry's SCITT-receipt and badge links can only
+        ever point at a TL record that actually exists.
       operationId: verifyDnsRecords
       parameters:
         - $ref: '#/components/parameters/AgentIdPath'
       responses:
         '202':
-          description: DNS verified, registration active
+          description: DNS verified and AGENT_REGISTERED sealed in the TL; registration active
           content:
             application/json:
               schema:
@@ -464,6 +640,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            `AGENT_HOST_TAKEN` — a different operator activated a
+            registration on this FQDN during this registration's pending
+            window. The FQDN belongs to that owner until no live
+            registration remains, so this activation is refused.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: DNS records not found or incorrect
           content:
@@ -472,6 +658,16 @@ paths:
                 $ref: '#/components/schemas/DnsVerificationError'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: |
+            `TL_UNAVAILABLE` — the Transparency Log could not seal the
+            `AGENT_REGISTERED` event. Retryable: the agent stays
+            `PENDING_DNS` and nothing is committed; retry verify-dns once
+            the TL is reachable.
           content:
             application/json:
               schema:
@@ -1921,6 +2117,210 @@ components:
         - status
         - ansName
         - nextSteps
+
+    # ── AI Catalog (producer-generated discovery artifact) ──────────
+    CatalogEntry:
+      type: object
+      description: |
+        One artifact's AI Catalog record, derived from a registration (AI
+        Catalog draft 2026-06-11 §4.4). A bare entry is served as
+        application/json — it is not itself a catalog document and carries no
+        `specVersion`. Exactly one of `url` or `data` is present: a
+        single-protocol entry carries `url`; a multi-protocol agent carries
+        `data` (an inline nested catalog of per-protocol children) with
+        `mediaType` `application/ai-catalog+json`.
+      properties:
+        identifier:
+          type: string
+          description: |
+            Stable, version-spanning lineage handle
+            `urn:ai:{agentHost}:agents:{label}`, where `{label}` is the
+            leftmost DNS label of agentHost. Never the per-version agentId.
+          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+        displayName:
+          type: string
+          maxLength: 64
+        description:
+          type: string
+          maxLength: 150
+        version:
+          type: string
+          example: 2.1.0
+        mediaType:
+          type: string
+          description: |
+            Artifact discriminator: `application/a2a-agent-card+json`,
+            `application/mcp-server-card+json`, or
+            `application/ai-catalog+json` for a multi-protocol nested entry.
+          example: application/a2a-agent-card+json
+        url:
+          type: string
+          format: uri
+          description: |
+            The endpoint's metaDataUrl (the protocol card location). Present
+            on a single-protocol or nested-child entry. Mutually exclusive
+            with `data`.
+        data:
+          allOf:
+            - $ref: '#/components/schemas/CatalogNested'
+          description: |
+            Inline nested catalog of per-protocol children, present only on a
+            multi-protocol outer entry. Mutually exclusive with `url`.
+        tags:
+          type: array
+          items:
+            type: string
+        updatedAt:
+          type: string
+          format: date-time
+        publisher:
+          $ref: '#/components/schemas/CatalogPublisher'
+        metadata:
+          $ref: '#/components/schemas/CatalogEntryMetadata'
+        trustManifest:
+          $ref: '#/components/schemas/CatalogTrustManifest'
+      required:
+        - identifier
+        - displayName
+        - mediaType
+
+    CatalogNested:
+      type: object
+      description: |
+        Inline nested catalog held in a multi-protocol entry's `data` (AI
+        Catalog §6.1 / IMPL §3.5).
+      properties:
+        specVersion:
+          type: string
+          example: "1.0"
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogEntry'
+      required:
+        - specVersion
+        - entries
+
+    CatalogDocument:
+      type: object
+      description: |
+        A host-complete AI Catalog document (AI Catalog §4.2), served as
+        application/ai-catalog+json. The file an AHP publishes at
+        `/.well-known/ai-catalog.json`; `entries` carries one CatalogEntry
+        per ACTIVE, catalog-eligible agent on the host (sorted by
+        identifier then version for a stable ETag).
+      properties:
+        specVersion:
+          type: string
+          example: "1.0"
+        host:
+          $ref: '#/components/schemas/CatalogHostInfo'
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogEntry'
+      required:
+        - specVersion
+        - entries
+
+    CatalogHostInfo:
+      type: object
+      description: |
+        Host Info object (AI Catalog §4.3) identifying the operator of a
+        catalog document. `displayName` is required within Host Info; for a
+        per-host document both fields are the agentHost.
+      properties:
+        identifier:
+          type: string
+          example: ai-agent.acmecorp.com
+        displayName:
+          type: string
+          example: ai-agent.acmecorp.com
+      required:
+        - displayName
+
+    CatalogPublisher:
+      type: object
+      description: |
+        Publishing entity (AI Catalog §4.6). DNS-anchored in this RA;
+        `identifier` and `displayName` are both the agentHost.
+      properties:
+        identifier:
+          type: string
+          example: ai-agent.acmecorp.com
+        displayName:
+          type: string
+          example: ai-agent.acmecorp.com
+        identityType:
+          type: string
+          example: dns
+      required:
+        - identifier
+        - displayName
+
+    CatalogEntryMetadata:
+      type: object
+      description: |
+        Entry-level identifiers a consumer verifies against (IMPL §5.3). No
+        `logId` — the TL is keyed by agentId, not logId.
+      properties:
+        ansName:
+          type: string
+          example: ans://v2.1.0.ai-agent.acmecorp.com
+        agentHost:
+          type: string
+          example: ai-agent.acmecorp.com
+        badgeUrl:
+          type: string
+          format: uri
+          description: |
+            TL status / card-integrity surface (`<tl>/v1/agents/{agentId}`).
+            Omitted when no TL base URL is configured.
+      required:
+        - ansName
+        - agentHost
+
+    CatalogTrustManifest:
+      type: object
+      description: |
+        Verifiable identity + trust metadata (AI Catalog §5). `identity`
+        MUST equal the containing entry's `identifier`.
+      properties:
+        identity:
+          type: string
+          example: urn:ai:ai-agent.acmecorp.com:agents:ai-agent
+        attestations:
+          type: array
+          description: |
+            Present only when a TL base URL is configured. The slice-1
+            attestation is the ANS-Registration SCITT receipt.
+          items:
+            $ref: '#/components/schemas/CatalogAttestation'
+      required:
+        - identity
+
+    CatalogAttestation:
+      type: object
+      description: |
+        A verifiable claim (AI Catalog §5.4). The ANS-Registration
+        attestation points at the agent's SCITT receipt on the Transparency
+        Log; it carries no digest (the receipt proves inclusion, not entry
+        content).
+      properties:
+        type:
+          type: string
+          example: ANS-Registration
+        uri:
+          type: string
+          format: uri
+          example: https://tl.example.org/v1/agents/550e8400-e29b-41d4-a716-446655440000/receipt
+        mediaType:
+          type: string
+          example: application/scitt-receipt+cose
+      required:
+        - type
+        - uri
+        - mediaType
 
     NextStep:
       type: object


### PR DESCRIPTION
## Summary

Adds producer-side **AI Catalog** artifact generation to the RA, plus the two invariants it depends on. Every byte is derived from the registration aggregate — nothing crawled, nothing fetched — and **the registration request and 202 response are untouched**.

## What's in this PR

### 1. AI Catalog generation (IMPL slices 1–2)
- **`internal/catalog`** (pure, no I/O): the per-agent `CatalogEntry` and the host-complete `ai-catalog.json` document. Eligibility gates (versioned, ACTIVE, an A2A/MCP endpoint with a policy-passing `metaDataUrl`), single vs nested entries, leftmost-DNS-label URN, `Cc`/`Cf` text sanitization, and an emitted-URL policy (absolute `https`, `host == agentHost`, no userinfo/query/fragment).
- **Routes** (owner-scoped via `ReadOwnership`):
  - `GET /v2/ans/agents/{agentId}/catalog-entry` — the bare entry (`application/json`).
  - `GET /v2/ans/agents/{agentId}/ai-catalog` — the **host-complete document** (`application/ai-catalog+json`) with a strong ETag + `If-None-Match`/304. This is the literal `ai-catalog.json` an Agent-Host Provider republishes at `https://{agentHost}/.well-known/ai-catalog.json`.
- `spec/api-spec-v2.yaml` and the embedded docsui copy updated.

### 2. FQDN exclusivity (one-host-one-owner)
Once a registration is live (ACTIVE/DEPRECATED) on an FQDN, a different owner may not register or activate on it — checked at register, verify-acme, and verify-dns. On activation the winner cancels losing pending registrations (no TL event, ANS-1 §4.4).

### 3. Seal-before-success activation (ANS-1 §12.3)
`verify-dns` seals the single terminal `AGENT_REGISTERED` event **inline** and reports ACTIVE only after the TL acknowledges. A failing or unconfigured sealer **fails closed**: `503 TL_UNAVAILABLE`, the agent stays `PENDING_DNS`, nothing is committed, no outbox row. Revocation still rides the outbox. This is what guarantees a catalogued agent's SCITT-receipt and badge links point at TL records that actually exist.

## The `ai-catalog.json` (the deliverable)

`scripts/demo/ai-catalog.sh` builds one host with a mixed population and saves the validated document to `data/demo/ai-catalog.json`:

| agent | status | in document |
|---|---|---|
| v1.0.0 MCP + metaDataUrl | ACTIVE, eligible | ✅ |
| v2.0.0 A2A + metaDataUrl | ACTIVE, eligible | ✅ |
| v3.0.0 HTTP-API (no card) | ACTIVE, ineligible | ❌ |
| v4.0.0 MCP | PENDING | ❌ |
| eligible agent on a different host | ACTIVE | ❌ |

It asserts host-completeness, the host object, sorted-by-version, per-card `mediaType`, the agent-scoped alias (byte-identical via any agentId), a deterministic ETag, and 304.

## Quality gates
- `make check` green at **90.2%** coverage (`internal/catalog` at 100%); `go test -race` clean on the affected packages.
- Demos pass end-to-end: `run-lifecycle.sh` (V2), `run-lifecycle-v1.sh` (V1), `catalog.sh` (per-agent entry), `ai-catalog.sh` (host document).
- Pre-push **adversarial review** across five dimensions (shape/contract, correctness, security, quality-bar, tests) with each finding independently verified; confirmed findings addressed in this PR (mostly comment/test accuracy), refuted findings documented.

## Known limitations / follow-ups
- **FQDN exclusivity is best-effort under concurrency.** Two different owners each holding a `PENDING_DNS` registration on the same FQDN can race `verify-dns` and both reach ACTIVE (the check runs before the inline seal and outside the activation tx). An in-tx re-check would trade this for a sealed-but-not-activated orphan under seal-before-success, so the proper fix is a **pre-seal host claim** (mirroring the identity lane's nonce claim) — deferred. Documented in `preflightRegistrationConflicts`. The owner-scoped catalog read contains the blast radius.
- **Public discovery route not built.** IMPL §6 models the catalog routes as *public/unauthenticated*; per an earlier maintainer call these are **owner-scoped behind auth**. The genuinely public host-discovery route `GET /v2/ans/catalog?agentHost=` (IMPL slice 3) is unbuilt — that's the surface an AHP fetches without owner credentials.
- Catalog `updatedAt` uses registration/last-renewal time as a documented proxy for the spec's "activation/latest seal timestamp" (the RA persists no activation timestamp; the field is optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)