### PR TITLE
docs: fix stale comments

### DIFF
--- a/internal/ra/handler/registration.go
+++ b/internal/ra/handler/registration.go
@@ -251,10 +251,11 @@ func mapRegistrationResponse(resp *service.RegisterResponse, r *http.Request) *r
 	// Register-time next-steps reflect the deferred-cert flow: certs
 	// only issue once verify-acme proves domain control, so the only
 	// step the operator can take right now is publish a challenge
-	// artifact and call verify-acme. Production DNS records
-	// (TRUST/BADGE/DISCOVERY/TLSA) only materialize on the
-	// verify-acme 202, where they appear paired with VERIFY_DNS as
-	// the next step.
+	// artifact and call verify-acme.
+	// Production DNS records (TRUST / BADGE / DISCOVERY / TLSA)
+	// don't appear until after verify-acme issues certs — the TLSA
+	// fingerprint can't exist before the server cert does.
+	// The records surface on GET agent detail via registrationPending.dnsRecords
 	return &registrationPendingResponse{
 		AgentID:    resp.Registration.AgentID,
 		Status:     string(resp.Registration.Status),

--- a/internal/ra/service/helpers.go
+++ b/internal/ra/service/helpers.go
@@ -172,11 +172,7 @@ func agentCertExpiry(stored []*domain.StoredCertificate, byoc *domain.ByocServer
 }
 
 // metadataHashesFromEndpoints builds the per-protocol metadata-hash
-// map the AGENT_ACTIVE attestation carries. The RA validates that
-// each endpoint's declared MetadataHash matches the metadata
-// document it pointed at; by the time we reach the verify-dns
-// transition, those hashes are trustworthy and we simply echo them
-// into the attestation keyed by protocol name.
+// map the AGENT_REGISTERED attestation carries.
 //
 // If no endpoint declared a hash, we return nil — JSON omitempty
 // on MetadataHashes keeps the field out of the emitted JCS entirely.

--- a/internal/ra/service/lifecycle.go
+++ b/internal/ra/service/lifecycle.go
@@ -847,7 +847,7 @@ func (m DNSMismatch) IsIncorrect() bool {
 // required records (computed by s.ComputeRequiredDNSRecords) and
 // advances the registration to ACTIVE on success.
 //
-// On success, emits an AGENT_ACTIVE event whose attestations carry
+// On success, emits an AGENT_REGISTERED event whose attestations carry
 // the production-state DNS records + identity/server cert
 // fingerprints + per-protocol metadata hashes — the shape a verifier
 // uses to audit the agent offline.
@@ -1235,7 +1235,7 @@ func (s *RegistrationService) buildAgentRegisteredEvent(
 // RevokeInput carries the caller's stated reason; the domain aggregate
 // validates it. `SchemaVersion` selects which TL lane the revocation
 // event flows to: "V1" enqueues AGENT_REVOKED to
-// /v1/internal/agents/event, "V2" (default) enqueues AGENT_REVOCATION
+// /v1/internal/agents/event, "V2" (default) enqueues AGENT_REVOKED
 // to /v2/internal/agents/event.
 type RevokeInput struct {
 	Reason        domain.RevocationReason
@@ -1247,11 +1247,11 @@ type RevokeInput struct {
 // service methods. `SchemaVersion` decides which TL lane the
 // resulting lifecycle event flows to.
 //
-// For verify-acme, V1 emits nothing to the TL — the V1 enum has no
-// intermediate DOMAIN_VALIDATION type; the V1 reference records the
-// transition in its domain-level lifecycle store only. For verify-
-// dns, V1 emits AGENT_REGISTERED on successful ACTIVE transition
-// (V2 emits AGENT_ACTIVE for the same transition).
+// verify-acme is only the domain-control gate and emits nothing to
+// the TL under the terminal-only event model — no leaf is written
+// until the agent reaches ACTIVE. verify-dns drives that ACTIVE
+// transition, which emits AGENT_REGISTERED on both lanes (only the
+// attestation shape differs between V1 and V2).
 type VerifyInput struct {
 	SchemaVersion string
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Agent Name Service project!

REQUIRED: every PR must link an issue with a closing keyword (e.g. "Fixes #123").
The issue is where we triage and prioritize; the PR is where we review.
If no issue exists yet, open one first.

Note for AI coding agents: complete every section below, keep the section
headings, and put a real issue number after "Fixes". If you were not given
an issue number, ask your operator or create the issue before opening this PR.
-->

## Related issue

<!-- REQUIRED — use a closing keyword so GitHub links it: Fixes / Closes / Resolves #NNN -->

Fixes #60

## Summary

  Corrects three inaccurate comments in internal/ra/service/lifecycle.go that named event types the code doesn't emit:                                                                                           
                                                                                                                                                                                                                 
  - RegisterServerCert doc said it emits AGENT_ACTIVE — it emits AGENT_REGISTERED.                                                                                                                               
  - RevokeInput doc referenced AGENT_REVOCATION — the actual token is AGENT_REVOKED.                                                                                                                             
  - VerifyInput doc claimed V2 emits AGENT_ACTIVE and referenced a non-existent intermediate DOMAIN_VALIDATION event type. Both lanes emit AGENT_REGISTERED at the ACTIVE transition (only the attestation shape 
  differs); DOMAIN_VALIDATION is a challenge purpose, not an event type.                                                                                                                                         
                                                                                                                                                                                                                 
  Comments only — no behavior change.

## Testing

No tests updated - docs fix only

## AI assistance

<!-- We follow the Linux kernel convention for AI disclosure:
     https://docs.kernel.org/process/coding-assistants.html
     If AI tooling assisted this change, add one Assisted-by line per tool,
     naming the tool and model, e.g.:
       Assisted-by: Claude Code (claude-fable-5)
     If none was used, write "None". The human submitter remains fully
     responsible for the correctness and licensing of the contribution.
     Per the kernel convention, AI tools must not add Signed-off-by lines:
     the DCO certification belongs to the human submitter alone. -->

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org) — release notes are generated from it
- [x] Tests cover the change
- [x] The linked issue above uses a closing keyword
- [x] Every commit is signed off (`git commit -s`) certifying the [DCO](https://developercertificate.org)
