### PR TITLE
fix(ra): emit v-prefixed ANSName version segment in TXT version= values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,12 @@ verify-dns flow without touching real DNS infrastructure.
   plus `dnsRecordsProvisioned[]` as typed `{name, data, type}`
   records. This distinguishes ephemeral ACME challenge records
   (never attested) from production-state records (always attested).
-- **TXT-record version format**: bare semver (`1.0.0`) in TXT record
-  values. The `v`-prefixed form only lives inside the ANS name's
-  hostname label (`ans://v1.0.0.agent.example.com`).
+- **TXT-record version format**: the `version=` value in the
+  `_ans`/`_ans-badge` TXT records carries the v-prefixed ANSName
+  version segment (`v1.0.0`) — the same segment that leads the ANS
+  name's hostname label (`ans://v1.0.0.agent.example.com`). Per
+  ANS-3 §6.3 and the `ans-txt` profile §2 (v0.2.0 spec set); the
+  single construction site is `domain.AnsName.VersionSegment()`.
 - **Leaf hash**: RFC 6962 `SHA-256(0x00 || canonicalEvent)` over the
   JCS-canonical inner-event bytes — same bytes the RA signed.
 

--- a/internal/adapter/discovery/ans/ansbadge.go
+++ b/internal/adapter/discovery/ans/ansbadge.go
@@ -30,7 +30,10 @@ func BadgeRecord(reg *domain.AgentRegistration, tlPublicBaseURL string) []domain
 	if len(reg.Endpoints) == 0 {
 		return nil
 	}
-	version := reg.AnsName.Version().String()
+	// version= carries the v-prefixed ANSName version segment (ANS-3
+	// §6.3), matching the leading label of the ANS name — not the bare
+	// semver.
+	version := reg.AnsName.VersionSegment()
 	badgeURL := reg.Endpoints[0].AgentURL
 	if tlPublicBaseURL != "" && reg.AgentID != "" {
 		// tlPublicBaseURL is validated at config load (https, no

--- a/internal/adapter/discovery/ans/ansbadge_test.go
+++ b/internal/adapter/discovery/ans/ansbadge_test.go
@@ -39,7 +39,7 @@ func TestBadgeRecord(t *testing.T) {
 				{Protocol: domain.ProtocolA2A, AgentURL: "https://agent.example.com/a2a"},
 			}),
 			wantName:  "_ans-badge.agent.example.com",
-			wantValue: "v=ans-badge1; version=1.2.3; url=https://agent.example.com/a2a",
+			wantValue: "v=ans-badge1; version=v1.2.3; url=https://agent.example.com/a2a",
 		},
 		{
 			name: "multiple_endpoints_badge_uses_first_url",
@@ -48,7 +48,7 @@ func TestBadgeRecord(t *testing.T) {
 				{Protocol: domain.ProtocolA2A, AgentURL: "https://agent.example.com/a2a"},
 			}),
 			wantName:  "_ans-badge.agent.example.com",
-			wantValue: "v=ans-badge1; version=2.0.0; url=https://agent.example.com/mcp",
+			wantValue: "v=ans-badge1; version=v2.0.0; url=https://agent.example.com/mcp",
 		},
 		{
 			// When the deployment supplies a public TL URL and the
@@ -62,7 +62,7 @@ func TestBadgeRecord(t *testing.T) {
 			agentID:   "test-agent-id",
 			tlBaseURL: "https://tl.example.org",
 			wantName:  "_ans-badge.agent.example.com",
-			wantValue: "v=ans-badge1; version=1.0.0; url=https://tl.example.org/v1/agents/test-agent-id",
+			wantValue: "v=ans-badge1; version=v1.0.0; url=https://tl.example.org/v1/agents/test-agent-id",
 		},
 		{
 			// Fallback: a TL URL is set but the registration has no AgentID,
@@ -74,7 +74,7 @@ func TestBadgeRecord(t *testing.T) {
 			}),
 			tlBaseURL: "https://tl.example.org",
 			wantName:  "_ans-badge.agent.example.com",
-			wantValue: "v=ans-badge1; version=1.0.0; url=https://agent.example.com/mcp",
+			wantValue: "v=ans-badge1; version=v1.0.0; url=https://agent.example.com/mcp",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/adapter/discovery/ans/txt.go
+++ b/internal/adapter/discovery/ans/txt.go
@@ -47,7 +47,10 @@ func (TXTProfile) ID() domain.DiscoveryProfile { return domain.DiscoveryProfileA
 // records.
 func (s TXTProfile) Records(reg *domain.AgentRegistration) []domain.ExpectedDNSRecord {
 	fqdn := reg.FQDN()
-	version := reg.AnsName.Version().String()
+	// version= carries the v-prefixed ANSName version segment (ANS-3
+	// §6.3, ans-txt profile §2), matching the leading label of the ANS
+	// name — not the bare semver.
+	version := reg.AnsName.VersionSegment()
 	var records []domain.ExpectedDNSRecord
 	for _, ep := range reg.Endpoints {
 		value := fmt.Sprintf("v=ans1; version=%s; p=%s; mode=direct; url=%s",

--- a/internal/adapter/discovery/ans/txt_test.go
+++ b/internal/adapter/discovery/ans/txt_test.go
@@ -33,12 +33,14 @@ func TestTXTProfile_Records(t *testing.T) {
 			wantHTTPS:   true,
 			wantInValue: []string{
 				"v=ans1",
-				"version=1.0.0",
+				"version=v1.0.0",
 				"p=a2a",
 				"mode=direct",
 				"url=https://agent.example.com/a2a",
 			},
-			wantNotIn: []string{"v1.0.0", "1-0-0"},
+			// version= must carry the v-prefixed ANSName segment
+			// (ANS-3 §6.3), never the bare semver or a mangled form.
+			wantNotIn: []string{"version=1.0.0", "1-0-0"},
 		},
 		{
 			name: "two_endpoints_emit_two_ans_txt_rows_one_https_rr",

--- a/internal/domain/ansname.go
+++ b/internal/domain/ansname.go
@@ -95,6 +95,12 @@ func ParseAnsName(s string) (AnsName, error) {
 // Version returns the semantic version component.
 func (n AnsName) Version() SimplifiedSemVer { return n.version }
 
+// VersionSegment returns the ANS-2 version segment: the v-prefixed
+// semver form ("v1.2.0") that appears as the leading hostname label of
+// the ANS name and as the `version=` value in the `_ans`/`_ans-badge`
+// TXT records (ANS-3 §6.3, ans-txt profile §2).
+func (n AnsName) VersionSegment() string { return "v" + n.version.String() }
+
 // AgentHost returns the FQDN component (lowercase).
 func (n AnsName) AgentHost() string { return n.agentHost }
 
@@ -103,7 +109,7 @@ func (n AnsName) FQDN() string { return n.agentHost }
 
 // String returns the full ANS name: ans://v1.2.0.myagent.example.com.
 func (n AnsName) String() string {
-	return fmt.Sprintf("%sv%s.%s", ansProtocolPrefix, n.version.String(), n.agentHost)
+	return fmt.Sprintf("%s%s.%s", ansProtocolPrefix, n.VersionSegment(), n.agentHost)
 }
 
 // IsZero returns true if the AnsName is uninitialized.

--- a/internal/domain/ansname_test.go
+++ b/internal/domain/ansname_test.go
@@ -128,6 +128,14 @@ func TestAnsName_String(t *testing.T) {
 	assert.Equal(t, "ans://v1.2.3.agent.example.com", n.String())
 }
 
+// TestAnsName_VersionSegment pins the ANS-2 v-prefixed segment form —
+// the value TXT builders publish in `version=` and the leading label
+// of the ANS name hostname.
+func TestAnsName_VersionSegment(t *testing.T) {
+	n, _ := NewAnsName(mustSemVer(1, 2, 3), "agent.example.com")
+	assert.Equal(t, "v1.2.3", n.VersionSegment())
+}
+
 func TestAnsName_FQDN(t *testing.T) {
 	n, _ := NewAnsName(mustSemVer(1, 2, 3), "Agent.Example.COM")
 	assert.Equal(t, "agent.example.com", n.FQDN())

--- a/internal/ra/service/dnsrecords_test.go
+++ b/internal/ra/service/dnsrecords_test.go
@@ -402,12 +402,17 @@ func TestComputeRequiredDNSRecords_UnknownStyleSkipped(t *testing.T) {
 // path) — replacing the old key65280/key65281 set. The fixture endpoints
 // carry a /.well-known/ metadataUrl so cap and well-known are exercised
 // here at the service-composition layer, not only in the adapter unit
-// tests. The slice ORDER and the 7-record SHAPE are unchanged; only the
-// SVCB SvcParam values move the hash. A future drift that is NOT a
-// deliberate SvcParam change is a regression: investigate before
-// touching this constant.
+// tests.
+//
+// REGENERATED again for the ANS-3 §6.3 version= fix (issue #69): the
+// three TXT rows in the union (two `_ans` + one `_ans-badge`) now
+// carry the v-prefixed ANSName version segment (`version=v1.2.3`)
+// instead of the bare semver. The slice ORDER and the 7-record SHAPE
+// are unchanged; only those three TXT values move the hash. A future
+// drift that is NOT a deliberate wire-value change is a regression:
+// investigate before touching this constant.
 func TestComputeRequiredDNSRecords_UnionCanonicalBytesRegression(t *testing.T) {
-	const wantSHA256Hex = "87b2902c6f1114029f888ed7ffe798ef1937f44e30add8fd2d5b8874d4c427c1"
+	const wantSHA256Hex = "2f7b7aefc0032e0900ae446595c503b853c45738e8ae717c3b2ba74c3edf3286"
 
 	svc := newComputeOnlyService(t)
 	reg := mustReg(t, "agent.example.com", "1.2.3",


### PR DESCRIPTION
## Summary

Fixes #69.

The `_ans` discovery and `_ans-badge` trust TXT builders interpolated the bare semver (`version=1.0.0`) into the `version=` field. The v0.2.0 spec set (ANS-3 §6.3, the `ans-txt` profile §2, the `ans-dnsaid` worked example, and the A.1 fixture — agentnameservice/ans-registry#32) settled the contract as the v-prefixed ANSName version segment (`version=v1.0.0`), the same segment that leads the ANS name's hostname label. Spec review confirmed the bare-semver emission here is the implementation bug.

## Changes

- **`internal/domain/ansname.go`** — new `AnsName.VersionSegment()` accessor returning the ANS-2 v-prefixed segment (`v1.2.3`). This is now the single construction site for the v-prefix; `AnsName.String()` is refactored onto it. New unit test keeps `internal/domain` at 100% statement coverage.
- **`internal/adapter/discovery/ans/txt.go`** and **`ansbadge.go`** — both builders emit `version=` from `VersionSegment()`.
- **`txt_test.go`** / **`ansbadge_test.go`** — pins updated to the v-prefixed form; `txt_test.go`'s `wantNotIn` now guards against the bare form (`version=1.0.0`) as the regression.
- **`internal/ra/service/dnsrecords_test.go`** — the V2 union canonical-bytes golden hash tripped as designed and was regenerated (`87b2902c…` → `2f7b7aef…`). Verified: only the three TXT `version=` values in the fixture union move the hash; slice order and the 7-record shape are unchanged. The constant's comment changelog records the drift.
- **`CLAUDE.md`** — the Wire-format choices bullet documented the old bare-semver contract; updated to the v-prefixed one.

## Shape diff (pre-implementation check)

Canonical contract, ANS-3 §6.3 / `ans-txt` profile §2 (v0.2.0 spec set, agentnameservice/ans-registry#32):

```
v=ans1; version=v1.0.0; p=a2a; mode=direct; url=https://…
v=ans-badge1; version=v1.0.0; url=https://…
```

Field-level diff vs. previous emission: **`version=` only** — `1.0.0` → `v1.0.0`. No other field, record name, type, TTL, Required flag, or record ordering changes.

## Rollout note

verify-dns compares live DNS against these same builders, so emission and verification stay self-consistent within this change. Records **already published** with the bare form will mismatch on later re-verification until re-published. The issue leaves dual-accept-at-verification vs. coordinated re-publish as an open rollout decision; this PR implements the scoped fix only. The Go verifier SDK's parser already tolerates both forms, so SDK-side parsing is unaffected.

## Verification

- `make check` passes (fmt, vet, golangci-lint, test-cover): total coverage 90.4%, `internal/domain` at 100.0%.
- Golden-hash baseline re-run on the unmodified tree confirmed the drift is attributable solely to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)