### PR TITLE
feat(ra/tl): add web bot auth identity

### DIFF
--- a/cmd/ans-ra/main.go
+++ b/cmd/ans-ra/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/agentnameservice/ans/internal/adapter/cert"
 	"github.com/agentnameservice/ans/internal/adapter/challenge"
 	"github.com/agentnameservice/ans/internal/adapter/didresolver"
+	"github.com/agentnameservice/ans/internal/adapter/directory/webbotauth"
 	"github.com/agentnameservice/ans/internal/adapter/dns"
 	"github.com/agentnameservice/ans/internal/adapter/docsui"
 	"github.com/agentnameservice/ans/internal/adapter/eventbus"
@@ -160,9 +161,14 @@ func run(cfgPath string) error {
 	// the lei kind's analog of
 	// the did:web resolver selection.
 	leiVerifier := selectLEIVerifier(cfg, logger)
+	// web-bot-auth directory resolver — noop (quickstart) or hardened
+	// HTTPS fetch of the HTTP Message Signatures directory, the
+	// web-bot-auth kind's analog of the did:web resolver selection.
+	dirResolver := selectWebBotAuthDirectoryResolver(cfg, logger)
 	logger.Info().
 		Str("resolver", cfg.Identity.Resolver.Type).
 		Str("vleiVerifier", cfg.VLEI.Type).
+		Str("webBotAuthDirectory", cfg.WebBotAuth.Directory.Type).
 		Dur("challengeTTL", cfg.Identity.ChallengeTTL).
 		Msg("verified-identity surface configured")
 
@@ -247,7 +253,7 @@ func run(cfgPath string) error {
 		identitySealer = tlSealer
 	}
 	identitySvc := service.NewIdentityService(
-		identityStore, identityLinks, agents, didResolver, identitySealer, leiVerifier, db,
+		identityStore, identityLinks, agents, didResolver, identitySealer, leiVerifier, dirResolver, db,
 	).WithSigner(service.EventSigner{
 		KeyManager: km,
 		KeyID:      signerKeyID,
@@ -683,5 +689,21 @@ func selectLEIVerifier(cfg *config.RAConfig, logger zerolog.Logger) port.LEICont
 		return leiverifier.NewNoop()
 	default: // "off"
 		return nil
+	}
+}
+
+// selectWebBotAuthDirectoryResolver returns the configured web-bot-auth
+// directory resolver — the web-bot-auth kind's analog of
+// selectDIDResolver. "http" performs the hardened HTTPS fetch of the HTTP
+// Message Signatures directory (WebPKI + SSRF dialer guards, shared
+// securefetch transport); the default "noop" synthesizes the endorsed
+// key set from the submitted proofs' embedded keys for self-contained
+// local development.
+func selectWebBotAuthDirectoryResolver(cfg *config.RAConfig, logger zerolog.Logger) port.WebBotAuthDirectoryResolver {
+	switch cfg.WebBotAuth.Directory.Type {
+	case "http":
+		return webbotauth.NewHTTPResolver(webbotauth.WithLogger(logger))
+	default:
+		return webbotauth.NewNoopResolver()
 	}
 }

--- a/internal/adapter/didresolver/resolver_test.go
+++ b/internal/adapter/didresolver/resolver_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -218,80 +217,9 @@ func TestWebResolver_NoRegistrableDomain(t *testing.T) {
 	}
 }
 
-func TestWebResolver_SSRFBlocksLoopback(t *testing.T) {
-	// A real end-to-end run against a loopback host: the pinning
-	// dialer must reject the resolved address class. The DID needs a
-	// registrable domain, so use a hosts-style resolver shim via the
-	// dialer directly.
-	d := &pinningDialer{}
-	_, err := d.DialContext(context.Background(), "tcp", "localhost:443")
-	if err == nil || !strings.Contains(err.Error(), "disallowed") {
-		t.Fatalf("loopback should be rejected: %v", err)
-	}
-}
-
-func TestPinningDialer_RejectsNon443(t *testing.T) {
-	d := &pinningDialer{}
-	if _, err := d.DialContext(context.Background(), "tcp", "example.com:8443"); err == nil {
-		t.Fatal("non-443 should be rejected")
-	}
-	if _, err := d.DialContext(context.Background(), "tcp", "malformed"); err == nil {
-		t.Fatal("malformed address should be rejected")
-	}
-}
-
-func TestPinningDialer_AllowPrivateReachesLoopback(t *testing.T) {
-	// With the test-only escape hatch the dialer connects to a local
-	// listener — proving the happy dial path works end to end.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = ln.Close() }()
-	go func() {
-		conn, aerr := ln.Accept()
-		if aerr == nil {
-			_ = conn.Close()
-		}
-	}()
-
-	_, port, _ := net.SplitHostPort(ln.Addr().String())
-	_ = port // the dialer pins 443; dial loopback via a name that resolves there
-	d := &pinningDialer{allowPrivate: true}
-	// localhost:443 likely has no listener; accept either a
-	// connection refusal (dial path reached) or success.
-	conn, err := d.DialContext(context.Background(), "tcp", "localhost:443")
-	if err == nil {
-		_ = conn.Close()
-	} else if strings.Contains(err.Error(), "disallowed") {
-		t.Fatalf("allowPrivate must bypass the class filter: %v", err)
-	}
-}
-
-func TestIsPublicUnicast(t *testing.T) {
-	cases := []struct {
-		ip   string
-		want bool
-	}{
-		{"127.0.0.1", false},
-		{"10.1.2.3", false},
-		{"172.16.0.1", false},
-		{"192.168.1.1", false},
-		{"169.254.169.254", false}, // cloud metadata (link-local)
-		{"::1", false},
-		{"fe80::1", false},
-		{"fc00::1", false},
-		{"ff02::1", false},
-		{"0.0.0.0", false},
-		{"93.184.216.34", true},
-		{"2606:2800:220:1::1", true},
-	}
-	for _, tc := range cases {
-		if got := isPublicUnicast(net.ParseIP(tc.ip)); got != tc.want {
-			t.Errorf("isPublicUnicast(%s) = %v, want %v", tc.ip, got, tc.want)
-		}
-	}
-}
+// The SSRF dialer, IP denylist, and registrable-domain helper now live
+// in the shared securefetch package; their unit tests moved there. This
+// file keeps the did:web-specific redirect-policy and parse coverage.
 
 func TestCheckRedirectPolicy(t *testing.T) {
 	w := NewWebResolver()

--- a/internal/adapter/didresolver/web.go
+++ b/internal/adapter/didresolver/web.go
@@ -2,21 +2,17 @@ package didresolver
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
-	"golang.org/x/net/publicsuffix"
 
+	"github.com/agentnameservice/ans/internal/adapter/securefetch"
 	"github.com/agentnameservice/ans/internal/domain"
 	"github.com/agentnameservice/ans/internal/port"
 )
@@ -165,14 +161,14 @@ func (w *Web) parseResponse(did string, resp *http.Response) (*port.DIDDocument,
 		return nil, domain.NewValidationError("DID_RESOLUTION_FAILED",
 			fmt.Sprintf("DID document fetch for %s returned status %d", did, resp.StatusCode))
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, w.maxBodyBytes+1))
+	body, err := securefetch.ReadCappedBody(resp.Body, w.maxBodyBytes)
+	if errors.Is(err, securefetch.ErrBodyTooLarge) {
+		return nil, domain.NewValidationError("DID_RESOLUTION_FAILED",
+			fmt.Sprintf("DID document for %s exceeds the %d-byte limit", did, w.maxBodyBytes))
+	}
 	if err != nil {
 		return nil, domain.NewValidationError("DID_RESOLUTION_FAILED",
 			fmt.Sprintf("could not read the DID document for %s", did))
-	}
-	if int64(len(body)) > w.maxBodyBytes {
-		return nil, domain.NewValidationError("DID_RESOLUTION_FAILED",
-			fmt.Sprintf("DID document for %s exceeds the %d-byte limit", did, w.maxBodyBytes))
 	}
 
 	doc, err := parseDIDDocument(body)
@@ -186,142 +182,40 @@ func (w *Web) parseResponse(did string, resp *http.Response) (*port.DIDDocument,
 	return doc, nil
 }
 
-// newClient builds the per-resolve HTTP client: pinning dialer +
-// WebPKI transport + same-registrable-domain redirect policy. A fresh
-// client per call keeps the DNS pin scoped to exactly one
-// verify-control round.
+// newClient builds the per-resolve HTTP client on the shared
+// securefetch toolkit: the SSRF-hardened pinning dialer (pinned to 443,
+// the only port did:web can express) + WebPKI transport +
+// same-registrable-domain redirect policy. A fresh client per call
+// keeps the DNS pin scoped to exactly one verify-control round.
 func (w *Web) newClient(originHost string) (*http.Client, error) {
-	pinned := &pinningDialer{allowPrivate: w.allowPrivate}
-	transport := &http.Transport{
-		DialContext:       pinned.DialContext,
-		ForceAttemptHTTP2: true,
-		TLSClientConfig:   &tls.Config{RootCAs: w.rootCAs, MinVersion: tls.VersionTLS12},
-		// This transport is built per Resolve call against one
-		// registrant-steered host; keeping idle connections open
-		// would let a connection linger ~90s after the fetch with no
-		// reuse benefit. Close them when the request completes.
-		DisableKeepAlives: true,
+	dialerOpts := []securefetch.DialerOption{securefetch.WithRequirePort("443")}
+	if w.allowPrivate {
+		dialerOpts = append(dialerOpts, securefetch.WithAllowPrivateNetworks())
 	}
-	originDomain, err := registrableDomain(originHost)
+	dialer := securefetch.NewDialer(dialerOpts...)
+
+	originDomain, err := securefetch.RegistrableDomain(originHost)
 	if err != nil {
 		return nil, domain.NewValidationError("DID_BAD_FORMAT",
 			fmt.Sprintf("did:web host %q has no registrable domain", originHost))
 	}
-	return &http.Client{
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= maxRedirects {
-				return domain.NewValidationError("DID_RESOLUTION_FAILED",
-					"too many redirects resolving the DID document")
-			}
-			if req.URL.Scheme != "https" {
-				return domain.NewValidationError("DID_RESOLUTION_FAILED",
-					"DID document redirect left https")
-			}
-			redirDomain, derr := registrableDomain(req.URL.Hostname())
-			if derr != nil || redirDomain != originDomain {
-				return domain.NewValidationError("DID_REDIRECT_DOMAIN_MISMATCH",
-					"DID document redirect left the DID's registrable domain")
-			}
-			return nil
-		},
-	}, nil
-}
-
-// registrableDomain returns the eTLD+1 for a host. Single-label hosts
-// (localhost, bare TLDs) error — they have no registrable domain.
-func registrableDomain(host string) (string, error) {
-	return publicsuffix.EffectiveTLDPlusOne(strings.ToLower(host))
-}
-
-// pinningDialer resolves, filters, and pins target IPs.
-//
-// The pin map lives for one Resolve call (one dialer per client per
-// call): the first connection to a host fixes its IP, so a DNS rebind
-// between the initial fetch and a redirect hop — or between TLS
-// handshake retries — cannot redirect a later connection to a
-// different (possibly internal) address. Every chosen IP passes the
-// denylist *after* resolution; hostname-string checks are worthless
-// against rebinding.
-type pinningDialer struct {
-	allowPrivate bool
-
-	mu  sync.Mutex
-	pin map[string]string // host → ip
-}
-
-func (d *pinningDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, errors.New("didresolver: malformed dial address")
-	}
-	if port != "443" {
-		// did:web fetches are pinned to 443; nothing else should
-		// ever reach the dialer.
-		return nil, errors.New("didresolver: refusing non-443 connection")
-	}
-
-	d.mu.Lock()
-	if d.pin == nil {
-		d.pin = make(map[string]string)
-	}
-	pinnedIP, ok := d.pin[host]
-	d.mu.Unlock()
-
-	if !ok {
-		var err error
-		pinnedIP, err = d.resolveAndPin(ctx, host)
-		if err != nil {
-			return nil, err
+	checkRedirect := func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return domain.NewValidationError("DID_RESOLUTION_FAILED",
+				"too many redirects resolving the DID document")
 		}
-	}
-
-	var dialer net.Dialer
-	return dialer.DialContext(ctx, network, net.JoinHostPort(pinnedIP, port))
-}
-
-// resolveAndPin resolves the host, applies the egress denylist to
-// every candidate address, and pins the first allowed IP. First
-// writer wins — concurrent dials for one host converge on one pin.
-func (d *pinningDialer) resolveAndPin(ctx context.Context, host string) (string, error) {
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil || len(ips) == 0 {
-		return "", errors.New("didresolver: host did not resolve")
-	}
-	chosen := ""
-	for _, ip := range ips {
-		if d.allowPrivate || isPublicUnicast(ip.IP) {
-			chosen = ip.IP.String()
-			break
+		if req.URL.Scheme != "https" {
+			return domain.NewValidationError("DID_RESOLUTION_FAILED",
+				"DID document redirect left https")
 		}
+		redirDomain, derr := securefetch.RegistrableDomain(req.URL.Hostname())
+		if derr != nil || redirDomain != originDomain {
+			return domain.NewValidationError("DID_REDIRECT_DOMAIN_MISMATCH",
+				"DID document redirect left the DID's registrable domain")
+		}
+		return nil
 	}
-	if chosen == "" {
-		return "", errors.New("didresolver: host resolves only to disallowed addresses")
-	}
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if existing, dup := d.pin[host]; dup {
-		return existing, nil
-	}
-	d.pin[host] = chosen
-	return chosen, nil
-}
-
-// isPublicUnicast rejects every address class the egress denylist
-// names: loopback, RFC 1918 / ULA private ranges, link-local (which
-// contains the cloud-metadata addresses), multicast, and unspecified.
-func isPublicUnicast(ip net.IP) bool {
-	switch {
-	case ip.IsLoopback(),
-		ip.IsPrivate(),
-		ip.IsLinkLocalUnicast(),
-		ip.IsLinkLocalMulticast(),
-		ip.IsMulticast(),
-		ip.IsUnspecified():
-		return false
-	default:
-		return true
-	}
+	return securefetch.NewClient(dialer, w.rootCAs, checkRedirect), nil
 }
 
 // didDocumentWire is the on-the-wire DID document subset we parse.

--- a/internal/adapter/directory/webbotauth/http.go
+++ b/internal/adapter/directory/webbotauth/http.go
@@ -1,0 +1,261 @@
+package webbotauth
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/agentnameservice/ans/internal/adapter/securefetch"
+	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/port"
+)
+
+// directoryContentType is the media type the web-bot-auth HTTP Message
+// Signatures directory MUST be served as
+// (draft-meunier-webbotauth-httpsig-protocol-02).
+const directoryContentType = "application/http-message-signatures-directory+json"
+
+// maxRedirects bounds the directory-fetch redirect chain, matching the
+// did:web resolver.
+const maxRedirects = 5
+
+// HTTP is the production directory resolver: an HTTPS GET of the HTTP
+// Message Signatures directory at the canonical Signature-Agent URL,
+// through the shared hardened fetcher.
+//
+// The fetch target is registrant-steered (any host the Signature-Agent
+// URL names), so SSRF is a first-class control, delegated in full to the
+// securefetch toolkit (egress denylist, DNS-rebind pin, WebPKI, bounded
+// redirects). Errors stay coarse — no resolved IPs, ports, or redirect
+// chains reach the caller (no SSRF oracle) — and every fetch-layer
+// failure is a retryable 503-class domain error, never a 500.
+type HTTP struct {
+	timeout      time.Duration
+	maxBodyBytes int64
+	rootCAs      *x509.CertPool
+	allowPrivate bool
+	logger       zerolog.Logger
+}
+
+// Option customizes the HTTP resolver.
+type Option func(*HTTP)
+
+// WithTimeout overrides the per-resolve hard timeout (default 5s).
+func WithTimeout(d time.Duration) Option {
+	return func(h *HTTP) {
+		if d > 0 {
+			h.timeout = d
+		}
+	}
+}
+
+// WithMaxBodyBytes overrides the response-size cap (default 1 MiB).
+func WithMaxBodyBytes(n int64) Option {
+	return func(h *HTTP) {
+		if n > 0 {
+			h.maxBodyBytes = n
+		}
+	}
+}
+
+// WithRootCAs overrides the trusted root pool (default: system roots).
+// Deployments with private PKI inject their pool here; tests inject the
+// httptest server's certificate.
+func WithRootCAs(pool *x509.CertPool) Option {
+	return func(h *HTTP) { h.rootCAs = pool }
+}
+
+// WithAllowPrivateNetworks disables the egress IP denylist. FOR TESTS
+// ONLY — it lets the full real fetch path run against a loopback TLS
+// server. Never reachable from configuration.
+func WithAllowPrivateNetworks() Option {
+	return func(h *HTTP) { h.allowPrivate = true }
+}
+
+// WithLogger attaches a component-tagged logger (default: no-op). It
+// records the failure CATEGORY (the underlying error) plus the directory
+// URL and elapsed time so an on-call engineer can tell a denylist
+// rejection from a DNS-rebind block, a TLS failure, a timeout, or a
+// refused connection — none of which reach the API caller (the wire
+// error stays coarse, no SSRF oracle).
+func WithLogger(logger zerolog.Logger) Option {
+	return func(h *HTTP) {
+		h.logger = logger.With().Str("component", "webbotauth-directory-resolver").Logger()
+	}
+}
+
+// NewHTTPResolver constructs the production directory resolver.
+func NewHTTPResolver(opts ...Option) *HTTP {
+	h := &HTTP{
+		timeout:      5 * time.Second,
+		maxBodyBytes: 1 << 20, // 1 MiB
+		logger:       zerolog.Nop(),
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// Resolve fetches and parses the directory at the canonical
+// Signature-Agent URL. Hints are ignored — the resolved directory is
+// always the key source.
+func (h *HTTP) Resolve(ctx context.Context, directoryURL string, _ []port.KeyHint) ([]port.DirectoryKey, error) {
+	u, err := url.Parse(directoryURL)
+	if err != nil || u.Scheme != "https" || u.Hostname() == "" {
+		// The canonical value is produced by the domain layer, so a
+		// malformed URL here is an internal inconsistency, not caller
+		// input; still fail retryable rather than 500.
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			"could not fetch the web-bot-auth directory")
+	}
+	originHost := u.Hostname()
+
+	client := h.newClient(originHost)
+
+	ctx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, directoryURL, nil)
+	if err != nil {
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			"could not build the directory request")
+	}
+	req.Header.Set("Accept", directoryContentType)
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		// Coarse wire error — the diagnosable category (denylist
+		// rejection, DNS-rebind block, TLS failure, timeout, refused)
+		// goes only to the server-side log.
+		h.logger.Info().
+			Err(err).
+			Str("directoryUrl", directoryURL).
+			Int64("elapsedMs", time.Since(start).Milliseconds()).
+			Msg("web-bot-auth directory fetch failed")
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			fmt.Sprintf("could not fetch the web-bot-auth directory at %s", directoryURL))
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return h.parseResponse(directoryURL, resp)
+}
+
+// parseResponse applies the status, content-type, size, and JWKS-parse
+// checks. Split from Resolve so the validation pipeline is testable
+// independent of the dial/TLS plumbing.
+func (h *HTTP) parseResponse(directoryURL string, resp *http.Response) ([]port.DirectoryKey, error) {
+	if resp.StatusCode != http.StatusOK {
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			fmt.Sprintf("directory fetch for %s returned status %d", directoryURL, resp.StatusCode))
+	}
+	if mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type")); err != nil ||
+		!strings.EqualFold(mediaType, directoryContentType) {
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			fmt.Sprintf("directory for %s has an unexpected content type", directoryURL))
+	}
+	body, err := securefetch.ReadCappedBody(resp.Body, h.maxBodyBytes)
+	if err != nil {
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			fmt.Sprintf("could not read the directory for %s", directoryURL))
+	}
+	return parseDirectory(body)
+}
+
+// newClient builds the per-resolve HTTP client on the shared securefetch
+// toolkit: the SSRF-hardened dialer (no fixed port — a Signature-Agent
+// URL may carry one) + WebPKI transport + a redirect policy pinned to
+// the directory host's registrable domain (or, for a host with none —
+// an IP literal, as in tests — the exact host). A fresh client per call
+// keeps the DNS pin scoped to one verify-control round.
+func (h *HTTP) newClient(originHost string) *http.Client {
+	var dialerOpts []securefetch.DialerOption
+	if h.allowPrivate {
+		dialerOpts = append(dialerOpts, securefetch.WithAllowPrivateNetworks())
+	}
+	dialer := securefetch.NewDialer(dialerOpts...)
+
+	anchorDomain, hasRegDomain := "", false
+	if d, err := securefetch.RegistrableDomain(originHost); err == nil {
+		anchorDomain, hasRegDomain = d, true
+	}
+	checkRedirect := func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+				"too many redirects fetching the directory")
+		}
+		if req.URL.Scheme != "https" {
+			return domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+				"directory redirect left https")
+		}
+		if hasRegDomain {
+			rd, err := securefetch.RegistrableDomain(req.URL.Hostname())
+			if err != nil || rd != anchorDomain {
+				return domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+					"directory redirect left the directory's registrable domain")
+			}
+			return nil
+		}
+		if !strings.EqualFold(req.URL.Hostname(), originHost) {
+			return domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+				"directory redirect left the directory host")
+		}
+		return nil
+	}
+	return securefetch.NewClient(dialer, h.rootCAs, checkRedirect)
+}
+
+// directoryWire is the JWKS shape the directory serves: a keys array of
+// raw JWK objects. Each entry is kept raw so its exact bytes can be
+// quoted verbatim into a seal.
+type directoryWire struct {
+	Keys []json.RawMessage `json:"keys"`
+}
+
+// keyWindow reads the optional per-key validity window
+// (draft-meunier-webbotauth-httpsig-protocol-02): nbf/exp are unix-second
+// JWK members. Absent members leave the corresponding bound unset.
+type keyWindow struct {
+	NotBefore *int64 `json:"nbf"`
+	NotAfter  *int64 `json:"exp"`
+}
+
+// parseDirectory materializes the DirectoryKey set from raw JWKS bytes.
+// Malformed JSON is a retryable failure (the remote is misconfigured); an
+// empty or missing keys array yields an empty set (the verifier then
+// rejects for "no matched key"). Each key's raw bytes are preserved for
+// verbatim sealing.
+func parseDirectory(body []byte) ([]port.DirectoryKey, error) {
+	var wire directoryWire
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return nil, domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE",
+			"directory is not valid JSON")
+	}
+	keys := make([]port.DirectoryKey, 0, len(wire.Keys))
+	for _, raw := range wire.Keys {
+		var w keyWindow
+		// A key whose window members are malformed is treated as
+		// unbounded rather than dropped — the thumbprint match and the
+		// signature check remain the load-bearing gates.
+		_ = json.Unmarshal(raw, &w)
+		dk := port.DirectoryKey{JWK: raw}
+		if w.NotBefore != nil {
+			dk.NotBefore = time.Unix(*w.NotBefore, 0).UTC()
+		}
+		if w.NotAfter != nil {
+			dk.NotAfter = time.Unix(*w.NotAfter, 0).UTC()
+		}
+		keys = append(keys, dk)
+	}
+	return keys, nil
+}
+
+// compile-time conformance.
+var _ port.WebBotAuthDirectoryResolver = (*HTTP)(nil)

--- a/internal/adapter/directory/webbotauth/noop.go
+++ b/internal/adapter/directory/webbotauth/noop.go
@@ -1,0 +1,50 @@
+package webbotauth
+
+import (
+	"context"
+
+	"github.com/agentnameservice/ans/internal/port"
+)
+
+// Noop is the quickstart directory resolver. It never dials anywhere:
+// the endorsed key set is synthesized from the hints — the kid → JWK
+// pairs the service extracted from the submitted proofs' `jwk` protected
+// headers.
+//
+// What this preserves and what it waives (the noop DID resolver
+// precedent — real crypto, waived external-world binding):
+//
+//   - PRESERVED: every JWS still genuinely verifies against the embedded
+//     key, the proof input still binds identityId / nonce / purpose, and
+//     the sealed event stays self-verifying.
+//   - WAIVED: the binding "the live directory at the Signature-Agent URL
+//     really endorses this key". Anyone can mint a keypair and claim any
+//     Signature-Agent URL.
+//
+// Strictly for local development and the demo scripts. NOT for
+// production.
+type Noop struct{}
+
+// NewNoopResolver returns the quickstart directory resolver.
+func NewNoopResolver() *Noop { return &Noop{} }
+
+// Resolve synthesizes the endorsed key set from the hints, one
+// DirectoryKey per hinted JWK, each with an unbounded validity window.
+// With no hints (the register-time advisory fetch) the set is empty —
+// the 202 challenge list then carries a single unkeyed entry, and the
+// registrant names keys via the JWS `kid` + `jwk` headers at verify
+// time. The hint's JWK bytes pass through verbatim, so the sealed
+// verification method quotes the registrant's exact key.
+func (n *Noop) Resolve(_ context.Context, _ string, hints []port.KeyHint) ([]port.DirectoryKey, error) {
+	keys := make([]port.DirectoryKey, 0, len(hints))
+	for _, h := range hints {
+		if len(h.PublicKeyJWK) == 0 {
+			continue
+		}
+		keys = append(keys, port.DirectoryKey{JWK: h.PublicKeyJWK})
+	}
+	return keys, nil
+}
+
+// compile-time conformance.
+var _ port.WebBotAuthDirectoryResolver = (*Noop)(nil)

--- a/internal/adapter/directory/webbotauth/webbotauth.go
+++ b/internal/adapter/directory/webbotauth/webbotauth.go
@@ -1,0 +1,15 @@
+// Package webbotauth provides the two port.WebBotAuthDirectoryResolver
+// adapters behind the web-bot-auth identifier kind:
+//
+//   - Noop — zero-I/O quickstart resolver; synthesizes the endorsed key
+//     set from the submitted proofs' embedded keys.
+//   - HTTP — the real thing: a hardened HTTPS fetch of the HTTP Message
+//     Signatures directory on the shared securefetch transport (WebPKI,
+//     SSRF dialer guards, DNS-rebind pin, size cap, bounded
+//     same-registrable-domain redirects), a content-type check, and a
+//     JWKS parse with per-key nbf/exp windows.
+//
+// Selected by `webbotauth.directory.type` ("noop" | "http") in the RA
+// config — the same pattern as the DNS verifier's `dns.type` and the
+// did:web resolver's `identity.resolver.type`.
+package webbotauth

--- a/internal/adapter/directory/webbotauth/webbotauth_test.go
+++ b/internal/adapter/directory/webbotauth/webbotauth_test.go
@@ -1,0 +1,203 @@
+package webbotauth
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentnameservice/ans/internal/port"
+)
+
+const testJWK = `{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+
+func TestNoopResolver_SynthesizesFromHints(t *testing.T) {
+	n := NewNoopResolver()
+
+	// No hints (advisory register-time fetch) → empty set.
+	keys, err := n.Resolve(context.Background(), "https://signer.example.com/.well-known/http-message-signatures-directory", nil)
+	if err != nil || len(keys) != 0 {
+		t.Fatalf("no-hint resolve: %d keys, %v", len(keys), err)
+	}
+
+	hints := []port.KeyHint{
+		{Kid: "kid-1", PublicKeyJWK: json.RawMessage(testJWK)},
+		{Kid: "kid-2"}, // no key — skipped
+	}
+	keys, err = n.Resolve(context.Background(), "https://signer.example.com", hints)
+	if err != nil {
+		t.Fatalf("resolve with hints: %v", err)
+	}
+	if len(keys) != 1 || string(keys[0].JWK) != testJWK {
+		t.Fatalf("synthesized keys wrong: %+v", keys)
+	}
+}
+
+func TestParseDirectory(t *testing.T) {
+	body := []byte(`{"keys":[
+		{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo","nbf":1000,"exp":2000},
+		{"kty":"OKP","crv":"Ed25519","x":"AAA"}
+	]}`)
+	keys, err := parseDirectory(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("want 2 keys, got %d", len(keys))
+	}
+	if keys[0].NotBefore != time.Unix(1000, 0).UTC() || keys[0].NotAfter != time.Unix(2000, 0).UTC() {
+		t.Fatalf("window not parsed: %+v", keys[0])
+	}
+	if !keys[1].NotBefore.IsZero() || !keys[1].NotAfter.IsZero() {
+		t.Fatalf("second key should be unbounded: %+v", keys[1])
+	}
+	// Empty keys array → empty set, no error.
+	empty, err := parseDirectory([]byte(`{"keys":[]}`))
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty directory: %d, %v", len(empty), err)
+	}
+	// Malformed JSON → retryable failure.
+	if _, err := parseDirectory([]byte(`{not json`)); err == nil {
+		t.Fatal("malformed JWKS should error")
+	}
+}
+
+// newTLSDirectory starts a loopback TLS server serving the given handler
+// and returns an HTTP resolver that trusts it and may reach loopback.
+func newTLSDirectory(t *testing.T, h http.HandlerFunc) (*httptest.Server, *HTTP) {
+	t.Helper()
+	srv := httptest.NewTLSServer(h)
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	r := NewHTTPResolver(
+		WithRootCAs(pool),
+		WithAllowPrivateNetworks(),
+		WithTimeout(2*time.Second),
+	)
+	return srv, r
+}
+
+func TestHTTPResolver_HappyPath(t *testing.T) {
+	srv, r := newTLSDirectory(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", directoryContentType)
+		_, _ = w.Write([]byte(`{"keys":[` + testJWK + `]}`))
+	})
+	defer srv.Close()
+
+	keys, err := r.Resolve(context.Background(), srv.URL, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(keys) != 1 || string(keys[0].JWK) != testJWK {
+		t.Fatalf("keys: %+v", keys)
+	}
+}
+
+func TestHTTPResolver_ContentTypeParametersAccepted(t *testing.T) {
+	srv, r := newTLSDirectory(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", directoryContentType+"; charset=utf-8")
+		_, _ = w.Write([]byte(`{"keys":[` + testJWK + `]}`))
+	})
+	defer srv.Close()
+	if _, err := r.Resolve(context.Background(), srv.URL, nil); err != nil {
+		t.Fatalf("content-type with parameters should be accepted: %v", err)
+	}
+}
+
+func TestHTTPResolver_Rejections(t *testing.T) {
+	cases := map[string]http.HandlerFunc{
+		"wrong content type": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"keys":[]}`))
+		},
+		"non-200": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+		"bad json": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", directoryContentType)
+			_, _ = w.Write([]byte(`{not json`))
+		},
+	}
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv, r := newTLSDirectory(t, h)
+			defer srv.Close()
+			_, err := r.Resolve(context.Background(), srv.URL, nil)
+			if err == nil || !strings.Contains(err.Error(), "WBA_DIRECTORY_UNAVAILABLE") {
+				t.Fatalf("want WBA_DIRECTORY_UNAVAILABLE, got %v", err)
+			}
+		})
+	}
+}
+
+func TestHTTPResolver_BodyTooLarge(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", directoryContentType)
+		_, _ = w.Write(make([]byte, 4096))
+	}))
+	defer srv.Close()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	r := NewHTTPResolver(WithRootCAs(pool), WithAllowPrivateNetworks(), WithMaxBodyBytes(1024))
+	if _, err := r.Resolve(context.Background(), srv.URL, nil); err == nil ||
+		!strings.Contains(err.Error(), "WBA_DIRECTORY_UNAVAILABLE") {
+		t.Fatalf("want size-cap failure, got %v", err)
+	}
+}
+
+// TestHTTPResolver_FetchFailureCoarse drives the real Resolve path
+// against an unresolvable host: the failure is retryable and the wire
+// error never leaks an address (no SSRF oracle). V15.
+func TestHTTPResolver_FetchFailureCoarse(t *testing.T) {
+	r := NewHTTPResolver(WithTimeout(2 * time.Second))
+	_, err := r.Resolve(context.Background(), "https://no-such-host-ans-test.invalid/.well-known/http-message-signatures-directory", nil)
+	if err == nil || !strings.Contains(err.Error(), "WBA_DIRECTORY_UNAVAILABLE") {
+		t.Fatalf("want WBA_DIRECTORY_UNAVAILABLE, got %v", err)
+	}
+}
+
+func TestHTTPResolver_MalformedURL(t *testing.T) {
+	r := NewHTTPResolver()
+	if _, err := r.Resolve(context.Background(), "http://not-https.example.com", nil); err == nil {
+		t.Fatal("non-https directory URL should fail")
+	}
+}
+
+func TestHTTPResolver_RedirectPolicy(t *testing.T) {
+	r := NewHTTPResolver()
+	mkReq := func(raw string) *http.Request {
+		u, _ := url.Parse(raw)
+		return &http.Request{URL: u}
+	}
+
+	// Registrable-domain-anchored host.
+	client := r.newClient("signer.example.com")
+	if err := client.CheckRedirect(mkReq("https://cdn.example.com/dir"), nil); err != nil {
+		t.Errorf("same registrable domain rejected: %v", err)
+	}
+	if err := client.CheckRedirect(mkReq("https://evil.other.com/dir"), nil); err == nil {
+		t.Error("cross-domain redirect should be rejected")
+	}
+	if err := client.CheckRedirect(mkReq("http://cdn.example.com/dir"), nil); err == nil {
+		t.Error("scheme downgrade should be rejected")
+	}
+	via := make([]*http.Request, maxRedirects)
+	if err := client.CheckRedirect(mkReq("https://cdn.example.com/dir"), via); err == nil ||
+		!strings.Contains(err.Error(), "too many redirects") {
+		t.Errorf("redirect cap: %v", err)
+	}
+
+	// IP-literal origin (no registrable domain) → exact-host anchor.
+	ipClient := r.newClient("127.0.0.1")
+	if err := ipClient.CheckRedirect(mkReq("https://127.0.0.1/dir"), nil); err != nil {
+		t.Errorf("same-host redirect rejected: %v", err)
+	}
+	if err := ipClient.CheckRedirect(mkReq("https://10.0.0.1/dir"), nil); err == nil {
+		t.Error("different-host redirect should be rejected for IP origin")
+	}
+}

--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -1214,12 +1214,22 @@ paths:
         - Verified Identities
       summary: Register a verified identity
       description: |
-        Registers an identifier (the kind — `did:web`, `did:key` — is
-        inferred from the value's lexical form, never caller-asserted)
-        and returns the challenge round to sign: one entry per
-        eligible key, all over a single anti-replay nonce. The
-        identity is created in `PENDING_CONTROL`; nothing is sealed
-        until verify-control passes.
+        Registers an identifier (the kind — `did:web`, `did:key`,
+        `web-bot-auth` — is inferred from the value's lexical form,
+        never caller-asserted) and returns the challenge round to
+        sign: one entry per eligible key, all over a single
+        anti-replay nonce. The identity is created in
+        `PENDING_CONTROL`; nothing is sealed until verify-control
+        passes.
+
+        The `web-bot-auth` kind's value is an `https://`
+        Signature-Agent URL. It is canonicalized to the well-known
+        directory URL
+        `https://<host>[:port]/.well-known/http-message-signatures-directory`
+        — the URL a verifier fetches the HTTP Message Signatures
+        directory at (draft-meunier-webbotauth-httpsig-protocol-02). A
+        bare origin gets the well-known path added; any other path
+        returns 422 `WBA_URL_INVALID`.
 
         Re-POSTing the same value while the row is `PENDING_CONTROL`
         is the idempotent re-add: the same `identityId` returns with
@@ -1259,7 +1269,9 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: |
-            Invalid or unsupported identifier; for the `did:web` kind the
+            Invalid or unsupported identifier; for the `web-bot-auth`
+            kind a malformed Signature-Agent URL fails with
+            `WBA_URL_INVALID`; for the `did:web` kind the
             register-time resolution may fail with `DID_RESOLUTION_FAILED`
             or `DID_DOCUMENT_ID_MISMATCH`; for the `lei` kind —
             `IDENTIFIER_PRESENTATION_REQUIRED`, `LEI_PRESENTATION_INVALID`,
@@ -1387,7 +1399,9 @@ paths:
         '422':
           description: |
             Invalid replacement value (incl. `IDENTIFIER_KIND_MISMATCH`);
-            for the `did:web` kind the register-time resolution may fail
+            for the `web-bot-auth` kind a malformed Signature-Agent URL
+            fails with `WBA_URL_INVALID`; for the `did:web` kind the
+            register-time resolution may fail
             with `DID_RESOLUTION_FAILED` or `DID_DOCUMENT_ID_MISMATCH`;
             for the `lei` kind — `IDENTIFIER_PRESENTATION_REQUIRED`,
             `LEI_PRESENTATION_INVALID`, `LEI_MISMATCH`,
@@ -1417,9 +1431,20 @@ paths:
         before verifying any signature). Every proof must verify
         against the identifier's AUTHORITATIVE key for its `kid`
         (resolved from the DID document for `did:web`, decoded from
-        the identifier for `did:key`); one bad proof fails the call
-        closed. The nonce is consumed exactly once, inside the
-        success transaction — a failed attempt does not consume it.
+        the identifier for `did:key`, located in the fetched HTTP
+        Message Signatures directory for `web-bot-auth`); one bad
+        proof fails the call closed. The nonce is consumed exactly
+        once, inside the success transaction — a failed attempt does
+        not consume it.
+
+        The `web-bot-auth` kind submits `signedProofs` (EdDSA only).
+        Each proof's `kid` is the RFC 7638 thumbprint of an Ed25519
+        key; the RA fetches the directory at the canonical
+        Signature-Agent URL and seals the INTERSECTION of the
+        possession-proven and the directory-endorsed keys. A proof
+        for a key the directory does not currently endorse is dropped
+        (mid-rotation tolerance); at least one proof must match, else
+        `IDENTIFIER_PROOF_INVALID`.
 
         The `lei` kind instead submits a single `cesrSignature` over
         the same `signingInput`: the RA forwards it to the
@@ -1493,7 +1518,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
         '503':
-          description: Upstream unavailable (TL_UNAVAILABLE, or LEI_VERIFIER_UNAVAILABLE — retryable; the nonce is NOT consumed)
+          description: Upstream unavailable (TL_UNAVAILABLE, LEI_VERIFIER_UNAVAILABLE, or WBA_DIRECTORY_UNAVAILABLE — retryable; the nonce is NOT consumed)
           content:
             application/json:
               schema:
@@ -2893,12 +2918,16 @@ components:
       description: |
         Registers (POST) or rotates (PUT) an identifier. The kind is
         inferred from the value's lexical form — `did:web:` prefix,
-        `did:key:` prefix, or a 20-character LEI — never
-        caller-asserted.
+        `did:key:` prefix, a 20-character LEI, or an `https://`
+        Signature-Agent URL (`web-bot-auth`) — never caller-asserted.
       properties:
         value:
           type: string
-          description: The identifier to prove control of
+          description: |
+            The identifier to prove control of. For `web-bot-auth`,
+            an `https://` Signature-Agent URL, canonicalized to the
+            well-known directory URL
+            `https://<host>[:port]/.well-known/http-message-signatures-directory`.
           example: did:web:identity.acme-corp.com
         vleiPresentation:
           $ref: '#/components/schemas/VLEIPresentation'
@@ -2939,7 +2968,7 @@ components:
           description: RA-assigned UUIDv7 — the TL stream key
         kind:
           type: string
-          enum: ['did:web', 'did:key', 'lei']
+          enum: ['did:web', 'did:key', 'lei', 'web-bot-auth']
         value:
           type: string
           description: The canonical identifier this round proves
@@ -3086,7 +3115,7 @@ components:
           type: string
         kind:
           type: string
-          enum: ['did:web', 'did:key', 'lei']
+          enum: ['did:web', 'did:key', 'lei', 'web-bot-auth']
         value:
           type: string
         status:
@@ -3159,7 +3188,7 @@ components:
           type: string
         kind:
           type: string
-          enum: ['did:web', 'did:key', 'lei']
+          enum: ['did:web', 'did:key', 'lei', 'web-bot-auth']
         value:
           type: string
         identityStatus:

--- a/internal/adapter/securefetch/securefetch.go
+++ b/internal/adapter/securefetch/securefetch.go
@@ -1,0 +1,201 @@
+// Package securefetch is the shared hardened-HTTP toolkit behind every
+// registrant-steered outbound fetch in the RA: the did:web DID-document
+// resolver and the web-bot-auth Signature-Agent directory resolver both
+// build their client here so the SSRF defense is written and audited
+// once, not duplicated per adapter.
+//
+// The fetch target is chosen by an untrusted party (any host a DID or a
+// Signature-Agent URL names), so SSRF is a first-class control:
+//
+//  1. Egress IP denylist enforced at connect time, POST-DNS: RFC 1918,
+//     loopback, link-local (which covers the cloud-metadata addresses),
+//     ULA, multicast, and unspecified addresses are rejected at the
+//     dialer — never by hostname-string inspection, which a rebind
+//     defeats.
+//  2. The resolved IP is pinned per host for the life of one Dialer, so
+//     a DNS rebind between redirect hops (or TLS retries) cannot slip an
+//     internal target past check 1.
+//  3. Full WebPKI validation (chain + hostname) on every fetch — Go's
+//     default TLS behavior, left fully enabled; TLS 1.2 floor.
+//  4. Bounded: caller-set timeout, response-size cap (ReadCappedBody),
+//     and a redirect policy the caller supplies (typically bounded and
+//     pinned to the origin's registrable domain).
+//
+// The package is deliberately free of any domain dependency: it returns
+// coarse, oracle-free errors and lets each adapter map them to its own
+// wire codes.
+package securefetch
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// Dialer resolves, filters, and pins target IPs for one fetch round.
+//
+// The pin map lives for the life of the Dialer (one per client per
+// resolve call): the first connection to a host fixes its IP, so a
+// rebind between the initial fetch and a later redirect hop cannot
+// redirect a connection to a different (possibly internal) address.
+// Every chosen IP passes the denylist AFTER resolution.
+type Dialer struct {
+	allowPrivate bool
+	requirePort  string // when set, the dialer refuses any other port
+
+	mu  sync.Mutex
+	pin map[string]string // host → ip
+}
+
+// DialerOption customizes a Dialer.
+type DialerOption func(*Dialer)
+
+// WithAllowPrivateNetworks disables the egress IP denylist. FOR TESTS
+// ONLY — it exists so the full real dial path is exercisable against a
+// loopback TLS server. Never reachable from configuration.
+func WithAllowPrivateNetworks() DialerOption {
+	return func(d *Dialer) { d.allowPrivate = true }
+}
+
+// WithRequirePort pins the dialer to a single destination port; a
+// connection to any other port is refused before DNS resolution. The
+// did:web resolver sets "443" (the method has no way to express a
+// port); the web-bot-auth resolver leaves it empty because a
+// Signature-Agent URL may carry an explicit port.
+func WithRequirePort(port string) DialerOption {
+	return func(d *Dialer) { d.requirePort = port }
+}
+
+// NewDialer builds a hardened dialer.
+func NewDialer(opts ...DialerOption) *Dialer {
+	d := &Dialer{}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// DialContext dials addr, applying the port restriction (if any), the
+// per-host pin, and the egress denylist.
+func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, errors.New("securefetch: malformed dial address")
+	}
+	if d.requirePort != "" && port != d.requirePort {
+		return nil, errors.New("securefetch: refusing connection on a disallowed port")
+	}
+
+	d.mu.Lock()
+	if d.pin == nil {
+		d.pin = make(map[string]string)
+	}
+	pinnedIP, ok := d.pin[host]
+	d.mu.Unlock()
+
+	if !ok {
+		pinnedIP, err = d.resolveAndPin(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, network, net.JoinHostPort(pinnedIP, port))
+}
+
+// resolveAndPin resolves the host, applies the egress denylist to every
+// candidate address, and pins the first allowed IP. First writer wins —
+// concurrent dials for one host converge on one pin.
+func (d *Dialer) resolveAndPin(ctx context.Context, host string) (string, error) {
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil || len(ips) == 0 {
+		return "", errors.New("securefetch: host did not resolve")
+	}
+	chosen := ""
+	for _, ip := range ips {
+		if d.allowPrivate || IsPublicUnicast(ip.IP) {
+			chosen = ip.IP.String()
+			break
+		}
+	}
+	if chosen == "" {
+		return "", errors.New("securefetch: host resolves only to disallowed addresses")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if existing, dup := d.pin[host]; dup {
+		return existing, nil
+	}
+	d.pin[host] = chosen
+	return chosen, nil
+}
+
+// IsPublicUnicast reports whether ip is a routable public unicast
+// address. It rejects every class the egress denylist names: loopback,
+// RFC 1918 / ULA private ranges, link-local (which contains the
+// cloud-metadata addresses), multicast, and unspecified.
+func IsPublicUnicast(ip net.IP) bool {
+	switch {
+	case ip.IsLoopback(),
+		ip.IsPrivate(),
+		ip.IsLinkLocalUnicast(),
+		ip.IsLinkLocalMulticast(),
+		ip.IsMulticast(),
+		ip.IsUnspecified():
+		return false
+	default:
+		return true
+	}
+}
+
+// RegistrableDomain returns the eTLD+1 for a host. Single-label hosts
+// (localhost, bare TLDs) error — they have no registrable domain, so a
+// redirect policy anchored on one can never be satisfied.
+func RegistrableDomain(host string) (string, error) {
+	return publicsuffix.EffectiveTLDPlusOne(strings.ToLower(host))
+}
+
+// NewClient assembles the hardened http.Client: the pinning dialer, full
+// WebPKI validation (TLS 1.2 floor, caller-supplied root pool or system
+// roots when nil), no idle keep-alives (each client serves one
+// registrant-steered host for one round), and the caller's redirect
+// policy.
+func NewClient(d *Dialer, rootCAs *x509.CertPool, checkRedirect func(*http.Request, []*http.Request) error) *http.Client {
+	transport := &http.Transport{
+		DialContext:       d.DialContext,
+		ForceAttemptHTTP2: true,
+		TLSClientConfig:   &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12},
+		DisableKeepAlives: true,
+	}
+	return &http.Client{
+		Transport:     transport,
+		CheckRedirect: checkRedirect,
+	}
+}
+
+// ErrBodyTooLarge is returned by ReadCappedBody when the body exceeds
+// the cap. Callers map it to their own wire code.
+var ErrBodyTooLarge = errors.New("securefetch: response body exceeds the size limit")
+
+// ReadCappedBody reads at most limit bytes from r, returning
+// ErrBodyTooLarge if the source holds more. It reads limit+1 bytes so
+// the overflow is detectable without trusting Content-Length.
+func ReadCappedBody(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, ErrBodyTooLarge
+	}
+	return body, nil
+}

--- a/internal/adapter/securefetch/securefetch_test.go
+++ b/internal/adapter/securefetch/securefetch_test.go
@@ -1,0 +1,121 @@
+package securefetch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestDialer_RejectsDisallowedPort pins WithRequirePort: a connection on
+// any other port is refused before DNS, and a malformed address errors.
+func TestDialer_RejectsDisallowedPort(t *testing.T) {
+	d := NewDialer(WithRequirePort("443"))
+	if _, err := d.DialContext(context.Background(), "tcp", "example.com:8443"); err == nil {
+		t.Fatal("non-443 should be rejected")
+	}
+	if _, err := d.DialContext(context.Background(), "tcp", "malformed"); err == nil {
+		t.Fatal("malformed address should be rejected")
+	}
+}
+
+// TestDialer_BlocksLoopback drives the real dial path: the pinning
+// dialer must reject a loopback-resolving host by address class.
+func TestDialer_BlocksLoopback(t *testing.T) {
+	d := NewDialer(WithRequirePort("443"))
+	_, err := d.DialContext(context.Background(), "tcp", "localhost:443")
+	if err == nil || !strings.Contains(err.Error(), "disallowed") {
+		t.Fatalf("loopback should be rejected: %v", err)
+	}
+}
+
+// TestDialer_NoRequirePortStillDenylists confirms that with no port
+// restriction the egress denylist still rejects a loopback target.
+func TestDialer_NoRequirePortStillDenylists(t *testing.T) {
+	d := NewDialer()
+	_, err := d.DialContext(context.Background(), "tcp", "localhost:8443")
+	if err == nil || !strings.Contains(err.Error(), "disallowed") {
+		t.Fatalf("loopback should be rejected regardless of port: %v", err)
+	}
+}
+
+// TestDialer_AllowPrivateReachesLoopback proves the test-only escape
+// hatch bypasses the class filter and reaches the real dial path.
+func TestDialer_AllowPrivateReachesLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		if conn, aerr := ln.Accept(); aerr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	d := NewDialer(WithRequirePort("443"), WithAllowPrivateNetworks())
+	conn, err := d.DialContext(context.Background(), "tcp", "localhost:443")
+	if err == nil {
+		_ = conn.Close()
+	} else if strings.Contains(err.Error(), "disallowed") {
+		t.Fatalf("allowPrivate must bypass the class filter: %v", err)
+	}
+}
+
+func TestIsPublicUnicast(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", false},
+		{"10.1.2.3", false},
+		{"172.16.0.1", false},
+		{"192.168.1.1", false},
+		{"169.254.169.254", false}, // cloud metadata (link-local)
+		{"::1", false},
+		{"fe80::1", false},
+		{"fc00::1", false},
+		{"ff02::1", false},
+		{"0.0.0.0", false},
+		{"93.184.216.34", true},
+		{"2606:2800:220:1::1", true},
+	}
+	for _, tc := range cases {
+		if got := IsPublicUnicast(net.ParseIP(tc.ip)); got != tc.want {
+			t.Errorf("IsPublicUnicast(%s) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+}
+
+func TestRegistrableDomain(t *testing.T) {
+	if d, err := RegistrableDomain("www.acme-corp.com"); err != nil || d != "acme-corp.com" {
+		t.Fatalf("registrable domain = %q, %v", d, err)
+	}
+	if _, err := RegistrableDomain("localhost"); err == nil {
+		t.Fatal("single-label host must have no registrable domain")
+	}
+}
+
+func TestReadCappedBody(t *testing.T) {
+	body, err := ReadCappedBody(bytes.NewReader([]byte("hello")), 1024)
+	if err != nil || string(body) != "hello" {
+		t.Fatalf("within cap: %q, %v", body, err)
+	}
+	if _, err := ReadCappedBody(bytes.NewReader(make([]byte, 4096)), 1024); !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("over cap: want ErrBodyTooLarge, got %v", err)
+	}
+}
+
+func TestNewClient_WiresRedirectPolicy(t *testing.T) {
+	sentinel := errors.New("blocked")
+	c := NewClient(NewDialer(), nil, func(*http.Request, []*http.Request) error { return sentinel })
+	if c.Transport == nil || c.CheckRedirect == nil {
+		t.Fatal("client missing transport or redirect policy")
+	}
+	if err := c.CheckRedirect(nil, nil); !errors.Is(err, sentinel) {
+		t.Fatalf("redirect policy not wired: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,24 @@ type VLEI struct {
 	PresentTimeout time.Duration `koanf:"present-timeout"`
 }
 
+// WebBotAuth selects the web-bot-auth (web-bot-auth kind) directory
+// resolver — the HTTP Message Signatures directory fetch behind the
+// web-bot-auth identifier kind. Top-level, matching the DNS verifier and
+// the vLEI verifier, because it is a distinct outbound dependency.
+type WebBotAuth struct {
+	Directory WebBotAuthDirectory `koanf:"directory"`
+}
+
+// WebBotAuthDirectory selects the directory resolver adapter. "noop"
+// (default) performs no I/O and synthesizes the endorsed key set from
+// the keys embedded in the submitted proofs (quickstart — signature
+// verification still genuinely runs, only the live-directory binding is
+// waived; NOT for production); "http" performs the hardened HTTPS fetch
+// with WebPKI validation and SSRF dialer guards.
+type WebBotAuthDirectory struct {
+	Type string `koanf:"type"` // "noop" | "http"
+}
+
 // Keys holds key-manager configuration.
 type Keys struct {
 	Type string    `koanf:"type"` // "file"
@@ -294,6 +312,7 @@ type RAConfig struct {
 	DNS        DNS        `koanf:"dns"`
 	Identity   Identity   `koanf:"identity"`
 	VLEI       VLEI       `koanf:"vlei"`
+	WebBotAuth WebBotAuth `koanf:"webbotauth"`
 	Keys       Keys       `koanf:"keys"`
 	Store      Store      `koanf:"store"`
 	TLClient   TLClient   `koanf:"tl-client"`
@@ -418,6 +437,7 @@ func loadKoanf(path, envPrefix string) (*koanf.Koanf, error) {
 const (
 	caTypeSelf       = "self"
 	verifierTypeNoop = "noop"
+	schemeHTTP       = "http"
 )
 
 // Validate ensures the RA config is internally consistent.
@@ -465,6 +485,11 @@ func (c *RAConfig) Validate() error {
 	}
 	if c.Identity.RegisterRateLimit < 0 {
 		return errors.New("identity.register-rate-limit must not be negative")
+	}
+	switch c.WebBotAuth.Directory.Type {
+	case "", verifierTypeNoop, schemeHTTP:
+	default:
+		return fmt.Errorf("webbotauth.directory.type %q not supported (expected 'noop' or 'http')", c.WebBotAuth.Directory.Type)
 	}
 	if err := validateVLEI(&c.VLEI); err != nil {
 		return err
@@ -561,7 +586,7 @@ func validateVLEI(v *VLEI) error {
 			return errors.New("vlei.base-url is required when vlei.type is 'verifier'")
 		}
 		u, err := url.Parse(v.BaseURL)
-		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		if err != nil || u.Host == "" || (u.Scheme != schemeHTTP && u.Scheme != "https") {
 			return fmt.Errorf("vlei.base-url must be a valid http(s) URL, got %q", v.BaseURL)
 		}
 	default:
@@ -633,7 +658,7 @@ func validateAbsoluteServiceURL(raw string, allowHTTP bool, label string) error 
 	}
 	switch u.Scheme {
 	case "https":
-	case "http":
+	case schemeHTTP:
 		if !allowHTTP {
 			return fmt.Errorf("%s must use https scheme, got %q", label, u.Scheme)
 		}

--- a/internal/crypto/jwk.go
+++ b/internal/crypto/jwk.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -160,6 +161,49 @@ func PublicKeyToJWK(pub any) (json.RawMessage, error) {
 	default:
 		return nil, fmt.Errorf("%w: unsupported public key type %T", ErrJWK, pub)
 	}
+}
+
+// JWKThumbprint returns the RFC 7638 SHA-256 thumbprint of a public
+// JWK, base64url-encoded (unpadded) — the value web-bot-auth requires
+// as the JWS `kid` (draft-meunier-webbotauth-httpsig-protocol-02) and
+// the RA uses to locate the endorsing key in the resolved directory
+// JWKS. Only OKP/Ed25519 keys are supported (web-bot-auth is
+// Ed25519-only, JWK-OKP A.3); any other kty/crv errors rather than
+// returns a thumbprint over an unvetted member set.
+//
+// The digest is over the canonical JWK: the key's REQUIRED members
+// only, ordered lexicographically, with no whitespace (RFC 7638 §3).
+// For OKP those are {"crv","kty","x"}.
+func JWKThumbprint(jwk json.RawMessage) (string, error) {
+	var f jwkFields
+	if err := json.Unmarshal(jwk, &f); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrJWK, err)
+	}
+	if f.Kty != "OKP" {
+		return "", fmt.Errorf("%w: JWK thumbprint supported only for OKP/Ed25519, got kty %q", ErrJWK, f.Kty)
+	}
+	if f.Crv != "Ed25519" {
+		return "", fmt.Errorf("%w: OKP thumbprint supported only for crv Ed25519, got %q", ErrJWK, f.Crv)
+	}
+	// A thumbprint over a malformed key would silently diverge from the
+	// directory's recomputation, so the x coordinate must be a
+	// well-formed Ed25519 point.
+	if x, err := base64.RawURLEncoding.DecodeString(f.X); err != nil || len(x) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("%w: OKP x must be a %d-byte base64url value", ErrJWK, ed25519.PublicKeySize)
+	}
+	// Struct field order IS the emitted JSON order and matches the RFC
+	// 7638 lexicographic requirement (crv < kty < x); json.Marshal adds
+	// no whitespace and escapes member values correctly.
+	canonical, err := json.Marshal(struct {
+		Crv string `json:"crv"`
+		Kty string `json:"kty"`
+		X   string `json:"x"`
+	}{Crv: f.Crv, Kty: f.Kty, X: f.X})
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrJWK, err)
+	}
+	sum := sha256.Sum256(canonical)
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
 func marshalJWK(members map[string]string) (json.RawMessage, error) {

--- a/internal/crypto/jwk_test.go
+++ b/internal/crypto/jwk_test.go
@@ -327,3 +327,58 @@ func TestEdDSAJWSVerify(t *testing.T) {
 		t.Fatal("EdDSA header must not verify with an ECDSA key")
 	}
 }
+
+// TestJWKThumbprint_RFC8037Vector pins the RFC 7638 thumbprint against
+// the Ed25519 vector from RFC 8037 Appendix A.3, the same key type
+// web-bot-auth uses. V4.
+func TestJWKThumbprint_RFC8037Vector(t *testing.T) {
+	jwk := json.RawMessage(`{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`)
+	got, err := JWKThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	const want = "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k"
+	if got != want {
+		t.Fatalf("thumbprint = %q, want %q", got, want)
+	}
+}
+
+// TestJWKThumbprint_MemberOrderIndependent confirms the digest is over
+// the canonical (lexicographically-ordered) member set, so a directory
+// JWK and a proof header jwk with differently-ordered members still
+// yield the same kid. V4.
+func TestJWKThumbprint_MemberOrderIndependent(t *testing.T) {
+	a := json.RawMessage(`{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`)
+	b := json.RawMessage(`{"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo","crv":"Ed25519","kty":"OKP"}`)
+	ta, err := JWKThumbprint(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tb, err := JWKThumbprint(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ta != tb {
+		t.Fatalf("member order changed thumbprint: %q vs %q", ta, tb)
+	}
+}
+
+// TestJWKThumbprint_Rejections pins V12/V4: only OKP/Ed25519 keys have
+// a thumbprint here; every other kty/crv and a malformed x errors.
+func TestJWKThumbprint_Rejections(t *testing.T) {
+	cases := map[string]json.RawMessage{
+		"EC key":     json.RawMessage(`{"kty":"EC","crv":"P-256","x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU","y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"}`),
+		"RSA key":    json.RawMessage(`{"kty":"RSA","n":"abc","e":"AQAB"}`),
+		"OKP X25519": json.RawMessage(`{"kty":"OKP","crv":"X25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`),
+		"bad x":      json.RawMessage(`{"kty":"OKP","crv":"Ed25519","x":"!!!"}`),
+		"short x":    json.RawMessage(`{"kty":"OKP","crv":"Ed25519","x":"AAAA"}`),
+		"not json":   json.RawMessage(`{`),
+	}
+	for name, jwk := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := JWKThumbprint(jwk); err == nil {
+				t.Fatalf("%s: expected error, got nil", name)
+			}
+		})
+	}
+}

--- a/internal/domain/identity.go
+++ b/internal/domain/identity.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -29,6 +30,13 @@ const (
 	// a vLEI credential presentation verified by the LEIControlVerifier
 	// port (noop quickstart adapter, or the real vlei-verifier client).
 	KindLEI IdentifierKind = "lei"
+
+	// KindWebBotAuth — a web-bot-auth Signature-Agent URL
+	// (draft-meunier-webbotauth-httpsig-protocol-02). The authoritative
+	// keys live in the HTTP Message Signatures directory the URL serves;
+	// control is a JWS possession proof over the served signingInput
+	// whose key the directory JWKS endorses.
+	KindWebBotAuth IdentifierKind = "web-bot-auth"
 )
 
 // IdentityStatus is the verified-identity lifecycle state.
@@ -119,6 +127,8 @@ func proofMethodForKind(kind IdentifierKind) string {
 		return "did-key-sig"
 	case KindLEI:
 		return "lei-vlei-acdc"
+	case KindWebBotAuth:
+		return "web-bot-auth-sig"
 	default:
 		return ""
 	}
@@ -145,6 +155,12 @@ func InferIdentifierKind(raw string) (IdentifierKind, string, error) {
 			return "", "", NewValidationError("DID_BAD_FORMAT", "did:key value is empty")
 		}
 		return KindDIDKey, value, nil
+	case strings.HasPrefix(value, "https://"):
+		canonical, err := canonicalizeWebBotAuthURL(value)
+		if err != nil {
+			return "", "", err
+		}
+		return KindWebBotAuth, canonical, nil
 	case isLEI(value):
 		return KindLEI, strings.ToUpper(value), nil
 	case strings.HasPrefix(value, "did:"):
@@ -162,8 +178,71 @@ func InferIdentifierKind(raw string) (IdentifierKind, string, error) {
 			fmt.Sprintf("did method %q is not supported (supported: did:web, did:key)", method))
 	default:
 		return "", "", NewValidationError("IDENTIFIER_KIND_UNSUPPORTED",
-			fmt.Sprintf("identifier %q matches no supported kind (did:web, did:key, lei)", value))
+			fmt.Sprintf("identifier %q matches no supported kind (did:web, did:key, lei, web-bot-auth https:// URL)", value))
 	}
+}
+
+// wellKnownDirectoryPath is the web-bot-auth HTTP Message Signatures
+// directory path (draft-meunier-webbotauth-httpsig-protocol-02). The
+// canonical identifier value is always the URL a verifier fetches this
+// document at, so any bare-origin submission is completed to it.
+const wellKnownDirectoryPath = "/.well-known/http-message-signatures-directory"
+
+// maxWebBotAuthURLLen bounds the Signature-Agent URL. The identifier is
+// stored and sealed, so an unbounded value is a resource concern.
+const maxWebBotAuthURLLen = 2048
+
+// canonicalizeWebBotAuthURL validates a web-bot-auth Signature-Agent
+// URL and returns its canonical form: the well-known directory URL a
+// verifier fetches the directory at
+// (https://<host>[:port]/.well-known/http-message-signatures-directory).
+//
+// The URL a verifier resolves IS the identifier (the draft's
+// "Signature-Agent URL is the identifier"), so canonicalization pins it:
+//   - scheme MUST be https; host is lowercased, port preserved,
+//   - no userinfo, query, or fragment — the identifier must be
+//     byte-derivable and carry no ambient request state,
+//   - a bare origin (empty path or "/") → derive the well-known path,
+//   - an explicit well-known path → accepted as-is,
+//   - any other path → WBA_URL_INVALID.
+func canonicalizeWebBotAuthURL(value string) (string, error) {
+	if len(value) > maxWebBotAuthURLLen {
+		return "", NewValidationError("WBA_URL_INVALID",
+			fmt.Sprintf("Signature-Agent URL exceeds the %d-character limit", maxWebBotAuthURLLen))
+	}
+	u, err := url.Parse(value)
+	if err != nil {
+		return "", NewValidationError("WBA_URL_INVALID", "Signature-Agent URL is not a valid URL")
+	}
+	if u.Scheme != "https" {
+		return "", NewValidationError("WBA_URL_INVALID", "Signature-Agent URL must use https")
+	}
+	if u.User != nil {
+		return "", NewValidationError("WBA_URL_INVALID", "Signature-Agent URL must not carry userinfo")
+	}
+	if u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return "", NewValidationError("WBA_URL_INVALID", "Signature-Agent URL must not carry a query or fragment")
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return "", NewValidationError("WBA_URL_INVALID", "Signature-Agent URL has no host")
+	}
+	if err := validateDNSHost(host); err != nil {
+		return "", NewValidationError("WBA_URL_INVALID",
+			fmt.Sprintf("Signature-Agent URL host %q is not a valid DNS name", host))
+	}
+	switch u.EscapedPath() {
+	case "", "/", wellKnownDirectoryPath:
+		// bare origin (derive the path) or the directory path itself.
+	default:
+		return "", NewValidationError("WBA_URL_INVALID",
+			"Signature-Agent URL path must be empty or the well-known directory path")
+	}
+	authority := host
+	if p := u.Port(); p != "" {
+		authority += ":" + p
+	}
+	return "https://" + authority + wellKnownDirectoryPath, nil
 }
 
 // isLEI reports whether the value is shaped like an ISO 17442 LEI:

--- a/internal/domain/identity_test.go
+++ b/internal/domain/identity_test.go
@@ -31,6 +31,20 @@ func TestInferIdentifierKind(t *testing.T) {
 		{in: "did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw", wantKind: KindDIDKey, wantCanonical: "did:key:zDnaeUm3QkcyZWZTPttxB711jgqRDhkwvhF485SFw1bDZ9AQw"},
 		{in: "5493001KJTIIGC8Y1R17", wantKind: KindLEI, wantCanonical: "5493001KJTIIGC8Y1R17"},
 		{in: "5493001kjtiigc8y1r17", wantKind: KindLEI, wantCanonical: "5493001KJTIIGC8Y1R17"},
+		// web-bot-auth: bare origin derives the well-known directory
+		// URL; an explicit directory path is accepted; host lowercased;
+		// port preserved. V1.
+		{in: "https://signer.example.com", wantKind: KindWebBotAuth, wantCanonical: "https://signer.example.com/.well-known/http-message-signatures-directory"},
+		{in: "https://Signer.Example.COM/", wantKind: KindWebBotAuth, wantCanonical: "https://signer.example.com/.well-known/http-message-signatures-directory"},
+		{in: "  https://signer.example.com:8443  ", wantKind: KindWebBotAuth, wantCanonical: "https://signer.example.com:8443/.well-known/http-message-signatures-directory"},
+		{in: "https://signer.example.com/.well-known/http-message-signatures-directory", wantKind: KindWebBotAuth, wantCanonical: "https://signer.example.com/.well-known/http-message-signatures-directory"},
+		{in: "http://signer.example.com", wantErr: "IDENTIFIER_KIND_UNSUPPORTED"},
+		{in: "https://signer.example.com/other/path", wantErr: "WBA_URL_INVALID"},
+		{in: "https://user@signer.example.com", wantErr: "WBA_URL_INVALID"},
+		{in: "https://signer.example.com/?a=b", wantErr: "WBA_URL_INVALID"},
+		{in: "https://signer.example.com/#frag", wantErr: "WBA_URL_INVALID"},
+		{in: "https://", wantErr: "WBA_URL_INVALID"},
+		{in: "https://signer_bad.example.com", wantErr: "WBA_URL_INVALID"},
 		{in: "did:web:", wantErr: "DID_BAD_FORMAT"},
 		{in: "did:web:acme.com%3A8443", wantErr: "DID_BAD_FORMAT"},
 		{in: "did:web:user@acme.com", wantErr: "DID_BAD_FORMAT"},
@@ -80,6 +94,15 @@ func TestValidateDNSHostEdges(t *testing.T) {
 	}
 	if _, _, err := InferIdentifierKind("did:web:acme-.com"); err == nil {
 		t.Error("trailing-hyphen label should fail")
+	}
+}
+
+// TestWebBotAuthURLLengthBound pins V1's ≤2048-character ceiling on the
+// Signature-Agent URL.
+func TestWebBotAuthURLLengthBound(t *testing.T) {
+	longHost := strings.Repeat("a", 2100) + ".example.com"
+	if _, _, err := InferIdentifierKind("https://" + longHost); err == nil {
+		t.Error("over-long web-bot-auth URL should fail")
 	}
 }
 
@@ -266,6 +289,7 @@ func TestProofMethodForKind(t *testing.T) {
 		KindDIDWeb:            "did-web-sig",
 		KindDIDKey:            "did-key-sig",
 		KindLEI:               "lei-vlei-acdc",
+		KindWebBotAuth:        "web-bot-auth-sig",
 		IdentifierKind("???"): "",
 	}
 	for kind, want := range cases {

--- a/internal/port/directory.go
+++ b/internal/port/directory.go
@@ -1,0 +1,53 @@
+package port
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// DirectoryKey is one key the web-bot-auth HTTP Message Signatures
+// directory endorses, as the RA needs it for the verify-control gate.
+//
+// JWK is the directory JWKS entry quoted VERBATIM — the exact bytes the
+// directory served — so the sealed verification method can carry it
+// untouched (the no-derived-values rule the DID resolver also honors).
+// The RFC 7638 thumbprint used to match a proof's `kid` is recomputed
+// from the required members, so any extra directory metadata inside the
+// object (nbf/exp) never perturbs the match.
+type DirectoryKey struct {
+	// JWK is the directory's key object, verbatim.
+	JWK json.RawMessage
+	// NotBefore and NotAfter bound the key's validity window. A zero
+	// value means unbounded on that side. Keys outside the window are
+	// skipped at match time (mid-rotation tolerance) — never fatal.
+	NotBefore time.Time
+	NotAfter  time.Time
+}
+
+// WebBotAuthDirectoryResolver fetches and parses the HTTP Message
+// Signatures directory a web-bot-auth Signature-Agent URL serves — the
+// authoritative key source for the web-bot-auth control proof, the
+// did:web resolver's analog on the web-bot-auth lane:
+//
+//   - The "http" adapter performs a hardened HTTPS fetch (shared
+//     securefetch transport: WebPKI, SSRF dialer guards, DNS-rebind pin,
+//     size cap, bounded same-registrable-domain redirects) of the
+//     directory at the canonical well-known URL, checks the
+//     content-type, and parses the JWKS. Hints are ignored — the
+//     resolved directory is always the key source.
+//
+//   - The "noop" adapter performs no I/O and synthesizes the key set
+//     from the hints (the kid → JWK pairs embedded in the submitted
+//     proofs' `jwk` headers). Signature verification still genuinely
+//     runs against those keys, so sealed events stay self-verifying even
+//     from quickstart runs — only the binding "the live directory really
+//     endorses this key" is waived. Mirrors the noop DID resolver. NOT
+//     for production.
+type WebBotAuthDirectoryResolver interface {
+	// Resolve returns the endorsed key set for the canonical directory
+	// URL. Fetch-layer failures are returned as retryable (503-class)
+	// domain errors, never 500 — the request was valid and consumed no
+	// state.
+	Resolve(ctx context.Context, directoryURL string, hints []KeyHint) ([]DirectoryKey, error)
+}

--- a/internal/ra/handler/identity_handler_test.go
+++ b/internal/ra/handler/identity_handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/agentnameservice/ans/internal/adapter/auth"
 	"github.com/agentnameservice/ans/internal/adapter/cert"
 	"github.com/agentnameservice/ans/internal/adapter/didresolver"
+	"github.com/agentnameservice/ans/internal/adapter/directory/webbotauth"
 	"github.com/agentnameservice/ans/internal/adapter/eventbus"
 	"github.com/agentnameservice/ans/internal/adapter/leiverifier"
 	"github.com/agentnameservice/ans/internal/adapter/store/sqlite"
@@ -95,6 +96,7 @@ func newIdentityHTTPFixture(t *testing.T) *identityHTTPFixture {
 		didresolver.NewNoopResolver(),
 		okSealer{},
 		leiverifier.NewNoop(),
+		webbotauth.NewNoopResolver(),
 		db,
 	).WithChallengeTTL(30 * time.Minute)
 

--- a/internal/ra/service/identity.go
+++ b/internal/ra/service/identity.go
@@ -117,13 +117,14 @@ func NewIdentityService(
 	resolver port.DIDResolver,
 	sealer IdentityEventSealer,
 	leiCtl port.LEIControlVerifier,
+	dirResolver port.WebBotAuthDirectoryResolver,
 	uow port.UnitOfWork,
 ) *IdentityService {
 	return &IdentityService{
 		identities:   identities,
 		links:        links,
 		agents:       agents,
-		verifiers:    newControlVerifiers(resolver, leiCtl),
+		verifiers:    newControlVerifiers(resolver, leiCtl, dirResolver),
 		sealer:       sealer,
 		uow:          uow,
 		challengeTTL: time.Hour,
@@ -157,6 +158,12 @@ func NewIdentityService(
 // from.
 func (s *IdentityService) WithLogger(logger zerolog.Logger) *IdentityService {
 	s.logger = logger.With().Str("component", "identity-service").Logger()
+	// The web-bot-auth verifier keeps its own component-tagged logger for
+	// the directory-fetch and intersection-drop signals; propagate the
+	// same base logger so a kind's diagnostics share the request's fields.
+	if wba, ok := s.verifiers[domain.KindWebBotAuth].(*webBotAuthVerifier); ok {
+		wba.logger = logger.With().Str("component", "webbotauth-verifier").Logger()
+	}
 	return s
 }
 
@@ -209,6 +216,12 @@ func (s *IdentityService) WithSealTimeout(timeout time.Duration) *IdentityServic
 // WithClock overrides the time source (tests only).
 func (s *IdentityService) WithClock(fn func() time.Time) *IdentityService {
 	s.clock = fn
+	// Keep the web-bot-auth verifier's nbf/exp window decisions on the
+	// same clock the service uses, so tests that override time see
+	// consistent directory-key window behavior.
+	if wba, ok := s.verifiers[domain.KindWebBotAuth].(*webBotAuthVerifier); ok {
+		wba.clock = fn
+	}
 	return s
 }
 

--- a/internal/ra/service/identity_test.go
+++ b/internal/ra/service/identity_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/agentnameservice/ans/internal/adapter/didresolver"
+	"github.com/agentnameservice/ans/internal/adapter/directory/webbotauth"
 	"github.com/agentnameservice/ans/internal/adapter/keymanager"
 	"github.com/agentnameservice/ans/internal/adapter/leiverifier"
 	"github.com/agentnameservice/ans/internal/adapter/store/sqlite"
@@ -146,6 +147,7 @@ func newIdentityFixtureWithLEI(t *testing.T, resolver port.DIDResolver, lei port
 		resolver,
 		sealer,
 		lei,
+		webbotauth.NewNoopResolver(),
 		db,
 	).WithSigner(service.EventSigner{
 		KeyManager: km,
@@ -1466,6 +1468,7 @@ func TestNilSealerFailsClosed(t *testing.T) {
 		didresolver.NewNoopResolver(),
 		nil, // no sealer
 		leiverifier.NewNoop(),
+		webbotauth.NewNoopResolver(),
 		db,
 	)
 	ctx := context.Background()
@@ -1564,6 +1567,7 @@ func TestReleaseClaim_LeakedClaimIsLoggedNotSwallowed(t *testing.T) {
 		didresolver.NewNoopResolver(),
 		sealer,
 		leiverifier.NewNoop(),
+		webbotauth.NewNoopResolver(),
 		db,
 	).WithSigner(service.EventSigner{KeyManager: km, KeyID: "ra-signer", RaID: "ra-test"}).
 		WithClock(clock.Now).WithLogger(zerolog.New(io.Discard))

--- a/internal/ra/service/identitykinds.go
+++ b/internal/ra/service/identitykinds.go
@@ -47,6 +47,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	anscrypto "github.com/agentnameservice/ans/internal/crypto"
 	"github.com/agentnameservice/ans/internal/domain"
@@ -143,7 +144,7 @@ type controlVerifier interface {
 // did:ion, and did:ethr slot in here when their verifiers are real;
 // until then domain.InferIdentifierKind may recognize a value's form
 // but the missing registry entry yields IDENTIFIER_KIND_UNSUPPORTED.
-func newControlVerifiers(resolver port.DIDResolver, leiCtl port.LEIControlVerifier) map[domain.IdentifierKind]controlVerifier {
+func newControlVerifiers(resolver port.DIDResolver, leiCtl port.LEIControlVerifier, dirResolver port.WebBotAuthDirectoryResolver) map[domain.IdentifierKind]controlVerifier {
 	// NOTE: deliberately NOT exhaustive over IdentifierKind — a
 	// recognized-but-absent kind (did:plc, did:ion, did:ethr, until
 	// their verifiers ship) MUST fail with IDENTIFIER_KIND_UNSUPPORTED
@@ -151,8 +152,9 @@ func newControlVerifiers(resolver port.DIDResolver, leiCtl port.LEIControlVerifi
 	// only registered when configured.
 	//exhaustive:ignore // registry is intentionally partial; absent kinds map to IDENTIFIER_KIND_UNSUPPORTED
 	m := map[domain.IdentifierKind]controlVerifier{
-		domain.KindDIDWeb: &didWebVerifier{resolver: resolver},
-		domain.KindDIDKey: &didKeyVerifier{},
+		domain.KindDIDWeb:     &didWebVerifier{resolver: resolver},
+		domain.KindDIDKey:     &didKeyVerifier{},
+		domain.KindWebBotAuth: &webBotAuthVerifier{resolver: dirResolver, clock: time.Now},
 	}
 	if leiCtl != nil {
 		m[domain.KindLEI] = &leiVerifier{v: leiCtl} // absent → IDENTIFIER_KIND_UNSUPPORTED

--- a/internal/ra/service/webbotauth_flow_test.go
+++ b/internal/ra/service/webbotauth_flow_test.go
@@ -1,0 +1,166 @@
+package service_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	anscrypto "github.com/agentnameservice/ans/internal/crypto"
+	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/ra/service"
+	identityevent "github.com/agentnameservice/ans/internal/tl/event/identity"
+)
+
+// signEd25519Flow builds a compact EdDSA JWS over the served signingInput
+// with the key's thumbprint as kid and its JWK embedded as the hint — the
+// shape a web-bot-auth registrant's tooling produces. The noop directory
+// resolver synthesizes the endorsed key set from that hint, so the full
+// verify-control flow runs end to end without any outbound fetch.
+func signEd25519Flow(t *testing.T, priv ed25519.PrivateKey, jwk json.RawMessage, kid, signingInput string) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]any{"alg": "EdDSA", "kid": kid, "jwk": jwk})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encodedHeader := base64.RawURLEncoding.EncodeToString(header)
+	toSign := encodedHeader + "." + signingInput
+	sig := ed25519.Sign(priv, []byte(toSign))
+	return toSign + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// TestIdentityVerifyControl_WebBotAuthNoop drives the full web-bot-auth
+// verify-control flow on the quickstart (noop) directory resolver: the
+// canonical well-known value is sealed as IDENTITY_VERIFIED with the
+// web-bot-auth-sig proof method, and the sealed key is self-verifying.
+func TestIdentityVerifyControl_WebBotAuthNoop(t *testing.T) {
+	t.Parallel()
+	fx := newIdentityFixture(t, nil)
+	ctx := context.Background()
+
+	res, err := fx.svc.Register(ctx, fx.providerID, "https://Signer.Example.com")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	wantValue := "https://signer.example.com/.well-known/http-message-signatures-directory"
+	if res.Identity.Value != wantValue {
+		t.Fatalf("canonical value = %q, want %q", res.Identity.Value, wantValue)
+	}
+	if res.Identity.Kind != domain.KindWebBotAuth {
+		t.Fatalf("kind = %q", res.Identity.Kind)
+	}
+	// No advisory keys on the noop path → a single unkeyed challenge.
+	if len(res.Challenges) != 1 || res.Challenges[0].Kid != "" {
+		t.Fatalf("challenge round = %+v", res.Challenges)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwk, err := anscrypto.PublicKeyToJWK(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp, err := anscrypto.JWKThumbprint(jwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jws := signEd25519Flow(t, priv, jwk, tp, res.Challenges[0].SigningInput)
+
+	identity, err := fx.svc.VerifyControl(ctx, fx.providerID, res.Identity.IdentityID,
+		service.ProofSubmission{SignedProofs: []string{jws}})
+	if err != nil {
+		t.Fatalf("verify-control: %v", err)
+	}
+	if identity.Status != domain.IdentityVerified || identity.ProofMethod != "web-bot-auth-sig" {
+		t.Fatalf("verified state: status=%s proofMethod=%s", identity.Status, identity.ProofMethod)
+	}
+
+	rows := fx.drainSealed(t)
+	if len(rows) != 1 {
+		t.Fatalf("sealed events: %d", len(rows))
+	}
+	inner := fx.decodeSealed(t, rows[0])
+	if inner.EventType != identityevent.TypeIdentityVerified || len(inner.Keys) != 1 {
+		t.Fatalf("sealed event: %+v", inner)
+	}
+	key := inner.Keys[0]
+	if key.ID() != wantValue+"#"+tp {
+		t.Fatalf("sealed key id = %q, want %q", key.ID(), wantValue+"#"+tp)
+	}
+	var vm struct {
+		Type         string          `json:"type"`
+		PublicKeyJwk json.RawMessage `json:"publicKeyJwk"`
+	}
+	if err := json.Unmarshal(key.VerificationMethod, &vm); err != nil {
+		t.Fatalf("sealed VM not an object: %v", err)
+	}
+	if vm.Type != "JsonWebKey2020" {
+		t.Fatalf("sealed VM type = %q", vm.Type)
+	}
+	sealedPub, err := anscrypto.ParseJWK(vm.PublicKeyJwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := anscrypto.VerifyStandardJWSWithPublicKey(sealedPub, key.SignedProof); err != nil {
+		t.Fatalf("sealed proof does not verify against sealed key: %v", err)
+	}
+}
+
+// TestIdentityRotate_WebBotAuth covers a same-kind URL replacement: a
+// verified web-bot-auth identity rotated to a new Signature-Agent URL
+// re-proves control and seals IDENTITY_UPDATED.
+func TestIdentityRotate_WebBotAuth(t *testing.T) {
+	t.Parallel()
+	fx := newIdentityFixture(t, nil)
+	ctx := context.Background()
+
+	res, err := fx.svc.Register(ctx, fx.providerID, "https://signer-one.example.com")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	verifyWBA(t, fx, res)
+
+	// Rotate to a new same-kind URL.
+	rot, err := fx.svc.Rotate(ctx, fx.providerID, res.Identity.IdentityID, "https://signer-two.example.com")
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if rot.Identity.PendingValue == "" {
+		t.Fatalf("rotate should stage a pending value: %+v", rot.Identity)
+	}
+	verifyWBA(t, fx, rot)
+
+	// The second seal is an update, not a fresh verify.
+	rows := fx.drainSealed(t)
+	last := fx.decodeSealed(t, rows[len(rows)-1])
+	if last.EventType != identityevent.TypeIdentityUpdated {
+		t.Fatalf("rotation sealed %s, want IDENTITY_UPDATED", last.EventType)
+	}
+}
+
+// verifyWBA proves control for a pending web-bot-auth challenge round on
+// the noop path.
+func verifyWBA(t *testing.T, fx *identityFixture, res *service.IdentityChallengeResponse) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwk, err := anscrypto.PublicKeyToJWK(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp, err := anscrypto.JWKThumbprint(jwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jws := signEd25519Flow(t, priv, jwk, tp, res.Challenges[0].SigningInput)
+	if _, err := fx.svc.VerifyControl(context.Background(), fx.providerID, res.Identity.IdentityID,
+		service.ProofSubmission{SignedProofs: []string{jws}}); err != nil {
+		t.Fatalf("verify-control: %v", err)
+	}
+}

--- a/internal/ra/service/webbotauthverifier.go
+++ b/internal/ra/service/webbotauthverifier.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	anscrypto "github.com/agentnameservice/ans/internal/crypto"
+	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/port"
+	identityevent "github.com/agentnameservice/ans/internal/tl/event/identity"
+)
+
+// webBotAuthVerifier is the web-bot-auth controlVerifier — the per-kind
+// gate behind the web-bot-auth identifier kind. It proves that the
+// Signature-Agent URL genuinely endorses the key the registrant signs
+// with, by making TWO gates pass together:
+//
+//   - possession — a compact JWS over the served signingInput verifies
+//     against a key (the JWS proof, the did:key/did:web analog), and
+//   - endorsement — that key is a member of the JWKS the URL's HTTP
+//     Message Signatures directory serves (the directory fetch, the
+//     did:web document-resolution analog).
+//
+// The directory is authoritative: the key sealed and verified against is
+// the entry located in the RESOLVED directory (by RFC 7638 thumbprint),
+// never the self-asserted `jwk` in the proof header — that header key is
+// a resolution hint only (the noop resolver synthesizes the endorsed set
+// from it for the quickstart). This mirrors didWebVerifier, where the
+// resolved document — not the proof — is the key source.
+//
+// The fetch target is the identifier's canonical value: the well-known
+// directory URL (domain.canonicalizeWebBotAuthURL), so any verifier
+// reproduces the same fetch. web-bot-auth is Ed25519-only; a proof
+// naming any other algorithm or a directory key of any other type is
+// rejected (alg-confusion defense).
+type webBotAuthVerifier struct {
+	resolver port.WebBotAuthDirectoryResolver
+	// clock sources the wall-clock used to test each directory key's
+	// nbf/exp window. Injected so the service's WithClock override drives
+	// window decisions deterministically in tests.
+	clock  func() time.Time
+	logger zerolog.Logger
+}
+
+// now returns the current time through the injected clock, defaulting to
+// the wall clock when unset (a zero-value verifier is still usable).
+func (v *webBotAuthVerifier) now() time.Time {
+	if v.clock != nil {
+		return v.clock().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// Challenges runs the advisory directory fetch and enumerates the
+// endorsed keys' thumbprints as the offered `kid`s. The fetch is
+// advisory only — the verify-time fetch is authoritative — so a failure
+// is tolerated: the registrant then receives a single unkeyed entry and
+// names keys via the JWS `kid`/`jwk` headers at verify time (the noop
+// DID resolver analog). A directory key whose type has no RFC 7638
+// thumbprint here (non-Ed25519) is skipped: it can never be a
+// web-bot-auth kid.
+func (v *webBotAuthVerifier) Challenges(ctx context.Context, identity *domain.VerifiedIdentity, signingInput string) ([]ProofChallenge, error) {
+	value := identity.EffectiveValue()
+	keys, err := v.resolver.Resolve(ctx, value, nil)
+	if err != nil {
+		v.logger.Debug().
+			Err(err).
+			Str("identityId", identity.IdentityID).
+			Msg("web-bot-auth advisory directory fetch failed; offering a single unkeyed challenge")
+		return []ProofChallenge{{SigningInput: signingInput}}, nil
+	}
+	challenges := make([]ProofChallenge, 0, len(keys))
+	for _, k := range keys {
+		tp, terr := anscrypto.JWKThumbprint(k.JWK)
+		if terr != nil {
+			continue
+		}
+		challenges = append(challenges, ProofChallenge{Kid: tp, SigningInput: signingInput})
+	}
+	if len(challenges) == 0 {
+		return []ProofChallenge{{SigningInput: signingInput}}, nil
+	}
+	return challenges, nil
+}
+
+// VerifyProofs runs the web-bot-auth control proof. It parses the JWS
+// envelope (payload equality checked BEFORE any signature work),
+// authoritatively fetches the directory at the canonical value, and
+// seals the INTERSECTION of possession-proven and directory-endorsed
+// keys: a proof whose key the directory does not currently endorse is
+// DROPPED (mid-rotation tolerance), not fatal, but at least one proof
+// must match. Each sealed key is the directory JWK verbatim; the JWS is
+// verified against it, so the seal is self-verifying.
+func (v *webBotAuthVerifier) VerifyProofs(ctx context.Context, identity *domain.VerifiedIdentity, sub ProofSubmission, signingInput string) ([]identityevent.ProvenKey, error) {
+	parsed, hints, err := parseJWSProofs(sub, signingInput)
+	if err != nil {
+		return nil, err
+	}
+	value := identity.EffectiveValue()
+	keys, err := v.resolver.Resolve(ctx, value, hints)
+	if err != nil {
+		// Retryable 503-class from the resolver — propagated as-is so the
+		// handler renders a retryable Problem, never a 500.
+		return nil, err
+	}
+
+	// Index the endorsed keys by RECOMPUTED thumbprint (never the kid
+	// string a directory entry might carry), skipping keys outside their
+	// validity window and keys whose type has no thumbprint (non-Ed25519,
+	// which can never be a web-bot-auth kid). First-wins on a degenerate
+	// duplicate thumbprint.
+	now := v.now()
+	byThumbprint := make(map[string]port.DirectoryKey, len(keys))
+	for _, k := range keys {
+		if !withinKeyWindow(k, now) {
+			continue
+		}
+		tp, terr := anscrypto.JWKThumbprint(k.JWK)
+		if terr != nil {
+			continue
+		}
+		if _, dup := byThumbprint[tp]; dup {
+			continue
+		}
+		byThumbprint[tp] = k
+	}
+
+	// Keep only the proofs whose kid names a currently-endorsed key. A
+	// dropped proof is a benign mid-rotation artifact (the registrant
+	// still holds a key the directory has since retired), logged at DEBUG
+	// but never fatal.
+	matched := make([]jwsProof, 0, len(parsed))
+	for _, p := range parsed {
+		if _, ok := byThumbprint[p.header.Kid]; !ok {
+			v.logger.Debug().
+				Str("identityId", identity.IdentityID).
+				Str("kid", p.header.Kid).
+				Msg("web-bot-auth proof names a key the directory does not endorse; dropping")
+			continue
+		}
+		// web-bot-auth is Ed25519-only: reject any other JWS algorithm
+		// outright (alg-confusion defense) rather than relying on the
+		// key-type check inside the verify step alone.
+		if p.header.Alg != anscrypto.AlgEdDSA {
+			return nil, domain.NewValidationError("IDENTIFIER_PROOF_INVALID",
+				fmt.Sprintf("web-bot-auth requires alg %q, got %q", anscrypto.AlgEdDSA, p.header.Alg))
+		}
+		// The embedded `jwk` header is a hint only, but when present it
+		// MUST be the key we located: its RFC 7638 thumbprint must equal
+		// the kid (the encoding-independent form of "the hint is the
+		// endorsed key"; byte-equality holds by construction on the noop
+		// path, where the directory key IS the hint's bytes). This also
+		// enforces the web-bot-auth `kid == thumbprint(jwk)` rule.
+		if len(p.header.Jwk) > 0 {
+			tp, terr := anscrypto.JWKThumbprint(p.header.Jwk)
+			if terr != nil || tp != p.header.Kid {
+				return nil, domain.NewValidationError("IDENTIFIER_PROOF_INVALID",
+					fmt.Sprintf("embedded jwk for kid %q is not that key", p.header.Kid))
+			}
+		}
+		matched = append(matched, p)
+	}
+	if len(matched) == 0 {
+		return nil, domain.NewValidationError("IDENTIFIER_PROOF_INVALID",
+			"no submitted proof matched a key the directory currently endorses")
+	}
+
+	// Verify and seal the matched proofs against the DIRECTORY keys
+	// (never the header jwk) through the shared machinery. The sealed
+	// verification method is an object carrying the directory JWK
+	// verbatim, so the event stays self-verifying.
+	proven, err := sealJWSProofs(matched, value, func(kid string) (any, json.RawMessage, error) {
+		dk := byThumbprint[kid]
+		pub, perr := anscrypto.ParseJWK(dk.JWK)
+		if perr != nil {
+			return nil, nil, domain.NewValidationError("IDENTIFIER_PROOF_INVALID",
+				fmt.Sprintf("directory key for kid %q did not parse: %v", kid, perr))
+		}
+		vm, verr := buildWebBotAuthVM(value, kid, dk.JWK)
+		if verr != nil {
+			return nil, nil, domain.NewInternalError("PROOF_SEAL",
+				"could not build web-bot-auth verification method", verr)
+		}
+		return pub, vm, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	v.logger.Info().
+		Str("identityId", identity.IdentityID).
+		Int("provenKeys", len(proven)).
+		Msg("web-bot-auth control proofs verified against the directory")
+	return proven, nil
+}
+
+// withinKeyWindow reports whether now falls inside a directory key's
+// optional nbf/exp validity window. A zero bound is unbounded on that
+// side.
+func withinKeyWindow(k port.DirectoryKey, now time.Time) bool {
+	if !k.NotBefore.IsZero() && now.Before(k.NotBefore) {
+		return false
+	}
+	if !k.NotAfter.IsZero() && now.After(k.NotAfter) {
+		return false
+	}
+	return true
+}
+
+// buildWebBotAuthVM renders the sealed verification method for a
+// web-bot-auth proven key: an object whose `id` is "<value>#<thumbprint>"
+// (a non-empty id the TL codec requires — event.go validateProofFields)
+// and whose `publicKeyJwk` is the directory JWK VERBATIM (nothing
+// derived or re-encoded enters a seal).
+func buildWebBotAuthVM(value, thumbprint string, jwk json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(struct {
+		ID           string          `json:"id"`
+		Type         string          `json:"type"`
+		PublicKeyJwk json.RawMessage `json:"publicKeyJwk"`
+	}{
+		ID:           value + "#" + thumbprint,
+		Type:         "JsonWebKey2020",
+		PublicKeyJwk: jwk,
+	})
+}
+
+// compile-time conformance.
+var _ controlVerifier = (*webBotAuthVerifier)(nil)

--- a/internal/ra/service/webbotauthverifier_test.go
+++ b/internal/ra/service/webbotauthverifier_test.go
@@ -1,0 +1,460 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	anscrypto "github.com/agentnameservice/ans/internal/crypto"
+	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/port"
+)
+
+// fakeDirResolver is a controllable port.WebBotAuthDirectoryResolver: it
+// returns a fixed key set (or error) and records the URL + hints it was
+// asked for, so a test can assert the fetch target and the hint pass-through.
+type fakeDirResolver struct {
+	keys     []port.DirectoryKey
+	err      error
+	gotURL   string
+	gotHints []port.KeyHint
+	calls    int
+}
+
+func (f *fakeDirResolver) Resolve(_ context.Context, url string, hints []port.KeyHint) ([]port.DirectoryKey, error) {
+	f.calls++
+	f.gotURL = url
+	f.gotHints = hints
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.keys, nil
+}
+
+const wbaSigningInput = "eyJ0ZXN0Ijoid2ViLWJvdC1hdXRoIn0"
+
+func wbaNow() time.Time { return time.Date(2026, 6, 10, 15, 0, 0, 0, time.UTC) }
+
+// newWBAIdentity builds a PENDING_CONTROL web-bot-auth identity whose
+// EffectiveValue is the canonical well-known directory URL.
+func newWBAIdentity(t *testing.T) *domain.VerifiedIdentity {
+	t.Helper()
+	id, err := domain.NewVerifiedIdentity("id-1", "owner-1", "https://signer.example.com", wbaNow())
+	if err != nil {
+		t.Fatalf("build identity: %v", err)
+	}
+	if id.Kind != domain.KindWebBotAuth {
+		t.Fatalf("kind = %q, want web-bot-auth", id.Kind)
+	}
+	return id
+}
+
+func newWBAVerifier(f *fakeDirResolver) *webBotAuthVerifier {
+	return &webBotAuthVerifier{resolver: f, clock: wbaNow, logger: zerolog.Nop()}
+}
+
+// genEd25519JWK returns a fresh Ed25519 keypair, its minimal JWK, and its
+// RFC 7638 thumbprint.
+func genEd25519JWK(t *testing.T) (ed25519.PrivateKey, json.RawMessage, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwk, err := anscrypto.PublicKeyToJWK(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp, err := anscrypto.JWKThumbprint(jwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv, jwk, tp
+}
+
+// signEd25519Proof builds a compact EdDSA JWS whose payload segment IS
+// the served signingInput verbatim (RFC 8037: EdDSA signs the raw signing
+// input, no prehash). alg overrides the header algorithm for alg-pinning
+// tests; jwk, when non-nil, is embedded as the header hint.
+func signEd25519Proof(t *testing.T, priv ed25519.PrivateKey, alg, kid, signingInput string, jwk json.RawMessage) string {
+	t.Helper()
+	header := map[string]any{"alg": alg, "kid": kid}
+	if jwk != nil {
+		header["jwk"] = jwk
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encodedHeader := base64.RawURLEncoding.EncodeToString(headerJSON)
+	toSign := encodedHeader + "." + signingInput
+	sig := ed25519.Sign(priv, []byte(toSign))
+	return toSign + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// TestWBAVerify_HappyPath: one proven key sealed as a VM object with a
+// non-empty id, the directory JWK verbatim, self-verifying (V2, V4, V7,
+// V17). The resolver is asked for the canonical well-known URL (V8).
+func TestWBAVerify_HappyPath(t *testing.T) {
+	t.Parallel()
+	priv, jwk, tp := genEd25519JWK(t)
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwk}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, wbaSigningInput, jwk)
+
+	proven, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if len(proven) != 1 {
+		t.Fatalf("proven keys = %d, want 1", len(proven))
+	}
+	if f.gotURL != id.Value {
+		t.Fatalf("fetch target = %q, want canonical value %q", f.gotURL, id.Value)
+	}
+
+	var vm struct {
+		ID           string          `json:"id"`
+		Type         string          `json:"type"`
+		PublicKeyJwk json.RawMessage `json:"publicKeyJwk"`
+	}
+	if err := json.Unmarshal(proven[0].VerificationMethod, &vm); err != nil {
+		t.Fatalf("VM not an object: %v", err)
+	}
+	if want := id.Value + "#" + tp; vm.ID != want {
+		t.Fatalf("VM id = %q, want %q", vm.ID, want)
+	}
+	if vm.Type != "JsonWebKey2020" {
+		t.Fatalf("VM type = %q", vm.Type)
+	}
+	if !bytes.Equal(vm.PublicKeyJwk, jwk) {
+		t.Fatalf("sealed jwk not the directory jwk verbatim")
+	}
+	// Self-verifying: the sealed proof verifies against the sealed key.
+	pub, err := anscrypto.ParseJWK(vm.PublicKeyJwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := anscrypto.VerifyStandardJWSWithPublicKey(pub, proven[0].SignedProof); err != nil {
+		t.Fatalf("sealed proof does not verify against sealed key: %v", err)
+	}
+}
+
+// TestWBAVerify_AuthoritativeIsDirectory: the sealed key is the DIRECTORY
+// JWK verbatim, NOT the (thumbprint-equal but byte-different) header hint
+// (V3). The directory entry carries an extra `use` member the minimal
+// header jwk omits; both share the same thumbprint.
+func TestWBAVerify_AuthoritativeIsDirectory(t *testing.T) {
+	t.Parallel()
+	priv, minimalJWK, tp := genEd25519JWK(t)
+	// Directory serves the same key with an extra member — byte-different,
+	// thumbprint-identical (the thumbprint is over crv/kty/x only).
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(minimalJWK, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["use"] = json.RawMessage(`"sig"`)
+	dirJWK, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(dirJWK, minimalJWK) {
+		t.Fatal("directory jwk should differ in bytes from the header hint")
+	}
+
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: dirJWK}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, wbaSigningInput, minimalJWK)
+
+	proven, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	var vm struct {
+		PublicKeyJwk json.RawMessage `json:"publicKeyJwk"`
+	}
+	_ = json.Unmarshal(proven[0].VerificationMethod, &vm)
+	if !bytes.Equal(vm.PublicKeyJwk, dirJWK) {
+		t.Fatalf("sealed jwk = %s, want the directory bytes %s", vm.PublicKeyJwk, dirJWK)
+	}
+}
+
+// TestWBAVerify_MultiKey: two directory-endorsed keys, two proofs, both
+// sealed (V6, V16).
+func TestWBAVerify_MultiKey(t *testing.T) {
+	t.Parallel()
+	privA, jwkA, tpA := genEd25519JWK(t)
+	privB, jwkB, tpB := genEd25519JWK(t)
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwkA}, {JWK: jwkB}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jwsA := signEd25519Proof(t, privA, anscrypto.AlgEdDSA, tpA, wbaSigningInput, jwkA)
+	jwsB := signEd25519Proof(t, privB, anscrypto.AlgEdDSA, tpB, wbaSigningInput, jwkB)
+
+	proven, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jwsA, jwsB}}, wbaSigningInput)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if len(proven) != 2 {
+		t.Fatalf("proven = %d, want 2", len(proven))
+	}
+}
+
+// TestWBAVerify_DropsUnmatchedProof: a proof for a key the directory does
+// not endorse is DROPPED, not fatal, as long as another proof matches
+// (V16 intersection, mid-rotation tolerance).
+func TestWBAVerify_DropsUnmatchedProof(t *testing.T) {
+	t.Parallel()
+	privA, jwkA, tpA := genEd25519JWK(t)
+	privB, jwkB, tpB := genEd25519JWK(t)
+	// Directory endorses A only.
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwkA}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jwsA := signEd25519Proof(t, privA, anscrypto.AlgEdDSA, tpA, wbaSigningInput, jwkA)
+	jwsB := signEd25519Proof(t, privB, anscrypto.AlgEdDSA, tpB, wbaSigningInput, jwkB)
+
+	proven, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jwsA, jwsB}}, wbaSigningInput)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if len(proven) != 1 {
+		t.Fatalf("proven = %d, want 1 (B dropped)", len(proven))
+	}
+}
+
+// TestWBAVerify_NoneMatchedRejected: every proof names a key absent from
+// the directory → reject (V16: ≥1 matched required).
+func TestWBAVerify_NoneMatchedRejected(t *testing.T) {
+	t.Parallel()
+	priv, jwk, tp := genEd25519JWK(t)
+	f := &fakeDirResolver{keys: nil} // empty directory
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, wbaSigningInput, jwk)
+
+	_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	assertValidationCode(t, err, "IDENTIFIER_PROOF_INVALID")
+}
+
+// TestWBAVerify_WindowSkipped: a directory key outside its nbf/exp window
+// is skipped, so a proof for it does not match (V16).
+func TestWBAVerify_WindowSkipped(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  port.DirectoryKey
+	}{
+		{"not-yet-valid", port.DirectoryKey{NotBefore: wbaNow().Add(time.Hour)}},
+		{"expired", port.DirectoryKey{NotAfter: wbaNow().Add(-time.Hour)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			priv, jwk, tp := genEd25519JWK(t)
+			key := tc.key
+			key.JWK = jwk
+			f := &fakeDirResolver{keys: []port.DirectoryKey{key}}
+			v := newWBAVerifier(f)
+			id := newWBAIdentity(t)
+			jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, wbaSigningInput, jwk)
+			_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+			assertValidationCode(t, err, "IDENTIFIER_PROOF_INVALID")
+		})
+	}
+}
+
+// TestWBAVerify_RejectsNonEdDSAAlg: a matched proof naming any algorithm
+// other than EdDSA is rejected (V5 alg-confusion defense).
+func TestWBAVerify_RejectsNonEdDSAAlg(t *testing.T) {
+	t.Parallel()
+	priv, jwk, tp := genEd25519JWK(t)
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwk}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	// kid matches the directory key, but the header claims ES256.
+	jws := signEd25519Proof(t, priv, "ES256", tp, wbaSigningInput, jwk)
+	_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	assertValidationCode(t, err, "IDENTIFIER_PROOF_INVALID")
+}
+
+// TestWBAVerify_RejectsNonEd25519DirectoryKey: an EC directory key has no
+// RFC 7638 (OKP) thumbprint, so it is never indexed; a proof for it does
+// not match and the call rejects (V12).
+func TestWBAVerify_RejectsNonEd25519DirectoryKey(t *testing.T) {
+	t.Parallel()
+	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecJWK, err := anscrypto.PublicKeyToJWK(&ecPriv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: ecJWK}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	// The proof itself is a valid Ed25519 JWS, but its kid can never match
+	// the un-thumbprintable EC directory entry.
+	priv, jwk, tp := genEd25519JWK(t)
+	jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, wbaSigningInput, jwk)
+	_, err = v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	assertValidationCode(t, err, "IDENTIFIER_PROOF_INVALID")
+}
+
+// TestWBAVerify_RejectsEmbeddedJWKMismatch: a header jwk hint whose
+// thumbprint differs from the kid is rejected (V4/V17 — the hint must be
+// the located key).
+func TestWBAVerify_RejectsEmbeddedJWKMismatch(t *testing.T) {
+	t.Parallel()
+	privA, jwkA, tpA := genEd25519JWK(t)
+	_, jwkB, _ := genEd25519JWK(t)
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwkA}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	// kid = A's thumbprint (matches the directory), but the embedded jwk
+	// is B — inconsistent.
+	jws := signEd25519Proof(t, privA, anscrypto.AlgEdDSA, tpA, wbaSigningInput, jwkB)
+	_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	assertValidationCode(t, err, "IDENTIFIER_PROOF_INVALID")
+}
+
+// TestWBAVerify_PayloadMismatchRejected: a proof whose payload segment is
+// not the served signingInput is rejected before any signature work (V2).
+func TestWBAVerify_PayloadMismatchRejected(t *testing.T) {
+	t.Parallel()
+	priv, jwk, tp := genEd25519JWK(t)
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwk}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, "a-different-payload", jwk)
+	_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	assertValidationCode(t, err, "PRICC_SIGNATURE_INVALID")
+	// The directory is never consulted when the envelope check fails.
+	if f.calls != 0 {
+		t.Fatalf("directory fetched %d times before payload check", f.calls)
+	}
+}
+
+// TestWBAVerify_ForgedSignatureRejected: a matched key with a valid
+// envelope but a signature made by a different private key fails the
+// verify against the directory key (V17).
+func TestWBAVerify_ForgedSignatureRejected(t *testing.T) {
+	t.Parallel()
+	_, jwk, tp := genEd25519JWK(t)
+	otherPriv, _, _ := genEd25519JWK(t) // signs with the wrong key
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwk}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	// kid + embedded jwk name the directory key, but the signature is the
+	// other key's — it cannot verify against the directory key.
+	jws := signEd25519Proof(t, otherPriv, anscrypto.AlgEdDSA, tp, wbaSigningInput, jwk)
+	_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	assertValidationCode(t, err, "PRICC_SIGNATURE_INVALID")
+}
+
+// TestWBAVerify_FetchFailureIsRetryable: a resolver failure propagates as
+// a retryable (503-class) error, never a 500 (V8, V15).
+func TestWBAVerify_FetchFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+	priv, jwk, tp := genEd25519JWK(t)
+	f := &fakeDirResolver{err: domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE", "down")}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	jws := signEd25519Proof(t, priv, anscrypto.AlgEdDSA, tp, wbaSigningInput, jwk)
+	_, err := v.VerifyProofs(context.Background(), id, ProofSubmission{SignedProofs: []string{jws}}, wbaSigningInput)
+	if !errors.Is(err, domain.ErrUnavailable) {
+		t.Fatalf("err = %v, want retryable ErrUnavailable", err)
+	}
+}
+
+// TestWBAChallenges_EnumeratesThumbprints: the advisory fetch enumerates
+// the thumbprintable directory keys as offered kids, skipping non-OKP
+// entries.
+func TestWBAChallenges_EnumeratesThumbprints(t *testing.T) {
+	t.Parallel()
+	_, jwkA, tpA := genEd25519JWK(t)
+	_, jwkB, tpB := genEd25519JWK(t)
+	ecPriv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ecJWK, _ := anscrypto.PublicKeyToJWK(&ecPriv.PublicKey)
+	f := &fakeDirResolver{keys: []port.DirectoryKey{{JWK: jwkA}, {JWK: ecJWK}, {JWK: jwkB}}}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+
+	ch, err := v.Challenges(context.Background(), id, wbaSigningInput)
+	if err != nil {
+		t.Fatalf("challenges: %v", err)
+	}
+	if len(ch) != 2 {
+		t.Fatalf("challenges = %d, want 2 (EC skipped)", len(ch))
+	}
+	got := map[string]bool{ch[0].Kid: true, ch[1].Kid: true}
+	if !got[tpA] || !got[tpB] {
+		t.Fatalf("challenge kids = %+v, want %s and %s", ch, tpA, tpB)
+	}
+	for _, c := range ch {
+		if c.SigningInput != wbaSigningInput {
+			t.Fatalf("challenge signingInput = %q", c.SigningInput)
+		}
+	}
+}
+
+// TestWBAChallenges_ToleratesFetchFailure: an advisory-fetch failure is
+// tolerated with a single unkeyed challenge — the register round never
+// fails on the directory (V8).
+func TestWBAChallenges_ToleratesFetchFailure(t *testing.T) {
+	t.Parallel()
+	f := &fakeDirResolver{err: domain.NewUnavailableError("WBA_DIRECTORY_UNAVAILABLE", "down")}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	ch, err := v.Challenges(context.Background(), id, wbaSigningInput)
+	if err != nil {
+		t.Fatalf("challenges should tolerate fetch failure, got %v", err)
+	}
+	if len(ch) != 1 || ch[0].Kid != "" || ch[0].SigningInput != wbaSigningInput {
+		t.Fatalf("want a single unkeyed challenge, got %+v", ch)
+	}
+}
+
+// TestWBAChallenges_NoKeysUnkeyed: a reachable-but-empty directory yields
+// a single unkeyed challenge.
+func TestWBAChallenges_NoKeysUnkeyed(t *testing.T) {
+	t.Parallel()
+	f := &fakeDirResolver{keys: nil}
+	v := newWBAVerifier(f)
+	id := newWBAIdentity(t)
+	ch, err := v.Challenges(context.Background(), id, wbaSigningInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ch) != 1 || ch[0].Kid != "" {
+		t.Fatalf("want a single unkeyed challenge, got %+v", ch)
+	}
+}
+
+// assertValidationCode asserts err is a domain validation error carrying
+// the given code.
+func assertValidationCode(t *testing.T, err error, code string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with code %q, got nil", code)
+	}
+	var de *domain.Error
+	if !errors.As(err, &de) {
+		t.Fatalf("error %v is not a *domain.Error", err)
+	}
+	if de.Code != code {
+		t.Fatalf("error code = %q, want %q", de.Code, code)
+	}
+}

--- a/scripts/demo/identity-lifecycle.sh
+++ b/scripts/demo/identity-lifecycle.sh
@@ -14,6 +14,10 @@
 #   5.  GET    /v2/ans/identities/{id}                     detail
 #   6.  POST   /v2/ans/identities                          register did:key (zero-I/O kind)
 #   7.  POST   .../verify-control                          did:key proof → VERIFIED
+#   7a. POST   /v2/ans/identities                          register web-bot-auth (Signature-Agent URL) → 202
+#   7b. POST   .../verify-control                          Ed25519 proof, kid = RFC 7638 JWK thumbprint →
+#                                                          VERIFIED (noop directory: real JWS, waived binding)
+#   7c. TL     /v1/identities/{id}/audit                   sealed IDENTITY_VERIFIED, web-bot-auth VM verbatim
 #   8.  (register TWO fresh agents to ACTIVE — the fleet)
 #   9.  POST   .../links                                   did:web → BOTH agents in one call (ONE IDENTITY_LINKED,
 #                                                          ansIds[2]); did:key → agent #1 (its own stream's event)
@@ -198,10 +202,47 @@ curl_json POST "/v2/ans/identities/$DK_ID/verify-control" \
 assert_2xx "did:key verify-control"
 ok "did:key identity VERIFIED — the keyless-future test track"
 
+# ----- 7a-7c. web-bot-auth — the Signature-Agent URL kind (noop directory) -----
+header "7a. POST /v2/ans/identities  (register a web-bot-auth Signature-Agent URL → 202 + challenge)"
+WBA_HOST="webbot-$(openssl rand -hex 4).example.com"
+WBA_VALUE="https://${WBA_HOST}"
+note "the identifier IS the Signature-Agent URL; the RA canonicalizes it to the well-known directory URL"
+WBA_RESP=$(curl_json POST /v2/ans/identities "$(jq -n --arg v "$WBA_VALUE" '{value: $v}')")
+WBA_ID=$(printf '%s' "$WBA_RESP" | jq -r '.identityId // empty')
+[ -n "$WBA_ID" ] || fail "web-bot-auth register failed"
+WBA_INPUT=$(printf '%s' "$WBA_RESP" | jq -r '.challenges[0].signingInput')
+WBA_CANONICAL=$(printf '%s' "$WBA_RESP" | jq -r '.value')
+ok "identityId=$WBA_ID → canonical $WBA_CANONICAL (PENDING_CONTROL)"
+
+header "7b. POST /v2/ans/identities/$WBA_ID/verify-control  (Ed25519 proof; kid = RFC 7638 JWK thumbprint)"
+note "web-bot-auth is Ed25519-only, and the kid MUST be the key's JWK thumbprint (not a free-form fragment)"
+signproof keygen -alg ed25519 -out "$KEY_DIR/webbot.pem" >/dev/null
+WBA_KID=$(signproof thumbprint -key "$KEY_DIR/webbot.pem")
+WBA_PROOF=$(signproof sign -key "$KEY_DIR/webbot.pem" -kid "$WBA_KID" -input "$WBA_INPUT")
+curl_json POST "/v2/ans/identities/$WBA_ID/verify-control" \
+  "$(jq -n --arg p "$WBA_PROOF" '{signedProofs: [$p]}')" >/dev/null
+assert_2xx "web-bot-auth verify-control"
+note "noop directory resolver: the JWS still genuinely verifies against the embedded key; only the"
+note "  'the live directory at the Signature-Agent URL endorses this key' binding is waived (quickstart)"
+ok "web-bot-auth identity VERIFIED — the automated-traffic kind (draft-meunier-webbotauth-httpsig-protocol-02)"
+
+header "7c. TL: GET /v1/identities/$WBA_ID/audit  (sealed IDENTITY_VERIFIED — web-bot-auth VM verbatim)"
+assert_tl_identity_audit "$WBA_ID" 1
+WBA_VM=$(curl_tl GET "/v1/identities/$WBA_ID/audit" | \
+  jq -r '[.records[].payload.producer.event | select(.keys)][0].keys[0].verificationMethod')
+WBA_VM_TYPE=$(printf '%s' "$WBA_VM" | jq -r '.type // empty')
+WBA_VM_ID=$(printf '%s' "$WBA_VM" | jq -r '.id // empty')
+WBA_VM_CRV=$(printf '%s' "$WBA_VM" | jq -r '.publicKeyJwk.crv // empty')
+[ "$WBA_VM_TYPE" = "JsonWebKey2020" ] || fail "web-bot-auth seal should be a JsonWebKey2020 method, got $WBA_VM_TYPE"
+[ "$WBA_VM_ID" = "${WBA_CANONICAL}#${WBA_KID}" ] || fail "web-bot-auth VM id should be <directoryURL>#<thumbprint>, got $WBA_VM_ID"
+[ "$WBA_VM_CRV" = "Ed25519" ] || fail "web-bot-auth key must be Ed25519, got $WBA_VM_CRV"
+ok "sealed verbatim: type=JsonWebKey2020, id=<directoryURL>#<thumbprint>, Ed25519 publicKeyJwk"
+
 # ----- 8. Register a small fleet (the WHATs) -----
-header "8. Register TWO fresh agents to ACTIVE (the fleet to link)"
+header "8. Register THREE fresh agents to ACTIVE (the fleet to link)"
 AGENT_1=$(register_agent "linked-a-$(openssl rand -hex 4).example.com")
 AGENT_2=$(register_agent "linked-b-$(openssl rand -hex 4).example.com")
+WBA_AGENT=$(register_agent "linked-bot-$(openssl rand -hex 4).example.com")
 # The AGENT lane still seals via the async outbox (flagged 2026-06-11
 # as a bug in the design doc §5.6.1 — agents should also wait for seal
 # confirmation; tracked separately). Until that lands, wait for both
@@ -209,7 +250,8 @@ AGENT_2=$(register_agent "linked-b-$(openssl rand -hex 4).example.com")
 # agent TL status, which needs the AGENT_REGISTERED leaves present.
 poll_tl_audit "$AGENT_1" 1 30
 poll_tl_audit "$AGENT_2" 1 30
-ok "fleet ready: $AGENT_1 + $AGENT_2"
+poll_tl_audit "$WBA_AGENT" 1 30
+ok "fleet ready: $AGENT_1 + $AGENT_2 + $WBA_AGENT"
 
 # ----- 9. Link the fleet — one owner-gated call per identity -----
 header "9a. POST /v2/ans/identities/$IDENTITY_ID/links  (did:web → BOTH agents, one call)"
@@ -225,6 +267,18 @@ DK_LINK=$(curl_json POST "/v2/ans/identities/$DK_ID/links" \
   "$(jq -n --arg a "$AGENT_1" '{agentIds: [$a]}')")
 [ "$(printf '%s' "$DK_LINK" | jq -r '.linked // 0')" = "1" ] || fail "did:key link failed"
 ok "agent-1 now carries TWO identities: the multi-key did:web and the Ed25519 did:key"
+
+header "9c. POST /v2/ans/identities/$WBA_ID/links  (web-bot-auth → the bot agent — the automated-traffic WHO)"
+note "the same link path carries every WHO kind; the automated-traffic identity binds to its agent identically"
+WBA_LINK=$(curl_json POST "/v2/ans/identities/$WBA_ID/links" \
+  "$(jq -n --arg a "$WBA_AGENT" '{agentIds: [$a]}')")
+[ "$(printf '%s' "$WBA_LINK" | jq -r '.linked // 0')" = "1" ] || fail "web-bot-auth link failed"
+# The web-bot-auth stream now carries IDENTITY_VERIFIED + IDENTITY_LINKED,
+# and the reverse join names the bot agent — seal-before-success, no poll.
+assert_tl_identity_audit "$WBA_ID" 2
+WBA_AGENTS_COUNT=$(curl_tl GET "/v1/identities/$WBA_ID/agents" | jq -r '.agents | length')
+[ "$WBA_AGENTS_COUNT" = "1" ] || fail "web-bot-auth reverse join should list 1 agent, got $WBA_AGENTS_COUNT"
+ok "web-bot-auth linked to the bot agent — IDENTITY_LINKED sealed, reverse join names 1 agent"
 
 # ----- 10. RA-side computed identities[] -----
 header "10. GET /v2/ans/agents/$AGENT_1  (RA detail — computed identities[], never stored on the agent)"
@@ -393,10 +447,13 @@ ok "ONE IDENTITY_REVOKED propagated to agent-2's join at read time; agent-1's di
 header "Identity lifecycle complete"
 printf "  did:web      %s  (VERIFIED w/ 2 keys → rotated to 1 → REVOKED)\n" "$IDENTITY_ID" >&2
 printf "  did:key      %s  (Ed25519 — VERIFIED, linked to agent-1 throughout)\n" "$DK_ID" >&2
+printf "  web-bot-auth %s  (Ed25519 Signature-Agent URL — VERIFIED via noop directory, linked to the bot agent)\n" "$WBA_ID" >&2
 printf "  agent-1      %s (carried BOTH whos; kept the did:key after the did:web unlink)\n" "$AGENT_1" >&2
 printf "  agent-2      %s (did:web-linked throughout; saw rotation + revocation at read time)\n" "$AGENT_2" >&2
+printf "  bot agent    %s (web-bot-auth-linked — the automated-traffic WHO)\n" "$WBA_AGENT" >&2
 printf "  receipt      %s\n" "$IDENTITY_RECEIPT" >&2
 printf "\n" >&2
 printf "  sealed: did:web stream — IDENTITY_VERIFIED (multi-key), IDENTITY_LINKED (ansIds[2]),\n" >&2
 printf "  IDENTITY_UPDATED, IDENTITY_UNLINKED, IDENTITY_REVOKED; did:key stream —\n" >&2
-printf "  IDENTITY_VERIFIED (Multikey, verbatim), IDENTITY_LINKED.\n" >&2
+printf "  IDENTITY_VERIFIED (Multikey, verbatim), IDENTITY_LINKED; web-bot-auth stream —\n" >&2
+printf "  IDENTITY_VERIFIED (JsonWebKey2020, Ed25519), IDENTITY_LINKED.\n" >&2

--- a/scripts/demo/signproof/main.go
+++ b/scripts/demo/signproof/main.go
@@ -52,8 +52,10 @@ func run(args []string) error {
 		return keygen(args[1:])
 	case "sign":
 		return sign(args[1:])
+	case "thumbprint":
+		return thumbprint(args[1:])
 	default:
-		return fmt.Errorf("unknown subcommand %q (want keygen or sign)", args[0])
+		return fmt.Errorf("unknown subcommand %q (want keygen, sign, or thumbprint)", args[0])
 	}
 }
 
@@ -106,6 +108,56 @@ func keygen(args []string) error {
 	// stdout carries exactly the did:key identifier so shell callers
 	// can capture it: DID=$(go run ./scripts/demo/signproof keygen ...).
 	fmt.Fprintln(os.Stdout, "did:key:"+multibase)
+	return nil
+}
+
+// thumbprint prints a key's RFC 7638 JWK thumbprint on stdout. This is
+// the kid a web-bot-auth proof must claim: the verifier indexes the
+// directory's endorsed keys by recomputed thumbprint and rejects any
+// proof whose kid (or embedded jwk) is not that thumbprint. Shell
+// callers capture it: KID=$(go run ./scripts/demo/signproof thumbprint -key key.pem).
+func thumbprint(args []string) error {
+	fs := flag.NewFlagSet("thumbprint", flag.ContinueOnError)
+	keyPath := fs.String("key", "", "path to the private key PEM (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *keyPath == "" {
+		return errors.New("thumbprint: -key is required")
+	}
+
+	raw, err := os.ReadFile(*keyPath)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return errors.New("key file is not PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse key: %w", err)
+	}
+
+	var pub any
+	switch key := parsed.(type) {
+	case *ecdsa.PrivateKey:
+		pub = &key.PublicKey
+	case ed25519.PrivateKey:
+		pub = key.Public()
+	default:
+		return fmt.Errorf("unsupported key type %T (want P-256 or Ed25519)", parsed)
+	}
+
+	jwk, err := anscrypto.PublicKeyToJWK(pub)
+	if err != nil {
+		return fmt.Errorf("encode jwk: %w", err)
+	}
+	tp, err := anscrypto.JWKThumbprint(jwk)
+	if err != nil {
+		return fmt.Errorf("thumbprint: %w", err)
+	}
+	fmt.Fprintln(os.Stdout, tp)
 	return nil
 }
 

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -1214,12 +1214,22 @@ paths:
         - Verified Identities
       summary: Register a verified identity
       description: |
-        Registers an identifier (the kind — `did:web`, `did:key` — is
-        inferred from the value's lexical form, never caller-asserted)
-        and returns the challenge round to sign: one entry per
-        eligible key, all over a single anti-replay nonce. The
-        identity is created in `PENDING_CONTROL`; nothing is sealed
-        until verify-control passes.
+        Registers an identifier (the kind — `did:web`, `did:key`,
+        `web-bot-auth` — is inferred from the value's lexical form,
+        never caller-asserted) and returns the challenge round to
+        sign: one entry per eligible key, all over a single
+        anti-replay nonce. The identity is created in
+        `PENDING_CONTROL`; nothing is sealed until verify-control
+        passes.
+
+        The `web-bot-auth` kind's value is an `https://`
+        Signature-Agent URL. It is canonicalized to the well-known
+        directory URL
+        `https://<host>[:port]/.well-known/http-message-signatures-directory`
+        — the URL a verifier fetches the HTTP Message Signatures
+        directory at (draft-meunier-webbotauth-httpsig-protocol-02). A
+        bare origin gets the well-known path added; any other path
+        returns 422 `WBA_URL_INVALID`.
 
         Re-POSTing the same value while the row is `PENDING_CONTROL`
         is the idempotent re-add: the same `identityId` returns with
@@ -1259,7 +1269,9 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: |
-            Invalid or unsupported identifier; for the `did:web` kind the
+            Invalid or unsupported identifier; for the `web-bot-auth`
+            kind a malformed Signature-Agent URL fails with
+            `WBA_URL_INVALID`; for the `did:web` kind the
             register-time resolution may fail with `DID_RESOLUTION_FAILED`
             or `DID_DOCUMENT_ID_MISMATCH`; for the `lei` kind —
             `IDENTIFIER_PRESENTATION_REQUIRED`, `LEI_PRESENTATION_INVALID`,
@@ -1387,7 +1399,9 @@ paths:
         '422':
           description: |
             Invalid replacement value (incl. `IDENTIFIER_KIND_MISMATCH`);
-            for the `did:web` kind the register-time resolution may fail
+            for the `web-bot-auth` kind a malformed Signature-Agent URL
+            fails with `WBA_URL_INVALID`; for the `did:web` kind the
+            register-time resolution may fail
             with `DID_RESOLUTION_FAILED` or `DID_DOCUMENT_ID_MISMATCH`;
             for the `lei` kind — `IDENTIFIER_PRESENTATION_REQUIRED`,
             `LEI_PRESENTATION_INVALID`, `LEI_MISMATCH`,
@@ -1417,9 +1431,20 @@ paths:
         before verifying any signature). Every proof must verify
         against the identifier's AUTHORITATIVE key for its `kid`
         (resolved from the DID document for `did:web`, decoded from
-        the identifier for `did:key`); one bad proof fails the call
-        closed. The nonce is consumed exactly once, inside the
-        success transaction — a failed attempt does not consume it.
+        the identifier for `did:key`, located in the fetched HTTP
+        Message Signatures directory for `web-bot-auth`); one bad
+        proof fails the call closed. The nonce is consumed exactly
+        once, inside the success transaction — a failed attempt does
+        not consume it.
+
+        The `web-bot-auth` kind submits `signedProofs` (EdDSA only).
+        Each proof's `kid` is the RFC 7638 thumbprint of an Ed25519
+        key; the RA fetches the directory at the canonical
+        Signature-Agent URL and seals the INTERSECTION of the
+        possession-proven and the directory-endorsed keys. A proof
+        for a key the directory does not currently endorse is dropped
+        (mid-rotation tolerance); at least one proof must match, else
+        `IDENTIFIER_PROOF_INVALID`.
 
         The `lei` kind instead submits a single `cesrSignature` over
         the same `signingInput`: the RA forwards it to the
@@ -1493,7 +1518,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
         '503':
-          description: Upstream unavailable (TL_UNAVAILABLE, or LEI_VERIFIER_UNAVAILABLE — retryable; the nonce is NOT consumed)
+          description: Upstream unavailable (TL_UNAVAILABLE, LEI_VERIFIER_UNAVAILABLE, or WBA_DIRECTORY_UNAVAILABLE — retryable; the nonce is NOT consumed)
           content:
             application/json:
               schema:
@@ -2893,12 +2918,16 @@ components:
       description: |
         Registers (POST) or rotates (PUT) an identifier. The kind is
         inferred from the value's lexical form — `did:web:` prefix,
-        `did:key:` prefix, or a 20-character LEI — never
-        caller-asserted.
+        `did:key:` prefix, a 20-character LEI, or an `https://`
+        Signature-Agent URL (`web-bot-auth`) — never caller-asserted.
       properties:
         value:
           type: string
-          description: The identifier to prove control of
+          description: |
+            The identifier to prove control of. For `web-bot-auth`,
+            an `https://` Signature-Agent URL, canonicalized to the
+            well-known directory URL
+            `https://<host>[:port]/.well-known/http-message-signatures-directory`.
           example: did:web:identity.acme-corp.com
         vleiPresentation:
           $ref: '#/components/schemas/VLEIPresentation'
@@ -2939,7 +2968,7 @@ components:
           description: RA-assigned UUIDv7 — the TL stream key
         kind:
           type: string
-          enum: ['did:web', 'did:key', 'lei']
+          enum: ['did:web', 'did:key', 'lei', 'web-bot-auth']
         value:
           type: string
           description: The canonical identifier this round proves
@@ -3086,7 +3115,7 @@ components:
           type: string
         kind:
           type: string
-          enum: ['did:web', 'did:key', 'lei']
+          enum: ['did:web', 'did:key', 'lei', 'web-bot-auth']
         value:
           type: string
         status:
@@ -3159,7 +3188,7 @@ components:
           type: string
         kind:
           type: string
-          enum: ['did:web', 'did:key', 'lei']
+          enum: ['did:web', 'did:key', 'lei', 'web-bot-auth']
         value:
           type: string
         identityStatus:


### PR DESCRIPTION
<!--
Thank you for contributing to the Agent Name Service project!

REQUIRED: every PR must link an issue with a closing keyword (e.g. "Fixes #123").
The issue is where we triage and prioritize; the PR is where we review.
If no issue exists yet, open one first.

Note for AI coding agents: complete every section below, keep the section
headings, and put a real issue number after "Fixes". If you were not given
an issue number, ask your operator or create the issue before opening this PR.
-->

## Related issue

<!-- REQUIRED — use a closing keyword so GitHub links it: Fixes / Closes / Resolves #NNN -->

Fixes #102 

## Summary

This branch adds a fourth verified-identity kind to the ANS
Registration Authority (RA): `web-bot-auth`. An agent operator can now
prove control of an `https://` Signature-Agent URL and bind it to the
agent identity, next to the `did:web`, `did:key`, and `lei` kinds.

Web-bot-auth is the IETF HTTP Message Signatures profile for automated
HTTP clients (`draft-meunier-webbotauth-httpsig-protocol-02`). A bot
sends a `Signature-Agent` header that names an `https://` URL. That URL
serves a JWKS directory of the keys the bot signs its requests with.
The URL is the identity. The directory is the authoritative key source.

Lets an ANS agent register that same Signature-Agent URL as a
verified identity. A relying party can then tie the agent ANS name to
the automated traffic it sends.

## Testing

- `internal/crypto/jwk_test.go` — thumbprint vectors and rejection of
  non-Ed25519 / malformed keys.
- `internal/domain/identity_test.go` — inference and canonicalization,
  including the reject paths.
- `internal/adapter/directory/webbotauth/webbotauth_test.go` — the
  parse pipeline, content-type and size checks, key windows.
- `internal/adapter/securefetch/securefetch_test.go` — the dialer and
  redirect guards.
- `internal/ra/service/webbotauthverifier_test.go` — possession,
  endorsement, intersection, mid-rotation drop, alg confusion.
- `internal/ra/service/webbotauth_flow_test.go` — the full
  register → verify → seal flow on the noop resolver, plus rotation.

e2e tests against noop verifier added in scripts/demo/identity-lifecycle.sh

## AI assistance

<!-- We follow the Linux kernel convention for AI disclosure:
     https://docs.kernel.org/process/coding-assistants.html
     If AI tooling assisted this change, add one Assisted-by line per tool,
     naming the tool and model, e.g.:
       Assisted-by: Claude Code (claude-fable-5)
     If none was used, write "None". The human submitter remains fully
     responsible for the correctness and licensing of the contribution.
     Per the kernel convention, AI tools must not add Signed-off-by lines:
     the DCO certification belongs to the human submitter alone. -->

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org) — release notes are generated from it
- [x] Tests cover the change
- [x] The linked issue above uses a closing keyword
- [x] Every commit is signed off (`git commit -s`) certifying the [DCO](https://developercertificate.org)
