### PR TITLE
build(deps): group Dependabot minor/patch updates into weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     open-pull-requests-limit: 5
     groups:
       actions-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,18 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     open-pull-requests-limit: 5
     groups:
       go-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

- Add `groups` to both Dependabot ecosystems (`gomod` and `github-actions`) so minor and patch bumps arrive as one consolidated PR per ecosystem per weekly run, instead of one PR per dependency.
- Major version updates intentionally remain individual PRs so breaking changes get isolated review — relevant given the byte-for-byte wire contracts this repo maintains.
- Schedule was already `weekly` for both ecosystems; this change only adds grouping.

## Notes

- On the first run after merge, Dependabot will close any currently open per-dependency PRs and re-open them as grouped PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)