### PR TITLE
fix(release): let GoReleaser infer the GitHub owner/name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -129,6 +129,8 @@ changelog:
 
 release:
   mode: append
-  github:
-    owner: godaddy
-    name: ans
+  # owner/name are intentionally omitted: GoReleaser infers them from the CI
+  # environment / git remote, so releases keep working across org renames and
+  # transfers. The hardcoded `github.owner: godaddy` is what broke the v0.1.6
+  # release after the repo moved to the agentnameservice org (asset uploads to
+  # the old owner path got 307 redirects GoReleaser cannot follow).


### PR DESCRIPTION
## Problem

Binary publishing has been broken since the repo moved from the `godaddy` org to `agentnameservice`. The v0.1.6 release ([run 28267836069](https://github.com/agentnameservice/ans/actions/runs/28267836069)) built everything, then every asset upload failed:

```
• releasing  tag=v0.1.6  repo=godaddy/ans
• upload failed  error=POST https://uploads.github.com/repos/godaddy/ans/releases/345549247/assets?name=ans_0.1.6_linux_amd64.tar.gz: 307 location <nil>
```

`.goreleaser.yaml` hardcodes `release.github.owner: godaddy` from before the transfer. GoReleaser still *finds* the release through GitHub's rename redirect, but the `uploads.github.com` POSTs to the old owner path return 307 redirects the client cannot follow with a file body. So v0.1.3–v0.1.5 (published pre-move) have binaries; v0.1.6 has none.

The same stale config was copied into `agent-trust-discovery`, where it broke that repo's v0.1.1 release as a hard 404 (no redirect there since `godaddy/agent-trust-discovery` never existed) — fixed in agentnameservice/agent-trust-discovery#4.

## Fix

Drop the `release.github:` block entirely. When omitted, GoReleaser infers owner/name from the CI environment / git remote, so releases keep working across org renames and transfers instead of recreating this trap with a new hardcoded owner. `release.mode: append` is kept — release-please still owns the release body; GoReleaser only attaches artifacts.

## Recovery

Re-running the failed v0.1.6 job cannot pick this up (the goreleaser job checks out the tag, whose config is frozen). This lands as a `fix:` commit so release-please cuts v0.1.7, which will publish binaries normally. v0.1.6 stays source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)