### PR TITLE
fix(tl): generate logId as UUIDv7 as documented

### DIFF
--- a/internal/tl/service/log.go
+++ b/internal/tl/service/log.go
@@ -51,7 +51,7 @@ type LogService struct {
 	attestKeyID string
 	originRAID  string // RAID stamped into the TL's attestation JWS header.
 	nowFn       func() time.Time
-	uuidFn      func() string
+	uuidFn      func() (string, error)
 
 	// shutdownCtx is cancelled when Close is called; the per-append
 	// awaiter goroutines watch it so they drain cleanly at shutdown
@@ -112,7 +112,15 @@ func NewLogService(
 		attestKeyID:    attestKeyID,
 		originRAID:     originRAID,
 		nowFn:          func() time.Time { return time.Now().UTC() },
-		uuidFn:         uuid.NewString,
+		// UUIDv7: time-ordered, per the logId contract in the TL API
+		// spec and the served event schemas.
+		uuidFn: func() (string, error) {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return "", err
+			}
+			return id.String(), nil
+		},
 	}
 }
 
@@ -121,7 +129,7 @@ func NewLogService(
 func (s *LogService) WithClock(fn func() time.Time) { s.nowFn = fn }
 
 // WithUUIDFn overrides the logId generator (for tests).
-func (s *LogService) WithUUIDFn(fn func() string) { s.uuidFn = fn }
+func (s *LogService) WithUUIDFn(fn func() (string, error)) { s.uuidFn = fn }
 
 // AppendV2 ingests a V2-schema producer event. Wired to the
 // `POST /v2/internal/agents/event` route. The RA's V2 routes
@@ -164,7 +172,10 @@ func (s *LogService) append(ctx context.Context, in AppendInput, codec envelopeC
 	// 2. Codec parses/validates/canonicalizes/wraps per schema version.
 	//    The returned envelope has an empty outer Signature; we sign
 	//    it in step 4.
-	logID := s.uuidFn()
+	logID, err := s.uuidFn()
+	if err != nil {
+		return nil, fmt.Errorf("generate logId: %w", err)
+	}
 	env, innerCanonical, err := codec.ParseAndBuild(in.RawBody, raID, keyID, in.ProducerSignature, logID)
 	if err != nil {
 		return nil, err

--- a/internal/tl/service/log_more_test.go
+++ b/internal/tl/service/log_more_test.go
@@ -2,8 +2,14 @@ package service_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/godaddy/ans/internal/tl/service"
 )
 
 // TestLogService_GettersAndOverrides covers the trivial accessor +
@@ -35,5 +41,51 @@ func TestLogService_GettersAndOverrides(t *testing.T) {
 	// Override the clock and uuid generator — pure setters, the
 	// behavioural effect is exercised in receipt_test.
 	tb.logSvc.WithClock(func() time.Time { return time.Unix(1700000000, 0).UTC() })
-	tb.logSvc.WithUUIDFn(func() string { return "fixed-uuid" })
+	tb.logSvc.WithUUIDFn(func() (string, error) { return "fixed-uuid", nil })
+}
+
+// TestAppend_LogIDIsUUIDv7 pins the default logId generator to
+// version 7. The TL API spec and the served event schemas document
+// logId as a "UUIDv7 assigned on first append"; the golden fixtures
+// inject their ids through WithUUIDFn, so only a test that exercises
+// the real default can catch the generator drifting to another
+// version (issue #58).
+func TestAppend_LogIDIsUUIDv7(t *testing.T) {
+	tb := newReceiptTestbed(t)
+	body, jws := tb.signedFixtureBody(t)
+
+	res, err := tb.logSvc.AppendV2(context.Background(), service.AppendInput{
+		RawBody:           body,
+		ProducerSignature: jws,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := uuid.Parse(res.LogID)
+	if err != nil {
+		t.Fatalf("LogID %q is not a UUID: %v", res.LogID, err)
+	}
+	if id.Version() != 7 {
+		t.Errorf("LogID %q: got UUID version %d, want 7", res.LogID, id.Version())
+	}
+}
+
+// TestAppend_UUIDFnError covers the logId-generator failure path:
+// append must fail closed before anything reaches the log rather
+// than minting an envelope with an empty logId.
+func TestAppend_UUIDFnError(t *testing.T) {
+	tb := newReceiptTestbed(t)
+	tb.logSvc.WithUUIDFn(func() (string, error) { return "", errors.New("entropy exhausted") })
+	body, jws := tb.signedFixtureBody(t)
+
+	_, err := tb.logSvc.AppendV2(context.Background(), service.AppendInput{
+		RawBody:           body,
+		ProducerSignature: jws,
+	})
+	if err == nil {
+		t.Fatal("Append with failing uuidFn: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "generate logId") {
+		t.Errorf("error %q: want mention of generate logId", err)
+	}
 }

--- a/internal/tl/service/log_more_test.go
+++ b/internal/tl/service/log_more_test.go
@@ -75,7 +75,8 @@ func TestAppend_LogIDIsUUIDv7(t *testing.T) {
 // than minting an envelope with an empty logId.
 func TestAppend_UUIDFnError(t *testing.T) {
 	tb := newReceiptTestbed(t)
-	tb.logSvc.WithUUIDFn(func() (string, error) { return "", errors.New("entropy exhausted") })
+	genErr := errors.New("entropy exhausted")
+	tb.logSvc.WithUUIDFn(func() (string, error) { return "", genErr })
 	body, jws := tb.signedFixtureBody(t)
 
 	_, err := tb.logSvc.AppendV2(context.Background(), service.AppendInput{
@@ -84,6 +85,11 @@ func TestAppend_UUIDFnError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Append with failing uuidFn: expected error, got nil")
+	}
+	// The %w chain is the programmatic contract; the message check
+	// pins the human-readable context the wrap adds.
+	if !errors.Is(err, genErr) {
+		t.Errorf("error %q: want errors.Is match for the generator error", err)
 	}
 	if !strings.Contains(err.Error(), "generate logId") {
 		t.Errorf("error %q: want mention of generate logId", err)

--- a/internal/tl/service/receipt_test.go
+++ b/internal/tl/service/receipt_test.go
@@ -279,6 +279,21 @@ func newReceiptTestbed(t *testing.T, opts ...receiptTestbedOpt) *receiptTestbed 
 // mimicking what the HTTP handler does with a signed body.
 func (tb *receiptTestbed) appendEvent(t *testing.T) string {
 	t.Helper()
+	body, jws := tb.signedFixtureBody(t)
+	if _, err := tb.logSvc.AppendV2(context.Background(), service.AppendInput{
+		RawBody:           body,
+		ProducerSignature: jws,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return tb.inner.AnsID
+}
+
+// signedFixtureBody marshals the testbed's fixture inner event and
+// signs it with the producer key, returning the raw body plus the
+// detached JWS that belongs in the X-Signature header.
+func (tb *receiptTestbed) signedFixtureBody(t *testing.T) ([]byte, string) {
+	t.Helper()
 	body, err := json.Marshal(tb.inner)
 	if err != nil {
 		t.Fatal(err)
@@ -295,13 +310,7 @@ func (tb *receiptTestbed) appendEvent(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := tb.logSvc.AppendV2(context.Background(), service.AppendInput{
-		RawBody:           body,
-		ProducerSignature: jws,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	return tb.inner.AnsID
+	return body, jws
 }
 
 // waitCheckpointCovers polls until a receipt can be minted without


### PR DESCRIPTION
## Summary

Fixes #58.

The TL assigned `logId` with `uuid.NewString()` — UUID**v4** — on all three ingest lanes (V2, V1, identity), while at least nine places document a **UUIDv7** "assigned on first append": `spec/api-spec-tl-v2.yaml`, the docsui mirror, the served `V0`/`V1`/`V2` event schemas, the SQLite migration, and code comments in `internal/tl`.

This takes the issue's recommended **Option A**: switch the generator to `uuid.NewV7()`, which makes every doc site true without touching any of them, and gives time-ordered log ids — same intent as `identityId`, which already genuinely uses v7 (`internal/ra/service/identity.go`).

## Changes

- **`internal/tl/service/log.go`** — default `uuidFn` now wraps `uuid.NewV7()`. Because `NewV7` returns `(UUID, error)` (entropy reads can fail), `uuidFn` widens to `func() (string, error)` — mirroring the `newID` shape in the RA identity service — and `append` fails closed with a wrapped `generate logId: …` error rather than panicking or swallowing it. `WithUUIDFn` follows the new signature.
- **`internal/tl/service/log_more_test.go`** — `TestAppend_LogIDIsUUIDv7` runs a real append through the *default* generator and asserts the returned `LogID` parses as version 7. This closes the blind spot called out in the issue: the golden fixtures inject ids via `WithUUIDFn`, so the suite couldn't previously catch the drift. `TestAppend_UUIDFnError` covers the new generator-failure branch.
- **`internal/tl/service/receipt_test.go`** — extracted a `signedFixtureBody` helper from `appendEvent` so the new tests reuse the sign-and-append plumbing.

## Cross-repo note

The ANS-1 spec rewrite in agentnameservice/ans-registry#32 states "logId — UUID v7"; with Option A landing here, that line stays as-is.

## Verification

- `make check` passes (fmt, vet, golangci-lint, coverage gate at 90.4% ≥ 90%).
- Commit is DCO-signed-off and GPG-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)