### PR TITLE
fix(ra): attest only the DNS records verification actually found

### DIFF
--- a/internal/adapter/dns/dns_more_test.go
+++ b/internal/adapter/dns/dns_more_test.go
@@ -52,8 +52,11 @@ func TestLookupVerifier_HTTPS_Mismatch(t *testing.T) {
 	}
 }
 
-// TestLookupVerifier_HTTPS_NXDOMAIN — server returns no records
-// → NXDOMAIN → r.Error populated with "rcode NXDOMAIN".
+// TestLookupVerifier_HTTPS_NXDOMAIN — server returns no records and the
+// owner name does not exist → NXDOMAIN → not Found, and Error stays empty
+// because absence is not a lookup fault. The CNAME-at-apex operator who
+// structurally cannot publish an HTTPS RR (RFC 1034 §3.6.2) lands here,
+// and their activation must not read as an upstream problem.
 func TestLookupVerifier_HTTPS_NXDOMAIN(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t)
@@ -65,8 +68,8 @@ func TestLookupVerifier_HTTPS_NXDOMAIN(t *testing.T) {
 	if got[0].found {
 		t.Error("NXDOMAIN HTTPS must not be Found")
 	}
-	if got[0].errString == "" {
-		t.Error("expected error to be populated for NXDOMAIN HTTPS")
+	if got[0].errString != "" {
+		t.Errorf("NXDOMAIN is absence, not a fault; Error must stay empty, got %q", got[0].errString)
 	}
 }
 

--- a/internal/adapter/dns/dns_test.go
+++ b/internal/adapter/dns/dns_test.go
@@ -71,14 +71,28 @@ type testServer struct {
 	addr    string
 	mu      sync.RWMutex
 	answers map[string][]miekg.RR
-	ad      bool // set AuthenticatedData on replies to simulate a DNSSEC-validating resolver
-	srv     *miekg.Server
-	stop    func()
+	// existing marks owner names that exist in the zone. An empty answer
+	// set for such a name is NODATA (SUCCESS, no answers) rather than
+	// NXDOMAIN — the distinction the drop classification depends on, so it
+	// has to be reachable from tests. Names absent from this map behave as
+	// they always have: an empty answer set is NXDOMAIN.
+	existing map[string]bool
+	// servfail forces a SERVFAIL reply per "name:TYPE" key, so the genuine
+	// lookup-fault path is reachable without an unroutable address and a
+	// timeout.
+	servfail map[string]bool
+	ad       bool // set AuthenticatedData on replies to simulate a DNSSEC-validating resolver
+	srv      *miekg.Server
+	stop     func()
 }
 
 func newTestServer(t *testing.T) *testServer {
 	t.Helper()
-	s := &testServer{answers: map[string][]miekg.RR{}}
+	s := &testServer{
+		answers:  map[string][]miekg.RR{},
+		existing: map[string]bool{},
+		servfail: map[string]bool{},
+	}
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
@@ -95,10 +109,18 @@ func newTestServer(t *testing.T) *testServer {
 		m.AuthenticatedData = s.ad
 		if len(req.Question) > 0 {
 			q := req.Question[0]
-			key := strings.ToLower(q.Name) + ":" + miekg.TypeToString[q.Qtype]
-			m.Answer = append(m.Answer, s.answers[key]...)
-			if len(m.Answer) == 0 {
-				m.Rcode = miekg.RcodeNameError
+			name := strings.ToLower(q.Name)
+			key := name + ":" + miekg.TypeToString[q.Qtype]
+			switch {
+			case s.servfail[key]:
+				m.Rcode = miekg.RcodeServerFailure
+			default:
+				m.Answer = append(m.Answer, s.answers[key]...)
+				// An empty answer set is NXDOMAIN unless the owner name is
+				// known to exist, in which case it is NODATA.
+				if len(m.Answer) == 0 && !s.existing[name] {
+					m.Rcode = miekg.RcodeNameError
+				}
 			}
 		}
 		s.mu.RUnlock()
@@ -129,6 +151,24 @@ func (s *testServer) add(name, typ, rrString string) {
 	key := strings.ToLower(miekg.Fqdn(name)) + ":" + typ
 	s.mu.Lock()
 	s.answers[key] = append(s.answers[key], rr)
+	s.mu.Unlock()
+}
+
+// addName marks an owner name as existing without giving it records of
+// any particular type, so a query for a type it lacks answers NODATA
+// (SUCCESS, empty answer) instead of NXDOMAIN. This is the apex-with-A-but-
+// no-HTTPS shape.
+func (s *testServer) addName(name string) {
+	s.mu.Lock()
+	s.existing[strings.ToLower(miekg.Fqdn(name))] = true
+	s.mu.Unlock()
+}
+
+// addServfail makes queries for one name/type answer SERVFAIL, which is
+// the genuine lookup fault — as opposed to either shape of absence.
+func (s *testServer) addServfail(name, typ string) {
+	s.mu.Lock()
+	s.servfail[strings.ToLower(miekg.Fqdn(name))+":"+typ] = true
 	s.mu.Unlock()
 }
 
@@ -452,10 +492,22 @@ func TestLookupVerifier_SVCB_DNSSECFlagPropagates(t *testing.T) {
 	}
 }
 
-func TestLookupVerifier_NXDOMAINSurfacedAsError(t *testing.T) {
+// TestLookupVerifier_NXDOMAINIsAbsenceNotError pins the rcode split the
+// service layer's drop classification reads. NXDOMAIN is an authoritative
+// "this name does not exist", which is exactly what an operator who
+// declined an optional record produces — they never created the owner
+// name, so there is nothing there to answer NODATA. Reporting it through
+// Error would put every such activation on the LOOKUP_ERROR/WARN arm and
+// bury the SERVFAIL narrowing that arm exists to surface.
+//
+// This test previously asserted the opposite. It was written when nothing
+// read RecordVerification.Error, so the field was descriptive only; the
+// attestation-narrowing change gave it behavioral meaning, and the old
+// shape was wrong under that meaning.
+func TestLookupVerifier_NXDOMAINIsAbsenceNotError(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t)
-	// No records added — server returns NXDOMAIN.
+	// No records and no owner name — server returns NXDOMAIN.
 	recs := []domain.ExpectedDNSRecord{{
 		Name: "missing.agent.example.com", Type: domain.DNSRecordTXT,
 		Value: "doesnt-matter", Required: true,
@@ -464,8 +516,89 @@ func TestLookupVerifier_NXDOMAINSurfacedAsError(t *testing.T) {
 	if got[0].found {
 		t.Error("NXDOMAIN must not be Found")
 	}
-	if got[0].errString == "" {
-		t.Error("NXDOMAIN should surface a descriptive error")
+	if got[0].errString != "" {
+		t.Errorf("NXDOMAIN is absence, not a lookup fault; Error must stay empty, got %q", got[0].errString)
+	}
+	if got[0].actual != "" {
+		t.Errorf("nothing answered, so Actual must stay empty (it is what separates MISSING from MISMATCH); got %q", got[0].actual)
+	}
+}
+
+// TestLookupVerifier_AbsenceShapesAndFaultsAreDistinguishable covers the
+// full rcode matrix across every record type ANS queries, because the
+// classification is per-type code paths and a regression in one would be
+// invisible from the others.
+//
+// The three columns are the ones the drop classification has to keep
+// apart: NXDOMAIN and NODATA are both ordinary absence (Error empty), and
+// SERVFAIL is a fault (Error set). TLSA is the type an operator most often
+// declines, and the apex HTTPS/SVCB rows are the NODATA shape — the name
+// exists with other records, just not this type.
+func TestLookupVerifier_AbsenceShapesAndFaultsAreDistinguishable(t *testing.T) {
+	t.Parallel()
+
+	types := []struct {
+		typ   domain.DNSRecordType
+		qtype string
+		value string
+	}{
+		{domain.DNSRecordTXT, "TXT", "v=ans1; irrelevant"},
+		{domain.DNSRecordTLSA, "TLSA", "3 0 1 abcdef"},
+		{domain.DNSRecordHTTPS, "HTTPS", "1 . alpn=h2"},
+		{domain.DNSRecordSVCB, "SVCB", "1 . alpn=a2a port=443"},
+	}
+
+	for _, tc := range types {
+		t.Run(string(tc.typ), func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("nxdomain_is_absence", func(t *testing.T) {
+				t.Parallel()
+				s := newTestServer(t)
+				got := s.verifyAgainst(t, []domain.ExpectedDNSRecord{{
+					Name: "nx.agent.example.com", Type: tc.typ, Value: tc.value,
+				}})
+				if got[0].found {
+					t.Error("must not be Found")
+				}
+				if got[0].errString != "" {
+					t.Errorf("NXDOMAIN must leave Error empty, got %q", got[0].errString)
+				}
+			})
+
+			t.Run("nodata_is_absence", func(t *testing.T) {
+				t.Parallel()
+				s := newTestServer(t)
+				s.addName("nodata.agent.example.com")
+				got := s.verifyAgainst(t, []domain.ExpectedDNSRecord{{
+					Name: "nodata.agent.example.com", Type: tc.typ, Value: tc.value,
+				}})
+				if got[0].found {
+					t.Error("must not be Found")
+				}
+				if got[0].errString != "" {
+					t.Errorf("NODATA must leave Error empty, got %q", got[0].errString)
+				}
+			})
+
+			t.Run("servfail_is_a_fault", func(t *testing.T) {
+				t.Parallel()
+				s := newTestServer(t)
+				s.addServfail("broken.agent.example.com", tc.qtype)
+				got := s.verifyAgainst(t, []domain.ExpectedDNSRecord{{
+					Name: "broken.agent.example.com", Type: tc.typ, Value: tc.value,
+				}})
+				if got[0].found {
+					t.Error("must not be Found")
+				}
+				if got[0].errString == "" {
+					t.Fatal("SERVFAIL is a genuine fault and must populate Error; without it the drop is indistinguishable from an operator's choice")
+				}
+				if !strings.Contains(got[0].errString, "SERVFAIL") {
+					t.Errorf("Error should name the rcode so operators can act on it, got %q", got[0].errString)
+				}
+			})
+		})
 	}
 }
 

--- a/internal/adapter/dns/lookup.go
+++ b/internal/adapter/dns/lookup.go
@@ -138,6 +138,51 @@ func (v *LookupVerifier) exchange(ctx context.Context, server string, name strin
 	return resp, nil
 }
 
+// inspectAnswers records the response's rcode outcome on r and reports whether
+// the answer section is worth inspecting.
+//
+// NXDOMAIN is an answer, not a fault. The resolver is stating
+// authoritatively that the name does not exist, so the record is
+// definitively unpublished, and Error stays empty. That empty Error is
+// what keeps the record on the MISSING path in the service layer's drop
+// classification: an operator who declines an optional record never
+// creates the owner name at all — no `_443._tcp.<fqdn>` when they skip
+// DANE — so real DNS answers NXDOMAIN rather than NODATA (RFC 2308 §2).
+// Reporting that as a lookup fault would escalate every such activation
+// to WARN and bury the genuine narrowing that channel exists to surface.
+//
+// NODATA (SUCCESS with an empty answer section — the name exists but
+// carries no records of this type, which is what an apex with A but no
+// HTTPS returns) also reaches the caller with Error empty, via the
+// SUCCESS arm and an answer loop that matches nothing. Both shapes of
+// ordinary absence therefore look the same to the service layer, which is
+// the intent: neither is a fault.
+//
+// Every other non-success rcode — SERVFAIL, REFUSED, and the rest — is a
+// genuine fault: we did not learn whether the record exists. Those
+// populate Error, the only signal the RA has that a signed attestation was
+// narrowed by an upstream problem rather than by an operator's choice.
+//
+// Returning early on NXDOMAIN means DNSSECVerified stays false even when
+// the denial of existence was itself authenticated. That is deliberate:
+// the field has exactly one consumer, the service layer's hard-fail rule
+// for a rewritten record in a signed zone, and that rule requires a live
+// value to disagree with (Actual != ""). Nothing answered here, so the
+// rule cannot apply, and a record dropped from the attestation never
+// reaches the wire where the flag would be published. Setting it would be
+// inert.
+func inspectAnswers(r *port.RecordVerification, resp *dns.Msg) bool {
+	switch resp.Rcode {
+	case dns.RcodeSuccess:
+		return true
+	case dns.RcodeNameError:
+		return false
+	default:
+		r.Error = fmt.Sprintf("rcode %s", dns.RcodeToString[resp.Rcode])
+		return false
+	}
+}
+
 func (v *LookupVerifier) verifyTXT(ctx context.Context, server string, rec domain.ExpectedDNSRecord) port.RecordVerification {
 	r := port.RecordVerification{Record: rec}
 	resp, err := v.exchange(ctx, server, rec.Name, dns.TypeTXT)
@@ -145,8 +190,7 @@ func (v *LookupVerifier) verifyTXT(ctx context.Context, server string, rec domai
 		r.Error = err.Error()
 		return r
 	}
-	if resp.Rcode != dns.RcodeSuccess {
-		r.Error = fmt.Sprintf("rcode %s", dns.RcodeToString[resp.Rcode])
+	if !inspectAnswers(&r, resp) {
 		return r
 	}
 	wantNorm := strings.TrimSpace(rec.Value)
@@ -186,8 +230,7 @@ func (v *LookupVerifier) verifyTLSA(ctx context.Context, server string, rec doma
 		r.Error = err.Error()
 		return r
 	}
-	if resp.Rcode != dns.RcodeSuccess {
-		r.Error = fmt.Sprintf("rcode %s", dns.RcodeToString[resp.Rcode])
+	if !inspectAnswers(&r, resp) {
 		return r
 	}
 	r.DNSSECVerified = resp.AuthenticatedData
@@ -228,8 +271,7 @@ func (v *LookupVerifier) verifyHTTPS(ctx context.Context, server string, rec dom
 		r.Error = err.Error()
 		return r
 	}
-	if resp.Rcode != dns.RcodeSuccess {
-		r.Error = fmt.Sprintf("rcode %s", dns.RcodeToString[resp.Rcode])
+	if !inspectAnswers(&r, resp) {
 		return r
 	}
 	r.DNSSECVerified = resp.AuthenticatedData
@@ -286,8 +328,7 @@ func (v *LookupVerifier) verifySVCB(ctx context.Context, server string, rec doma
 		r.Error = err.Error()
 		return r
 	}
-	if resp.Rcode != dns.RcodeSuccess {
-		r.Error = fmt.Sprintf("rcode %s", dns.RcodeToString[resp.Rcode])
+	if !inspectAnswers(&r, resp) {
 		return r
 	}
 	r.DNSSECVerified = resp.AuthenticatedData

--- a/internal/adapter/docsui/openapi/ra.yaml
+++ b/internal/adapter/docsui/openapi/ra.yaml
@@ -1921,14 +1921,17 @@ components:
           default: ["ANS_DNSAID"]
           description: |
             Set of DNS record families the RA tells the operator to
-            publish and emits in the AGENT_REGISTERED TL event's
-            attestations.dnsRecordsProvisioned[]. The computed records
-            surface to the client on GET /v2/ans/agents/{agentId} as
-            registrationPending.dnsRecords[] once the agent reaches
-            PENDING_DNS — not on the 202 register response, which
-            returns only the ACME challenge (production records are
-            deferred until verify-acme proves domain control and issues
-            the certificates the TLSA binding depends on).
+            publish. The AGENT_REGISTERED TL event's
+            attestations.dnsRecordsProvisioned[] carries these records
+            narrowed to the ones DNS actually answered with at
+            verify-dns, so an optional record the operator chose not to
+            publish is absent from the event rather than attested as
+            present. The computed records surface to the client on GET
+            /v2/ans/agents/{agentId} as registrationPending.dnsRecords[]
+            once the agent reaches PENDING_DNS — not on the 202 register
+            response, which returns only the ACME challenge (production
+            records are deferred until verify-acme proves domain control
+            and issues the certificates the TLSA binding depends on).
 
             Each value names one record family; an operator publishing
             the union (DNS-AID-aligned SVCB plus the original `_ans` TXT

--- a/internal/port/dns.go
+++ b/internal/port/dns.go
@@ -21,7 +21,24 @@ type RecordVerification struct {
 	// the live record carries coexistence extras) and is informational
 	// only — Found is the verdict.
 	Actual string
-	Error  string // Lookup error, if any.
+	// Error carries the reason the lookup could not answer the question at
+	// all: a transport failure, or a non-success rcode other than NXDOMAIN.
+	//
+	// NXDOMAIN is deliberately NOT an error. It is an authoritative answer
+	// that the name does not exist, which is how ordinary absence looks
+	// when an operator declines an optional record — they never create the
+	// owner name, so there is nothing there to return NODATA for. Both
+	// shapes of absence (NXDOMAIN, and SUCCESS with no matching answer)
+	// therefore leave Error empty.
+	//
+	// The service layer relies on that split when it decides what to say
+	// about a record it dropped from an attestation: an empty Error means
+	// the zone genuinely lacks the record and the operator chose that, so
+	// the drop is expected; a non-empty Error means an upstream fault left
+	// the question unanswered and a signed attestation was narrowed by
+	// something nobody intended. Widening Error to cover absence would
+	// collapse those two into one and make the distinction unrecoverable.
+	Error string
 	// DNSSECVerified is true when the response carried an
 	// authenticated-data (AD) bit from a validating resolver. Set
 	// on TLSA, SVCB, and HTTPS responses; surfaced to the TL

--- a/internal/ra/service/dnsattest_integration_test.go
+++ b/internal/ra/service/dnsattest_integration_test.go
@@ -1,0 +1,249 @@
+package service
+
+// Integration cover across the seam that let a real defect through: the
+// lookup adapter's per-record output feeding the attestation filter and its
+// drop classification.
+//
+// Both sides were unit-tested and both were self-consistent, yet the pair
+// disagreed. The adapter reported NXDOMAIN through Error, while every
+// service-side fixture modelled ordinary absence as Error=="". So the
+// filter's INFO/MISSING arm was covered by tests that no real lookup could
+// produce, and the most common drop on real DNS — an operator declining
+// DANE, which yields NXDOMAIN because the `_443._tcp` owner name is never
+// created — landed on the WARN/LOOKUP_ERROR arm instead.
+//
+// Hand-written port.RecordVerification values cannot catch a disagreement
+// of that kind, because they encode what the author believes the adapter
+// does. These tests run the actual adapter against an actual nameserver and
+// hand the real results to the real filter, so the two are pinned to each
+// other rather than to an assumption.
+//
+// This is deliberately not driven through VerifyDNS. The drop summary is
+// only ever logged, so asserting the INFO/WARN level would mean swapping
+// the package-global zerolog logger from a parallel test. The cause is what
+// selects the level (droppedForLookupError reads exactly it), so pinning
+// the cause pins the level without the global mutation.
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	miekg "github.com/miekg/dns"
+
+	dnsadapter "github.com/agentnameservice/ans/internal/adapter/dns"
+	"github.com/agentnameservice/ans/internal/domain"
+)
+
+// zone is a minimal authoritative nameserver over UDP. Names carrying
+// records answer with them; names registered as existing but holding no
+// record of the queried type answer NODATA; anything else is NXDOMAIN,
+// matching what a real zone does for a label that was never created.
+// The handler goroutine is running before the test populates the zone, so
+// every map is guarded. Ordering the writes first is not enough on its own:
+// without a synchronisation edge there is no happens-before relationship
+// between the test goroutine's writes and the handler's reads, and the race
+// detector is right to flag it.
+type zone struct {
+	addr     string
+	mu       sync.RWMutex
+	answers  map[string][]miekg.RR
+	existing map[string]bool
+	servfail map[string]bool
+}
+
+func newZone(t *testing.T) *zone {
+	t.Helper()
+	z := &zone{
+		answers:  map[string][]miekg.RR{},
+		existing: map[string]bool{},
+		servfail: map[string]bool{},
+	}
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	z.addr = pc.LocalAddr().String()
+
+	mux := miekg.NewServeMux()
+	mux.HandleFunc(".", func(w miekg.ResponseWriter, req *miekg.Msg) {
+		m := new(miekg.Msg)
+		m.SetReply(req)
+		m.Authoritative = true
+		z.mu.RLock()
+		if len(req.Question) > 0 {
+			q := req.Question[0]
+			name := strings.ToLower(q.Name)
+			key := name + ":" + miekg.TypeToString[q.Qtype]
+			switch {
+			case z.servfail[key]:
+				m.Rcode = miekg.RcodeServerFailure
+			default:
+				m.Answer = append(m.Answer, z.answers[key]...)
+				if len(m.Answer) == 0 && !z.existing[name] {
+					m.Rcode = miekg.RcodeNameError
+				}
+			}
+		}
+		z.mu.RUnlock()
+		_ = w.WriteMsg(m)
+	})
+
+	srv := &miekg.Server{PacketConn: pc, Handler: mux}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.ActivateAndServe()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = srv.Shutdown()
+		<-done
+	})
+	time.Sleep(20 * time.Millisecond)
+	return z
+}
+
+func (z *zone) add(rrString, typ string) {
+	rr, err := miekg.NewRR(rrString)
+	if err != nil {
+		panic("zone.add: bad RR: " + err.Error())
+	}
+	key := strings.ToLower(rr.Header().Name) + ":" + typ
+	z.mu.Lock()
+	z.answers[key] = append(z.answers[key], rr)
+	z.mu.Unlock()
+}
+
+func (z *zone) addName(name string) {
+	z.mu.Lock()
+	z.existing[strings.ToLower(miekg.Fqdn(name))] = true
+	z.mu.Unlock()
+}
+
+func (z *zone) addServfail(name, typ string) {
+	z.mu.Lock()
+	z.servfail[strings.ToLower(miekg.Fqdn(name))+":"+typ] = true
+	z.mu.Unlock()
+}
+
+// verify runs the real lookup adapter against this zone and feeds its
+// per-record output straight into the real filter, returning what would be
+// attested and the drop summary the seal path would log.
+func (z *zone) verify(
+	t *testing.T, recs []domain.ExpectedDNSRecord,
+) ([]domain.ExpectedDNSRecord, []droppedRecord) {
+	t.Helper()
+	v := dnsadapter.NewLookupVerifier(
+		dnsadapter.WithServer(z.addr), dnsadapter.WithTimeout(2*time.Second))
+	res, err := v.VerifyRecords(context.Background(), "agent.example.com", recs)
+	if err != nil {
+		t.Fatalf("VerifyRecords: %v", err)
+	}
+	if len(res.Results) != len(recs) {
+		t.Fatalf("adapter returned %d results for %d records", len(res.Results), len(recs))
+	}
+	return attestedDNSRecords(recs, res.Results)
+}
+
+// TestRealLookupOutputClassifiesAsMissing is the regression for the seam.
+// An operator publishes the required discovery and badge records and
+// declines the optional TLSA, which on real DNS means the `_443._tcp` label
+// does not exist. The filter must drop that row, and it must report the
+// drop as MISSING so it stays on the INFO arm — a routine operator choice,
+// not an upstream fault that quietly narrowed a signed attestation.
+func TestRealLookupOutputClassifiesAsMissing(t *testing.T) {
+	t.Parallel()
+	const (
+		badgeName = "_ans-badge.agent.example.com"
+		tlsaName  = "_443._tcp.agent.example.com"
+		badgeVal  = "v=ans-badge1; id=abc"
+	)
+	z := newZone(t)
+	z.add(`_ans-badge.agent.example.com. 3600 IN TXT "`+badgeVal+`"`, "TXT")
+
+	recs := []domain.ExpectedDNSRecord{
+		rec(badgeName, domain.DNSRecordTXT, badgeVal, true),
+		rec(tlsaName, domain.DNSRecordTLSA, "3 0 1 abcdef", false),
+	}
+	attested, dropped := z.verify(t, recs)
+
+	if len(attested) != 1 || attested[0].Name != badgeName {
+		t.Fatalf("only the published badge record may be attested; got %+v", attested)
+	}
+	if len(dropped) != 1 {
+		t.Fatalf("expected exactly one drop; got %+v", dropped)
+	}
+	got := dropped[0]
+	if got.Name != tlsaName || got.Type != string(domain.DNSRecordTLSA) {
+		t.Errorf("wrong record dropped: %+v", got)
+	}
+	if got.Cause != dropCauseMissing {
+		t.Errorf("declining an optional record is MISSING, not %q — this is the classification that selects INFO over WARN", got.Cause)
+	}
+	if got.Error != "" {
+		t.Errorf("absence must carry no resolver error; got %q", got.Error)
+	}
+	if droppedForLookupError(dropped) {
+		t.Error("a skipped optional record must not escalate the drop log to WARN")
+	}
+}
+
+// TestRealLookupOutputClassifiesNodataAsMissing covers the other absence
+// shape end to end. The apex exists (it has other records) but carries no
+// HTTPS RR, which is NODATA rather than NXDOMAIN — the CNAME-at-apex
+// operator's position (RFC 1034 §3.6.2). It must classify identically.
+func TestRealLookupOutputClassifiesNodataAsMissing(t *testing.T) {
+	t.Parallel()
+	const fqdn = "agent.example.com"
+	z := newZone(t)
+	z.addName(fqdn)
+
+	recs := []domain.ExpectedDNSRecord{rec(fqdn, domain.DNSRecordHTTPS, "1 . alpn=h2", false)}
+	attested, dropped := z.verify(t, recs)
+
+	if len(attested) != 0 {
+		t.Fatalf("an unpublished HTTPS RR must not be attested; got %+v", attested)
+	}
+	if len(dropped) != 1 || dropped[0].Cause != dropCauseMissing {
+		t.Fatalf("NODATA is absence and must classify as MISSING; got %+v", dropped)
+	}
+	if droppedForLookupError(dropped) {
+		t.Error("NODATA must not escalate to WARN")
+	}
+}
+
+// TestRealLookupOutputClassifiesServfailAsLookupError is the other side of
+// the split, and the reason the split exists. A SERVFAIL means the RA never
+// learned whether the record was published, so the narrowing of a signed
+// attestation was not the operator's decision and has to reach the logs at
+// WARN with the resolver's own reason attached.
+func TestRealLookupOutputClassifiesServfailAsLookupError(t *testing.T) {
+	t.Parallel()
+	const tlsaName = "_443._tcp.agent.example.com"
+	z := newZone(t)
+	z.addServfail(tlsaName, "TLSA")
+
+	recs := []domain.ExpectedDNSRecord{rec(tlsaName, domain.DNSRecordTLSA, "3 0 1 abcdef", false)}
+	attested, dropped := z.verify(t, recs)
+
+	if len(attested) != 0 {
+		t.Fatalf("a record whose lookup failed must not be attested; got %+v", attested)
+	}
+	if len(dropped) != 1 {
+		t.Fatalf("expected exactly one drop; got %+v", dropped)
+	}
+	got := dropped[0]
+	if got.Cause != dropCauseLookupError {
+		t.Errorf("SERVFAIL is a fault, not absence; got cause %q", got.Cause)
+	}
+	if !strings.Contains(got.Error, "SERVFAIL") {
+		t.Errorf("the resolver's reason must survive into the log summary; got %q", got.Error)
+	}
+	if !droppedForLookupError(dropped) {
+		t.Error("a resolver fault must escalate the drop log to WARN")
+	}
+}

--- a/internal/ra/service/dnsattest_internal_test.go
+++ b/internal/ra/service/dnsattest_internal_test.go
@@ -1,0 +1,360 @@
+package service
+
+// White-box tests for attestedDNSRecords, the filter that decides what
+// `dnsRecordsProvisioned[]` claims in the AGENT_REGISTERED leaf.
+//
+// The leaf is signed and appended to a log nobody can amend, so the
+// invariant these tests defend is one-directional: a record may only
+// appear in the attestation if a verification result said it was found.
+// Every case below is a shape the real lookup verifier produces.
+//
+// attestedDNSRecords is unexported, so this is an internal-package test.
+// It reuses rec() from lifecycle_verifydns_test.go.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/port"
+)
+
+// verified pairs an expected record with the verifier's verdict, mirroring
+// what the lookup adapter returns: the same Record struct it was handed,
+// plus Found. Actual stays empty, which is the MISSING shape — nothing
+// answered at that name.
+func verified(r domain.ExpectedDNSRecord, found bool) port.RecordVerification {
+	return port.RecordVerification{Record: r, Found: found}
+}
+
+// mismatched models the other not-found shape the real verifier produces:
+// the zone HAS a record at that name and type, but its value disagrees.
+// verifyTLSA and friends set Actual to the live value and leave Found
+// false (internal/adapter/dns/lookup.go).
+//
+// This shape is why the filter's predicate must be Found alone. Widening
+// it to "we saw something at that name" would attest the value the RA
+// expected while the zone serves a different one, which is a strictly
+// worse false claim than the one this filter exists to remove.
+func mismatched(r domain.ExpectedDNSRecord, live string) port.RecordVerification {
+	return port.RecordVerification{Record: r, Found: false, Actual: live}
+}
+
+// lookupFailed models a per-record lookup fault. LookupVerifier only
+// returns a hard error when it cannot resolve a nameserver at all; a
+// SERVFAIL, REFUSED, or timeout on one record comes back as Found=false
+// with Error set and Actual empty, and VerifyRecords still reports success.
+func lookupFailed(r domain.ExpectedDNSRecord, errText string) port.RecordVerification {
+	return port.RecordVerification{Record: r, Found: false, Error: errText}
+}
+
+func TestAttestedDNSRecords(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fqdn      = "agent.example.com"
+		txtName   = "_ans.agent.example.com"
+		badgeName = "_ans-badge.agent.example.com"
+		tlsaName  = "_443._tcp.agent.example.com"
+	)
+
+	var (
+		svcb  = rec(fqdn, domain.DNSRecordSVCB, "1 . alpn=mcp port=443", true)
+		txt   = rec(txtName, domain.DNSRecordTXT, "v=ans1; ...", true)
+		badge = rec(badgeName, domain.DNSRecordTXT, "v=ans-badge1; ...", true)
+		tlsa  = rec(tlsaName, domain.DNSRecordTLSA, "3 0 1 aabb", false)
+		https = rec(fqdn, domain.DNSRecordHTTPS, "1 . alpn=h2", false)
+	)
+
+	cases := []struct {
+		name      string
+		expected  []domain.ExpectedDNSRecord
+		perRecord []port.RecordVerification
+		want      []domain.ExpectedDNSRecord
+		// wantDropped pins the log-safe account of what was removed and
+		// why. Asserting the cause matters as much as asserting the set:
+		// the three not-found shapes are indistinguishable in the logs
+		// without it, and only one of them is a normal operator choice.
+		wantDropped []droppedRecord
+	}{
+		{
+			// No verifier wired (local dev): verifyDNSRecords returns a nil
+			// perRecord and treats DNS as correct. There is no observation to
+			// filter against, so the expected set passes through and the
+			// quickstart keeps emitting the full record list.
+			name:        "nil_perRecord_passes_expected_through",
+			expected:    []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			perRecord:   nil,
+			want:        []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			wantDropped: nil,
+		},
+		{
+			// The default-profile bug this filter exists to fix. Operator
+			// published SVCB and badge, skipped the optional TLSA. Activation
+			// succeeds either way; the leaf must not claim the TLSA.
+			name:     "unpublished_optional_is_dropped",
+			expected: []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			perRecord: []port.RecordVerification{
+				verified(svcb, true), verified(badge, true), verified(tlsa, false),
+			},
+			want:        []domain.ExpectedDNSRecord{svcb, badge},
+			wantDropped: []droppedRecord{{Name: tlsaName, Type: "TLSA", Cause: "MISSING"}},
+		},
+		{
+			// The operator who did opt into DANE keeps their TLSA attested —
+			// the filter narrows to observation, it does not blanket-drop
+			// optional records.
+			name:     "published_optional_is_kept",
+			expected: []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			perRecord: []port.RecordVerification{
+				verified(svcb, true), verified(badge, true), verified(tlsa, true),
+			},
+			want:        []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			wantDropped: nil,
+		},
+		{
+			// The MISMATCH shape, and the reason the predicate is Found
+			// alone. The operator's zone HAS a TLSA at that name, but it
+			// binds a stale fingerprint from before a cert reissue. On an
+			// unsigned zone this raises no 422 (TLSA is optional and the
+			// DNSSEC hard-fail arm needs the AD bit), so it reaches the
+			// seal. Attesting it would sign the fingerprint the RA
+			// expected while the zone serves a different one.
+			name:     "optional_with_mismatched_value_is_dropped",
+			expected: []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			perRecord: []port.RecordVerification{
+				verified(svcb, true), verified(badge, true), mismatched(tlsa, "3 0 1 ccdd"),
+			},
+			want:        []domain.ExpectedDNSRecord{svcb, badge},
+			wantDropped: []droppedRecord{{Name: tlsaName, Type: "TLSA", Cause: "MISMATCH"}},
+		},
+		{
+			// A resolver fault, and the precedence rule in dropCause. A
+			// failed lookup leaves Actual empty, so classifying on Actual
+			// first would report this as MISSING and hide an upstream
+			// fault behind "the operator didn't publish it". The Error arm
+			// runs first precisely to keep them apart.
+			name:     "optional_lookup_error_is_dropped_and_not_reported_as_missing",
+			expected: []domain.ExpectedDNSRecord{svcb, badge, tlsa},
+			perRecord: []port.RecordVerification{
+				verified(svcb, true), verified(badge, true), lookupFailed(tlsa, "rcode SERVFAIL"),
+			},
+			want: []domain.ExpectedDNSRecord{svcb, badge},
+			wantDropped: []droppedRecord{
+				{Name: tlsaName, Type: "TLSA", Cause: "LOOKUP_ERROR", Error: "rcode SERVFAIL"},
+			},
+		},
+		{
+			// Union mode (ANS_TXT + ANS_DNSAID): SVCB rows are flipped
+			// Required=false and the apex HTTPS RR is optional. A CNAME-at-apex
+			// operator structurally cannot publish HTTPS (RFC 1034 §3.6.2), so
+			// the leaf must not assert it — while the TXT rows they did publish
+			// survive.
+			name:     "union_mode_drops_unpublishable_apex_https",
+			expected: []domain.ExpectedDNSRecord{txt, https, badge},
+			perRecord: []port.RecordVerification{
+				verified(txt, true), verified(https, false), verified(badge, true),
+			},
+			want:        []domain.ExpectedDNSRecord{txt, badge},
+			wantDropped: []droppedRecord{{Name: fqdn, Type: "HTTPS", Cause: "MISSING"}},
+		},
+		{
+			// Ordering is load-bearing: ComputeRequiredDNSRecords regroups to
+			// [discovery..., badge, TLSA] to pin the V2 canonical bytes, and
+			// those bytes are what the RA signs and the TL dedupes on. The
+			// filter walks `expected`, so relative order survives even though
+			// perRecord arrives shuffled.
+			name:     "preserves_expected_order_regardless_of_perRecord_order",
+			expected: []domain.ExpectedDNSRecord{txt, svcb, badge, tlsa},
+			perRecord: []port.RecordVerification{
+				verified(tlsa, true), verified(badge, true),
+				verified(svcb, true), verified(txt, true),
+			},
+			want:        []domain.ExpectedDNSRecord{txt, svcb, badge, tlsa},
+			wantDropped: nil,
+		},
+		{
+			// Why recordKey includes Value. Two TLSA rows share one owner name
+			// and type during a cert rollover. The operator published the new
+			// one and has not yet added the old one; keying on name+type alone
+			// would let the found row vouch for the absent one.
+			name:     "two_tlsa_at_one_name_attest_independently",
+			expected: []domain.ExpectedDNSRecord{badge, tlsa, rec(tlsaName, domain.DNSRecordTLSA, "3 0 1 ccdd", false)},
+			perRecord: []port.RecordVerification{
+				verified(badge, true),
+				verified(tlsa, false),
+				verified(rec(tlsaName, domain.DNSRecordTLSA, "3 0 1 ccdd", false), true),
+			},
+			want:        []domain.ExpectedDNSRecord{badge, rec(tlsaName, domain.DNSRecordTLSA, "3 0 1 ccdd", false)},
+			wantDropped: []droppedRecord{{Name: tlsaName, Type: "TLSA", Cause: "MISSING"}},
+		},
+		{
+			// A record absent from perRecord entirely (not merely Found=false)
+			// is also unattestable — no evidence is not evidence. Guards
+			// against a future verifier that returns a short result list.
+			name:        "record_missing_from_perRecord_is_dropped",
+			expected:    []domain.ExpectedDNSRecord{svcb, badge},
+			perRecord:   []port.RecordVerification{verified(svcb, true)},
+			want:        []domain.ExpectedDNSRecord{svcb},
+			wantDropped: []droppedRecord{{Name: badgeName, Type: "TXT", Cause: "NO_RESULT"}},
+		},
+		{
+			// Empty-but-non-nil perRecord is distinct from nil: the verifier
+			// ran and answered with nothing, so nothing is attestable. Only a
+			// nil perRecord means "no verifier wired".
+			name:      "empty_perRecord_drops_everything",
+			expected:  []domain.ExpectedDNSRecord{svcb, badge},
+			perRecord: []port.RecordVerification{},
+			want:      []domain.ExpectedDNSRecord{},
+			wantDropped: []droppedRecord{
+				{Name: fqdn, Type: "SVCB", Cause: "NO_RESULT"},
+				{Name: badgeName, Type: "TXT", Cause: "NO_RESULT"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, dropped := attestedDNSRecords(tc.expected, tc.perRecord)
+			if len(got) != len(tc.want) {
+				t.Fatalf("attested count: got %d want %d (got %+v)", len(got), len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("record[%d]: got %+v want %+v", i, got[i], tc.want[i])
+				}
+			}
+			if len(dropped) != len(tc.wantDropped) {
+				t.Fatalf("dropped count: got %d want %d (got %+v)", len(dropped), len(tc.wantDropped), dropped)
+			}
+			for i := range tc.wantDropped {
+				if dropped[i] != tc.wantDropped[i] {
+					t.Errorf("dropped[%d]: got %+v want %+v", i, dropped[i], tc.wantDropped[i])
+				}
+			}
+			// Attested and dropped must together account for every
+			// expected record exactly once. A record that fell out of both
+			// would be silently missing from the leaf with nothing in the
+			// logs to explain it.
+			if tc.perRecord != nil && len(got)+len(dropped) != len(tc.expected) {
+				t.Errorf("attested %d + dropped %d != expected %d", len(got), len(dropped), len(tc.expected))
+			}
+		})
+	}
+}
+
+// TestAttestedDNSRecords_DropsNothingWhenAllFound pins the no-op case that
+// keeps the quickstart and every noop-verifier test stable: the noop
+// adapter reports Found=true for every record it is handed, so the filter
+// must return the expected set unchanged rather than reordering or
+// reallocating it into a different shape.
+func TestAttestedDNSRecords_DropsNothingWhenAllFound(t *testing.T) {
+	t.Parallel()
+	expected := []domain.ExpectedDNSRecord{
+		rec("_ans.a.example.com", domain.DNSRecordTXT, "v=ans1", true),
+		rec("a.example.com", domain.DNSRecordSVCB, "1 . alpn=mcp", true),
+		rec("_443._tcp.a.example.com", domain.DNSRecordTLSA, "3 0 1 ab", false),
+	}
+	perRecord := make([]port.RecordVerification, 0, len(expected))
+	for _, r := range expected {
+		perRecord = append(perRecord, verified(r, true))
+	}
+	got, dropped := attestedDNSRecords(expected, perRecord)
+	if len(got) != len(expected) {
+		t.Fatalf("count: got %d want %d", len(got), len(expected))
+	}
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Errorf("record[%d]: got %+v want %+v", i, got[i], expected[i])
+		}
+	}
+	// No drops means the caller logs nothing at all, so a phantom entry
+	// here would produce a log line contradicting the leaf.
+	if len(dropped) != 0 {
+		t.Errorf("want no dropped records, got %+v", dropped)
+	}
+}
+
+// TestAttestedDNSRecords_DropSummaryIsLogSafe pins the log-safety
+// contract on the summary the seal path emits. Record values hold cert
+// fingerprints (TLSA) and endpoint metadata (SVCB, HTTPS, TXT), and the
+// live value a mismatch turned up is operator zone content. None of it
+// may reach log aggregation.
+func TestAttestedDNSRecords_DropSummaryIsLogSafe(t *testing.T) {
+	t.Parallel()
+	const (
+		expectedTLSA = "3 0 1 deadbeef"
+		liveTLSA     = "3 0 1 cafebabe"
+		expectedSVCB = "1 . alpn=mcp port=8443"
+	)
+	txtRec := rec("_ans.a.example.com", domain.DNSRecordTXT, "v=ans1", true)
+	tlsaRec := rec("_443._tcp.a.example.com", domain.DNSRecordTLSA, expectedTLSA, false)
+	svcbRec := rec("a.example.com", domain.DNSRecordSVCB, expectedSVCB, false)
+
+	_, dropped := attestedDNSRecords(
+		[]domain.ExpectedDNSRecord{txtRec, tlsaRec, svcbRec},
+		[]port.RecordVerification{
+			verified(txtRec, true),
+			mismatched(tlsaRec, liveTLSA),
+			lookupFailed(svcbRec, "rcode SERVFAIL"),
+		},
+	)
+	if len(dropped) != 2 {
+		t.Fatalf("dropped count: got %d want 2 (%+v)", len(dropped), dropped)
+	}
+
+	// Every field of every entry, checked against every value in play. The
+	// struct has no Value field today, so this cannot fail now; it exists so
+	// that adding one, or widening Error to carry a record body, fails here
+	// instead of silently shipping cert fingerprints to a log aggregator.
+	secrets := []string{expectedTLSA, liveTLSA, expectedSVCB, "v=ans1"}
+	for _, d := range dropped {
+		for _, field := range []string{d.Name, d.Type, d.Cause, d.Error} {
+			for _, s := range secrets {
+				if strings.Contains(field, s) {
+					t.Errorf("record value %q leaked into the log summary: %+v", s, d)
+				}
+			}
+		}
+	}
+
+	// The resolver's own message is the one thing that must survive: it is
+	// why the record went unattested, and nothing else in the RA reports it.
+	if dropped[1].Cause != dropCauseLookupError || dropped[1].Error != "rcode SERVFAIL" {
+		t.Errorf("resolver failure must reach the log with its cause: %+v", dropped[1])
+	}
+}
+
+// TestDroppedForLookupError pins the level gate. The distinction is the
+// point of the whole summary: an operator skipping an optional record is
+// INFO, an upstream resolver fault that narrowed a signed leaf is WARN.
+func TestDroppedForLookupError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		dropped []droppedRecord
+		want    bool
+	}{
+		{"nothing_dropped", nil, false},
+		{"operator_skipped", []droppedRecord{{Cause: dropCauseMissing}}, false},
+		{"stale_value", []droppedRecord{{Cause: dropCauseMismatch}}, false},
+		{"no_result", []droppedRecord{{Cause: dropCauseNoResult}}, false},
+		{"resolver_failed", []droppedRecord{{Cause: dropCauseLookupError}}, true},
+		{
+			// One fault among ordinary drops still has to escalate, or a
+			// SERVFAIL hides behind an operator's skipped TLSA.
+			"one_fault_among_normal_drops",
+			[]droppedRecord{{Cause: dropCauseMissing}, {Cause: dropCauseLookupError}},
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := droppedForLookupError(tc.dropped); got != tc.want {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ra/service/dnsattest_internal_test.go
+++ b/internal/ra/service/dnsattest_internal_test.go
@@ -21,8 +21,12 @@ import (
 
 // verified pairs an expected record with the verifier's verdict, mirroring
 // what the lookup adapter returns: the same Record struct it was handed,
-// plus Found. Actual stays empty, which is the MISSING shape — nothing
-// answered at that name.
+// plus Found. With found=false, Actual and Error both stay empty, which is
+// the MISSING shape — the adapter produces it for both NXDOMAIN (the name
+// does not exist, which is what declining an optional record looks like)
+// and NODATA (the name exists with no records of this type). See
+// TestDropCauseMatchesLookupAdapterShapes for why those two must not carry
+// an Error.
 func verified(r domain.ExpectedDNSRecord, found bool) port.RecordVerification {
 	return port.RecordVerification{Record: r, Found: found}
 }
@@ -92,6 +96,12 @@ func TestAttestedDNSRecords(t *testing.T) {
 			// The default-profile bug this filter exists to fix. Operator
 			// published SVCB and badge, skipped the optional TLSA. Activation
 			// succeeds either way; the leaf must not claim the TLSA.
+			//
+			// On real DNS this is the NXDOMAIN shape: declining DANE means
+			// never creating `_443._tcp.<fqdn>`, so the name does not exist.
+			// The adapter reports that as Found=false with Error empty, which
+			// is why this drops as MISSING rather than LOOKUP_ERROR and stays
+			// on the INFO arm.
 			name:     "unpublished_optional_is_dropped",
 			expected: []domain.ExpectedDNSRecord{svcb, badge, tlsa},
 			perRecord: []port.RecordVerification{
@@ -323,6 +333,94 @@ func TestAttestedDNSRecords_DropSummaryIsLogSafe(t *testing.T) {
 	// why the record went unattested, and nothing else in the RA reports it.
 	if dropped[1].Cause != dropCauseLookupError || dropped[1].Error != "rcode SERVFAIL" {
 		t.Errorf("resolver failure must reach the log with its cause: %+v", dropped[1])
+	}
+}
+
+// TestDropCauseMatchesLookupAdapterShapes is the seam test between this
+// classification and the adapter that feeds it. Every case below is the
+// exact port.RecordVerification the real LookupVerifier emits for one DNS
+// outcome, so the two stay in agreement.
+//
+// This exists because the classification is only as good as the adapter's
+// contract, and that contract is easy to get wrong in a way no
+// service-level test would catch: the adapter used to report NXDOMAIN
+// through Error, which put the single most common drop — an operator
+// declining DANE, which yields NXDOMAIN on real DNS because the
+// `_443._tcp` owner name is never created — on the LOOKUP_ERROR/WARN arm.
+// Hand-built fixtures modelled absence as Error=="" and so agreed with the
+// intent while the adapter disagreed with both. The adapter side is pinned
+// by TestLookupVerifier_AbsenceShapesAndFaultsAreDistinguishable; this is
+// the other half.
+func TestDropCauseMatchesLookupAdapterShapes(t *testing.T) {
+	t.Parallel()
+	rec := rec("_443._tcp.a.example.com", domain.DNSRecordTLSA, "3 0 1 abcd", false)
+
+	cases := []struct {
+		name string
+		// dnsOutcome names the real-world DNS response this models.
+		dnsOutcome string
+		v          port.RecordVerification
+		haveResult bool
+		want       string
+	}{
+		{
+			name:       "nxdomain",
+			dnsOutcome: "NXDOMAIN — owner name absent; the skip-DANE case",
+			v:          port.RecordVerification{Record: rec},
+			haveResult: true,
+			want:       dropCauseMissing,
+		},
+		{
+			name:       "nodata",
+			dnsOutcome: "NOERROR, empty answer — name exists, no record of this type",
+			v:          port.RecordVerification{Record: rec},
+			haveResult: true,
+			want:       dropCauseMissing,
+		},
+		{
+			name:       "value_disagrees",
+			dnsOutcome: "NOERROR with a record whose value differs (stale fingerprint)",
+			v:          port.RecordVerification{Record: rec, Actual: "3 0 1 ffff"},
+			haveResult: true,
+			want:       dropCauseMismatch,
+		},
+		{
+			name:       "servfail",
+			dnsOutcome: "SERVFAIL — the question went unanswered",
+			v:          port.RecordVerification{Record: rec, Error: "rcode SERVFAIL"},
+			haveResult: true,
+			want:       dropCauseLookupError,
+		},
+		{
+			name:       "refused",
+			dnsOutcome: "REFUSED — likewise a fault, not an answer",
+			v:          port.RecordVerification{Record: rec, Error: "rcode REFUSED"},
+			haveResult: true,
+			want:       dropCauseLookupError,
+		},
+		{
+			name:       "transport_failure",
+			dnsOutcome: "no response at all (timeout / unreachable resolver)",
+			v:          port.RecordVerification{Record: rec, Error: "read udp: i/o timeout"},
+			haveResult: true,
+			want:       dropCauseLookupError,
+		},
+		{
+			name:       "no_result_for_record",
+			dnsOutcome: "verifier returned a short result list — no evidence either way",
+			v:          port.RecordVerification{},
+			haveResult: false,
+			want:       dropCauseNoResult,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := dropCause(tc.v, tc.haveResult); got != tc.want {
+				t.Errorf("%s\n  got %q want %q", tc.dnsOutcome, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/ra/service/dnsattest_test.go
+++ b/internal/ra/service/dnsattest_test.go
@@ -1,0 +1,351 @@
+package service_test
+
+// End-to-end cover for the attestation narrowing: drive a registration
+// all the way to ACTIVE against a verifier that reports the optional
+// TLSA row as unpublished, then read the sealed AGENT_REGISTERED leaf
+// and check it does not claim that row.
+//
+// The unit tests for the filter itself live in
+// dnsattest_internal_test.go. What these add is the wiring: that the
+// filtered set is what reaches both event builders, and that dropping a
+// record does not disturb activation.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/port"
+	"github.com/agentnameservice/ans/internal/ra/service"
+	event "github.com/agentnameservice/ans/internal/tl/event"
+	eventv1 "github.com/agentnameservice/ans/internal/tl/event/v1"
+)
+
+// selectiveDNSVerifier answers per record against the set it was handed:
+// everything is found except records whose type appears in absent, which
+// come back the way an unpublished record does — not found, with no live
+// answer, which is the MISSING half of the port.RecordVerification
+// contract rather than a mismatch.
+//
+// The two existing stubs return a fixed result list and ignore their
+// input, so neither can model "the operator published the required
+// records and skipped the optional one" against the record set
+// ComputeRequiredDNSRecords actually built.
+type selectiveDNSVerifier struct {
+	// absent: the zone has no record of this type.
+	absent map[domain.DNSRecordType]bool
+	// lookupError: the query for this type failed. LookupVerifier reports
+	// that as Found=false with Error set and still returns success
+	// overall, so it is indistinguishable from an absent record unless
+	// something reads Error.
+	lookupError map[domain.DNSRecordType]string
+
+	mu     sync.Mutex
+	calls  int
+	handed []domain.ExpectedDNSRecord
+}
+
+func (v *selectiveDNSVerifier) VerifyRecords(
+	_ context.Context, _ string, expected []domain.ExpectedDNSRecord,
+) (*port.VerificationResult, error) {
+	v.mu.Lock()
+	v.calls++
+	v.handed = append(v.handed, expected...)
+	v.mu.Unlock()
+
+	res := &port.VerificationResult{
+		AllRequired: true,
+		Results:     make([]port.RecordVerification, 0, len(expected)),
+	}
+	for _, r := range expected {
+		errText := v.lookupError[r.Type]
+		found := errText == "" && !v.absent[r.Type]
+		if !found && r.Required {
+			res.AllRequired = false
+		}
+		// Actual stays empty on both not-found paths: nothing answered, so
+		// there is no live value that could have been rewritten. A failed
+		// lookup carries Error instead.
+		res.Results = append(res.Results, port.RecordVerification{
+			Record: r, Found: found, Error: errText,
+		})
+	}
+	return res, nil
+}
+
+func (v *selectiveDNSVerifier) observed() (int, []domain.ExpectedDNSRecord) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.calls, append([]domain.ExpectedDNSRecord(nil), v.handed...)
+}
+
+// activateWithAbsentTLSA registers an agent, clears the ACME gate on the
+// fixture's noop verifier, then swaps in a verifier that reports the
+// optional TLSA row unpublished before verify-dns. The swap happens
+// after verify-acme on purpose: the gate does its own challenge lookup,
+// and keeping that on the noop verifier means the records handed to the
+// selective one are exactly the production record set.
+//
+// Returns the records verify-dns asked about, so callers can derive what
+// the leaf should and should not carry rather than hardcoding names the
+// discovery profiles own.
+func activateWithAbsentTLSA(t *testing.T, schemaVersion string) (*regFixture, []domain.ExpectedDNSRecord) {
+	t.Helper()
+	return activateWithTLSAUnverified(t, schemaVersion,
+		&selectiveDNSVerifier{absent: map[domain.DNSRecordType]bool{domain.DNSRecordTLSA: true}})
+}
+
+// activateWithTLSAUnverified is activateWithAbsentTLSA parameterized by the
+// reason the TLSA row goes unverified, so the absent case and the
+// lookup-failure case share one path to the seal.
+func activateWithTLSAUnverified(
+	t *testing.T, schemaVersion string, v *selectiveDNSVerifier,
+) (*regFixture, []domain.ExpectedDNSRecord) {
+	t.Helper()
+	fx := newRegFixture(t)
+	req := fx.req
+	req.SchemaVersion = schemaVersion
+
+	resp, err := fx.svc.RegisterAgent(context.Background(), req)
+	if err != nil {
+		t.Fatalf("precondition: register should succeed; got: %v", err)
+	}
+	agentID := resp.Registration.AgentID
+	if _, err := fx.svc.VerifyACME(context.Background(), agentID, service.VerifyInput{SchemaVersion: schemaVersion}); err != nil {
+		t.Fatalf("precondition: verify-acme should pass the gate; got: %v", err)
+	}
+
+	fx.svc.WithDNSVerifier(v)
+
+	if _, err := fx.svc.VerifyDNS(context.Background(), agentID, service.VerifyInput{SchemaVersion: schemaVersion}); err != nil {
+		t.Fatalf("an unpublished optional record must not block activation; verify-dns failed: %v", err)
+	}
+
+	got, err := fx.agents.FindByAgentID(context.Background(), agentID)
+	if err != nil {
+		t.Fatalf("FindByAgentID: %v", err)
+	}
+	if got.Status != domain.StatusActive {
+		t.Fatalf("agent must reach ACTIVE with the optional TLSA unpublished; got %q", got.Status)
+	}
+
+	calls, handed := v.observed()
+	// One call keeps the counting assertions below honest — a second
+	// round of lookups would duplicate every record in handed.
+	if calls != 1 {
+		t.Fatalf("verify-dns should verify the record set once; got %d calls", calls)
+	}
+	// Guard the premise. If the default profile set stops emitting an
+	// optional TLSA row, this test silently stops covering anything, so
+	// fail here rather than pass vacuously.
+	sawOptionalTLSA := false
+	sawRequired := false
+	for _, r := range handed {
+		if r.Type == domain.DNSRecordTLSA && !r.Required {
+			sawOptionalTLSA = true
+		}
+		if r.Required {
+			sawRequired = true
+		}
+	}
+	if !sawOptionalTLSA {
+		t.Fatalf("premise: expected an optional TLSA record in the computed set; got %+v", handed)
+	}
+	if !sawRequired {
+		t.Fatalf("premise: expected at least one required record in the computed set; got %+v", handed)
+	}
+	return fx, handed
+}
+
+// partitionHanded splits the records verify-dns asked about into the ones
+// the verifier reported found and the ones it reported absent.
+func partitionHanded(handed []domain.ExpectedDNSRecord) (published, unpublished []domain.ExpectedDNSRecord) {
+	for _, r := range handed {
+		if r.Type == domain.DNSRecordTLSA {
+			unpublished = append(unpublished, r)
+			continue
+		}
+		published = append(published, r)
+	}
+	return published, unpublished
+}
+
+// TestVerifyDNS_SealedV2LeafOmitsUnpublishedOptionalRecord is the
+// regression this whole change exists for. The V2 leaf's
+// dnsRecordsProvisioned[] used to be built from the expected set, so an
+// operator who skipped the optional TLSA got a signed, append-only claim
+// that they had published one.
+func TestVerifyDNS_SealedV2LeafOmitsUnpublishedOptionalRecord(t *testing.T) {
+	t.Parallel()
+	fx, handed := activateWithAbsentTLSA(t, "")
+	published, unpublished := partitionHanded(handed)
+
+	var attested []event.DNSRecord
+	sawV2 := false
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion != event.SchemaVersion {
+			continue
+		}
+		var ev event.Event
+		if err := json.Unmarshal(s.InnerCanonical, &ev); err != nil {
+			t.Fatalf("unmarshal inner V2 event: %v", err)
+		}
+		if ev.EventType != event.TypeAgentRegistered {
+			continue
+		}
+		sawV2 = true
+		if ev.Attestations == nil {
+			t.Fatal("V2 AGENT_REGISTERED must carry attestations")
+		}
+		attested = ev.Attestations.DNSRecordsProvisioned
+	}
+	if !sawV2 {
+		t.Fatal("expected a sealed V2 AGENT_REGISTERED event")
+	}
+
+	inLeaf := make(map[string]bool, len(attested))
+	for _, r := range attested {
+		inLeaf[r.Name+"|"+r.Type+"|"+r.Data] = true
+	}
+	for _, r := range unpublished {
+		key := r.Name + "|" + string(r.Type) + "|" + r.Value
+		if inLeaf[key] {
+			t.Errorf("leaf attests %s %s, which DNS did not answer with", r.Type, r.Name)
+		}
+	}
+	for _, r := range published {
+		key := r.Name + "|" + string(r.Type) + "|" + r.Value
+		if !inLeaf[key] {
+			t.Errorf("leaf is missing %s %s, which DNS did answer with", r.Type, r.Name)
+		}
+	}
+	// Count check catches the other direction: a record in the leaf that
+	// verify-dns never asked about.
+	if len(attested) != len(published) {
+		t.Errorf("leaf record count: got %d want %d (attested %+v)", len(attested), len(published), attested)
+	}
+}
+
+// TestVerifyDNS_SealedV1LeafOmitsUnpublishedOptionalRecord covers the
+// other lane. V1's dnsRecordsProvisioned is a map[name]data, built by a
+// separate builder, so the shared filter needs pinning on both sides.
+func TestVerifyDNS_SealedV1LeafOmitsUnpublishedOptionalRecord(t *testing.T) {
+	t.Parallel()
+	fx, handed := activateWithAbsentTLSA(t, eventv1.SchemaVersion)
+	published, unpublished := partitionHanded(handed)
+
+	var attested map[string]string
+	sawV1 := false
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion != eventv1.SchemaVersion {
+			continue
+		}
+		var ev eventv1.Event
+		if err := json.Unmarshal(s.InnerCanonical, &ev); err != nil {
+			t.Fatalf("unmarshal inner V1 event: %v", err)
+		}
+		if ev.EventType != eventv1.TypeAgentRegistered {
+			continue
+		}
+		sawV1 = true
+		if ev.Attestations == nil {
+			t.Fatal("V1 AGENT_REGISTERED must carry attestations")
+		}
+		attested = ev.Attestations.DNSRecordsProvisioned
+	}
+	if !sawV1 {
+		t.Fatal("expected a sealed V1 AGENT_REGISTERED event")
+	}
+
+	// V1 keys on name alone, so a dropped record only proves anything if
+	// no surviving record shares its owner name.
+	publishedNames := make(map[string]bool, len(published))
+	for _, r := range published {
+		publishedNames[r.Name] = true
+		if attested[r.Name] != r.Value {
+			t.Errorf("V1 map for %s: got %q want %q", r.Name, attested[r.Name], r.Value)
+		}
+	}
+	for _, r := range unpublished {
+		if publishedNames[r.Name] {
+			continue
+		}
+		if _, ok := attested[r.Name]; ok {
+			t.Errorf("V1 map attests %s, which DNS did not answer with", r.Name)
+		}
+	}
+	// The skip above exists because V1 keys on name alone, but if it fired
+	// for every dropped record the negative assertion would be vacuous and
+	// this test would pin nothing. Fail loudly rather than pass silently.
+	provedSomething := false
+	for _, r := range unpublished {
+		if !publishedNames[r.Name] {
+			provedSomething = true
+		}
+	}
+	if len(unpublished) > 0 && !provedSomething {
+		t.Fatal("vacuous: every dropped record shares an owner name with a surviving one, so nothing was asserted")
+	}
+}
+
+// TestVerifyDNS_LookupFailureOnOptionalRecordStillActivatesAndNarrows covers
+// the fault the absent-record tests cannot reach. LookupVerifier returns a
+// hard error only when it cannot resolve a nameserver at all; a SERVFAIL,
+// REFUSED, or timeout on one record comes back as a clean not-found with
+// Error set, and VerifyRecords still reports overall success.
+//
+// TLSA, HTTPS, and SVCB are exactly the query types older resolvers and
+// middleboxes drop while TXT keeps working, so a partial failure that
+// leaves the required records healthy is the ordinary shape of this fault.
+// The agent must still activate, and the leaf must not attest a record the
+// RA never actually saw.
+func TestVerifyDNS_LookupFailureOnOptionalRecordStillActivatesAndNarrows(t *testing.T) {
+	t.Parallel()
+	fx, handed := activateWithTLSAUnverified(t, "", &selectiveDNSVerifier{
+		lookupError: map[domain.DNSRecordType]string{domain.DNSRecordTLSA: "rcode SERVFAIL"},
+	})
+	published, unverified := partitionHanded(handed)
+
+	var attested []event.DNSRecord
+	sawV2 := false
+	for _, s := range fx.sealer.sealed() {
+		if s.SchemaVersion != event.SchemaVersion {
+			continue
+		}
+		var ev event.Event
+		if err := json.Unmarshal(s.InnerCanonical, &ev); err != nil {
+			t.Fatalf("unmarshal inner V2 event: %v", err)
+		}
+		if ev.EventType != event.TypeAgentRegistered {
+			continue
+		}
+		sawV2 = true
+		if ev.Attestations == nil {
+			t.Fatal("V2 AGENT_REGISTERED must carry attestations")
+		}
+		attested = ev.Attestations.DNSRecordsProvisioned
+	}
+	if !sawV2 {
+		t.Fatal("expected a sealed V2 AGENT_REGISTERED event")
+	}
+
+	inLeaf := make(map[string]bool, len(attested))
+	for _, r := range attested {
+		inLeaf[r.Name+"|"+r.Type+"|"+r.Data] = true
+	}
+	for _, r := range unverified {
+		if inLeaf[r.Name+"|"+string(r.Type)+"|"+r.Value] {
+			t.Errorf("leaf attests %s %s, but that lookup failed", r.Type, r.Name)
+		}
+	}
+	for _, r := range published {
+		if !inLeaf[r.Name+"|"+string(r.Type)+"|"+r.Value] {
+			t.Errorf("leaf is missing %s %s, which verified fine", r.Type, r.Name)
+		}
+	}
+	if len(attested) != len(published) {
+		t.Errorf("leaf record count: got %d want %d", len(attested), len(published))
+	}
+}

--- a/internal/ra/service/dnsrecords.go
+++ b/internal/ra/service/dnsrecords.go
@@ -4,13 +4,17 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/agentnameservice/ans/internal/domain"
+	"github.com/agentnameservice/ans/internal/port"
 )
 
 // ComputeRequiredDNSRecords returns the DNS records the operator must
 // publish for reg, composed by walking the discovery registry. The RA
 // does not create these records — the operator manages their own DNS;
-// the RA only verifies they exist and emits the same set onto the TL
-// as `dnsRecordsProvisioned[]`.
+// the RA only verifies they exist.
+//
+// This is the asked-for set, not the attested set. What reaches the TL
+// as `dnsRecordsProvisioned[]` is this set narrowed to the records DNS
+// actually answered with; see attestedDNSRecords.
 //
 // Composition rules:
 //
@@ -75,7 +79,7 @@ func (s *RegistrationService) ComputeRequiredDNSRecords(reg *domain.AgentRegistr
 			// false), so first-seen wins. A profile that disagreed
 			// would have its flag silently dropped here — keep the
 			// flags aligned across adapters.
-			key := r.Name + "|" + string(r.Type) + "|" + r.Value
+			key := recordKey(r)
 			if seen[key] {
 				continue
 			}
@@ -117,6 +121,152 @@ func (s *RegistrationService) ComputeRequiredDNSRecords(reg *domain.AgentRegistr
 	}
 
 	return result
+}
+
+// recordKey identifies one expected record by the three fields that
+// make it distinct on the wire: owner name, RR type, and presentation
+// value. Value is part of the key because a single owner name legitimately
+// carries several records of the same type — two TLSA rows at
+// `_443._tcp.<fqdn>` during a cert rollover, for instance — and collapsing
+// them would make the dedup in ComputeRequiredDNSRecords drop one and the
+// filter in attestedDNSRecords attest one on the other's evidence.
+//
+// Required is deliberately excluded; see the dedup call site above.
+func recordKey(r domain.ExpectedDNSRecord) string {
+	return r.Name + "|" + string(r.Type) + "|" + r.Value
+}
+
+// attestedDNSRecords narrows the expected record set to the records DNS
+// actually answered with, so the AGENT_REGISTERED leaf's
+// `dnsRecordsProvisioned[]` states what was observed rather than what was
+// asked for.
+//
+// This matters because optional records do not block activation. An
+// operator who publishes the required discovery and badge records but no
+// TLSA passes verify-dns — verifyDNSRecords skips absent optional records
+// by design, and DNSSEC does not help since authenticated absence is not
+// tampering. Iterating `expected` at that point would sign "TLSA is
+// provisioned" into an append-only log for an operator who never published
+// one. The apex HTTPS RR is worse: CNAME-at-apex operators cannot publish
+// it at all (RFC 1034 §3.6.2), so the claim could never come true.
+//
+// The predicate is `Found` alone. Required records need no separate arm:
+// a required record that was missing or mismatched comes back from
+// verifyDNSRecords as a mismatch, and VerifyDNS returns 422 before the
+// seal, so by the time this runs every required record is Found.
+//
+// A nil perRecord means the service was built without a DNS verifier (the
+// test/embedding path — cmd/ans-ra always wires one, `noop` included), so
+// verifyDNSRecords short-circuits to "DNS is correct". There is no
+// observation to filter on, so expected passes through unchanged, matching
+// that path's existing contract. An empty-but-non-nil perRecord is
+// different: the verifier ran and reported nothing, so nothing is
+// attestable.
+//
+// Iteration walks `expected` rather than perRecord so the deliberate
+// `[discovery..., badge, TLSA]` grouping that pins the V2 canonical bytes
+// survives the filter. Keys match exactly, with no case or trailing-dot
+// normalization, because the verifier echoes back the same
+// ExpectedDNSRecord struct it was handed.
+//
+// The second return is the log-safe account of what was removed and why.
+// It comes from this same pass deliberately: a separate helper
+// recomputing "what got dropped" could disagree with the filter, and the
+// disagreement would surface as a log line that misdescribes a signed
+// leaf.
+func attestedDNSRecords(
+	expected []domain.ExpectedDNSRecord, perRecord []port.RecordVerification,
+) ([]domain.ExpectedDNSRecord, []droppedRecord) {
+	if perRecord == nil {
+		return expected, nil
+	}
+	// One entry per key: ComputeRequiredDNSRecords dedups `expected` on
+	// exactly recordKey, and the port contract is one result per expected
+	// record, so the map is 1:1 with no collisions to resolve.
+	byKey := make(map[string]port.RecordVerification, len(perRecord))
+	for _, r := range perRecord {
+		byKey[recordKey(r.Record)] = r
+	}
+	attested := make([]domain.ExpectedDNSRecord, 0, len(expected))
+	var dropped []droppedRecord
+	for _, r := range expected {
+		v, ok := byKey[recordKey(r)]
+		if ok && v.Found {
+			attested = append(attested, r)
+			continue
+		}
+		dropped = append(dropped, droppedRecord{
+			Name:  r.Name,
+			Type:  string(r.Type),
+			Cause: dropCause(v, ok),
+			Error: v.Error,
+		})
+	}
+	return attested, dropped
+}
+
+// Causes reported on a dropped record. MISSING and MISMATCH reuse the 422
+// classification codes so one vocabulary covers both surfaces.
+// LOOKUP_ERROR and NO_RESULT have no 422 equivalent: a required record
+// failing either way is reported as MISSING and blocks activation, so they
+// only ever reach the seal on an optional record.
+const (
+	dropCauseMissing     = dnsCodeMissing
+	dropCauseMismatch    = dnsCodeMismatch
+	dropCauseLookupError = "LOOKUP_ERROR"
+	dropCauseNoResult    = "NO_RESULT"
+)
+
+// droppedRecord is the log-safe view of a record attestedDNSRecords
+// removed. Name, type and cause only: record values carry cert
+// fingerprints and endpoint metadata that have no business in log
+// aggregation, matching the 422 mismatch log's discipline. Error is the
+// resolver's own text (an rcode or a network error), present only on the
+// LOOKUP_ERROR cause.
+type droppedRecord struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Cause string `json:"cause"`
+	Error string `json:"error,omitempty"`
+}
+
+// dropCause classifies why a record went unattested. Without this the
+// three causes are indistinguishable in the logs, and they are not
+// equivalent: an operator skipping DANE is a normal choice, a value that
+// disagrees means their zone contradicts the cert just issued, and a
+// failed lookup means an upstream fault silently narrowed a signed leaf.
+//
+// The Error arm comes first on purpose. A failed lookup leaves Actual
+// empty, so it would otherwise be reported as MISSING — exactly the
+// conflation that hides a SERVFAILing resolver behind "operator didn't
+// publish it". Nothing else in the RA reads
+// port.RecordVerification.Error, so this is the only place that fault
+// becomes visible.
+func dropCause(v port.RecordVerification, haveResult bool) string {
+	switch {
+	case !haveResult:
+		return dropCauseNoResult
+	case v.Error != "":
+		return dropCauseLookupError
+	case v.Actual == "":
+		return dropCauseMissing
+	default:
+		return dropCauseMismatch
+	}
+}
+
+// droppedForLookupError reports whether any record went unattested because
+// the lookup itself failed rather than because of the zone's contents.
+// Callers log those at WARN: LookupVerifier only returns a hard error when
+// it cannot find a resolver at all, so a per-record SERVFAIL, REFUSED, or
+// timeout arrives looking like a clean not-found.
+func droppedForLookupError(dropped []droppedRecord) bool {
+	for _, d := range dropped {
+		if d.Cause == dropCauseLookupError {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveRequestedProfiles filters reg.DiscoveryProfiles to those the

--- a/internal/ra/service/lifecycle.go
+++ b/internal/ra/service/lifecycle.go
@@ -955,6 +955,42 @@ func (s *RegistrationService) VerifyDNS(ctx context.Context, agentID string, in 
 		return nil, err
 	}
 
+	// The leaf attests what DNS answered with, not what we asked for.
+	// Optional records don't block activation, so an operator can reach
+	// this line having published the required records and skipped the
+	// TLSA or apex HTTPS rows; attesting those would sign a claim about
+	// records that don't exist. attestedDNSRecords drops them.
+	//
+	// Narrowing the leaf does not hide the record set from the operator.
+	// They read the full computed set from GET
+	// /v2/ans/agents/{agentId} as `registrationPending.dnsRecords[]`
+	// while the agent is PENDING_DNS, which is before they call
+	// verify-dns. It is not in this response: VerifyDNSResult carries no
+	// records, and the 202 body is agentStatus. It is also gone once the
+	// agent is ACTIVE, since buildRegistrationPendingBlock emits nothing
+	// outside the pending statuses.
+	attested, dropped := attestedDNSRecords(expected, perRecord)
+	if len(dropped) > 0 {
+		// Names, types and causes only, never values — same discipline as
+		// the 422 log above. The cause is the point: an operator skipping
+		// DANE, a stale value in their zone, and the resolver failing all
+		// land here looking identical, and only the first is a normal
+		// choice. A failed lookup is an upstream fault that just narrowed
+		// an append-only signed attestation, so it goes out at WARN and
+		// carries the resolver's own message.
+		ev := log.Info()
+		if droppedForLookupError(dropped) {
+			ev = log.Warn()
+		}
+		ev.
+			Str("agentId", agentID).
+			Str("fqdn", reg.FQDN()).
+			Int("expectedCount", len(expected)).
+			Int("attestedCount", len(attested)).
+			Interface("droppedRecords", dropped).
+			Msg("omitting unverified optional DNS records from the activation attestation")
+	}
+
 	// Seal-before-success (ANS-1 §12.3: "the RA MUST NOT activate without a
 	// sealed event (step (d) is the point of no return)"). AGENT_REGISTERED
 	// is the single terminal transition that marks the agent live in the
@@ -967,7 +1003,7 @@ func (s *RegistrationService) VerifyDNS(ctx context.Context, agentID string, in 
 	// (Both lanes emit the same eventType token in version-specific
 	// envelope shapes; the seal runs outside the tx so the network round
 	// trip never holds the SQLite write lock.)
-	sealed, err := s.sealActivationEvent(ctx, reg, expected, perRecord, in.SchemaVersion, now)
+	sealed, err := s.sealActivationEvent(ctx, reg, attested, perRecord, in.SchemaVersion, now)
 	if err != nil {
 		return nil, err
 	}
@@ -1146,10 +1182,16 @@ func (s *RegistrationService) buildAgentRegisteredEvent(
 ) (*event.Event, error) {
 	inner := s.baseInnerEvent(reg, event.TypeAgentRegistered, now)
 
-	// Provisioned records: the exact record set the operator was
-	// asked to configure, now verified live. ACME challenge records
-	// are never on this list by construction — ComputeRequiredDNSRecords
-	// doesn't include them.
+	// Provisioned records: what the caller observed in DNS, already
+	// narrowed by attestedDNSRecords. Every required record is here
+	// (a required miss 422s before the seal), but optional records the
+	// operator chose not to publish — a TLSA row without DANE, the apex
+	// HTTPS RR a CNAME-at-apex zone cannot carry — are absent rather
+	// than attested. ACME challenge records are never on this list by
+	// construction; ComputeRequiredDNSRecords doesn't emit them.
+	//
+	// Callers must pass the filtered set. Handing this builder the raw
+	// expected set would sign claims about records nobody published.
 	//
 	// DNSSECVerified carries forward from the per-record verification
 	// result (set true by the lookup verifier when a validating

--- a/internal/ra/service/registration.go
+++ b/internal/ra/service/registration.go
@@ -806,8 +806,12 @@ type sealedActivation struct {
 // mirroring the identity lane). A failed seal is a failed activation:
 // nothing is committed and the agent stays PENDING_DNS for the operator to
 // retry. A nil sealer fails closed with TL_UNAVAILABLE — there is no "seal
-// later" mode for the ACTIVE transition. expected/perRecord feed the
-// version-specific attestation block.
+// later" mode for the ACTIVE transition.
+//
+// expected/perRecord feed the version-specific attestation block. Callers
+// pass the attestedDNSRecords-filtered set, not the raw expected set: this
+// leaf is signed into an append-only log, so an optional record the
+// operator never published must be absent from it rather than attested.
 func (s *RegistrationService) sealActivationEvent(
 	ctx context.Context, reg *domain.AgentRegistration,
 	expected []domain.ExpectedDNSRecord, perRecord []port.RecordVerification,

--- a/internal/ra/service/v1event.go
+++ b/internal/ra/service/v1event.go
@@ -173,6 +173,11 @@ func (s *RegistrationService) buildAgentRegisteredV1Event(
 	// operator publishes two records at the same owner name (e.g.
 	// two TXTs), V1 can only keep one. We preserve the last value
 	// encountered; this is a known V1 lossiness the V2 shape fixes.
+	//
+	// `expected` arrives already filtered to the records DNS answered
+	// with (see attestedDNSRecords) — the caller does that once for both
+	// lanes, so an optional record the operator skipped is absent here
+	// too rather than attested on the V1 wire.
 	dnsMap := make(map[string]string, len(expected))
 	for _, r := range expected {
 		dnsMap[r.Name] = r.Value
@@ -259,8 +264,17 @@ func (s *RegistrationService) buildAgentRegisteredV1Event(
 //
 //   - `revokedAt` timestamp (RFC3339 UTC).
 //   - `revocationReasonCode` from the caller's stated reason.
-//   - `dnsRecordsProvisioned` — the records the operator now needs
-//     to tear down (same set that was attested at ACTIVE).
+//   - `dnsRecordsProvisioned` — the records the operator now needs to
+//     tear down. This is the currently computed set, NOT the set the
+//     AGENT_REGISTERED leaf attested. The two can differ two ways: an
+//     optional record the operator never published was dropped from the
+//     activation attestation (see attestedDNSRecords) but is still
+//     computed here, and a server-cert renewal moves the TLSA value to
+//     the current fingerprint. Revoke does no DNS lookup, so there is no
+//     observation to narrow against — tear-down guidance is the honest
+//     reading of this field on the revoke event, and a verifier should
+//     not diff it against the registration leaf as if it were a second
+//     attestation of the same state.
 //   - `validIdentityCerts[]` — the identity certs being revoked,
 //     so offline verifiers can mark their fingerprints untrusted.
 //   - `validServerCerts[]` — the BYOC server cert if any.

--- a/internal/tl/event/event.go
+++ b/internal/tl/event/event.go
@@ -205,11 +205,12 @@ type DNSRecord struct {
 	Type string `json:"type"`
 	// DNSSECVerified is true when the RA's verifier observed the
 	// DNSSEC authenticated-data bit on the response that produced
-	// this attestation. Only set for TLSA records where a
-	// validating resolver chain confirmed the cert-binding; absent
-	// on TXT/HTTPS and on TLSA lookups where the chain didn't
-	// validate. `omitempty` so the field drops out unless true —
-	// matches V1 byte-for-byte when zero.
+	// this attestation. Set on TLSA, SVCB, and HTTPS records, whose
+	// lookups capture the AD bit; absent on TXT, which doesn't, and
+	// absent on any lookup where the resolver chain didn't validate.
+	// Because DNSSEC signs RRsets, records sharing an owner name and
+	// type share one AD bit. `omitempty` so the field drops out
+	// unless true — matches V1 byte-for-byte when zero.
 	DNSSECVerified bool `json:"dnssecVerified,omitempty"`
 }
 

--- a/spec/api-spec-v2.yaml
+++ b/spec/api-spec-v2.yaml
@@ -1921,14 +1921,17 @@ components:
           default: ["ANS_DNSAID"]
           description: |
             Set of DNS record families the RA tells the operator to
-            publish and emits in the AGENT_REGISTERED TL event's
-            attestations.dnsRecordsProvisioned[]. The computed records
-            surface to the client on GET /v2/ans/agents/{agentId} as
-            registrationPending.dnsRecords[] once the agent reaches
-            PENDING_DNS — not on the 202 register response, which
-            returns only the ACME challenge (production records are
-            deferred until verify-acme proves domain control and issues
-            the certificates the TLSA binding depends on).
+            publish. The AGENT_REGISTERED TL event's
+            attestations.dnsRecordsProvisioned[] carries these records
+            narrowed to the ones DNS actually answered with at
+            verify-dns, so an optional record the operator chose not to
+            publish is absent from the event rather than attested as
+            present. The computed records surface to the client on GET
+            /v2/ans/agents/{agentId} as registrationPending.dnsRecords[]
+            once the agent reaches PENDING_DNS — not on the 202 register
+            response, which returns only the ACME challenge (production
+            records are deferred until verify-acme proves domain control
+            and issues the certificates the TLSA binding depends on).
 
             Each value names one record family; an operator publishing
             the union (DNS-AID-aligned SVCB plus the original `_ans` TXT


### PR DESCRIPTION
## What was wrong

When an agent activates, the RA signs an `AGENT_REGISTERED` leaf into the
append-only log. Its `attestations.dnsRecordsProvisioned[]` was built by
walking the *expected* record set rather than the verification results, so
optional records the operator never published were signed in as provisioned.

This is reachable on the default profile with the real lookup verifier. The
TLSA rows are `Required: false`, so an operator who publishes the SVCB and
badge records and skips the TLSA still activates, and the leaf claimed a TLSA
was there. DNSSEC does not catch it: the hard-fail arm needs a live record
that disagrees, and authenticated absence is deliberately allowed through.
With `ANS_TXT` requested it widens to the apex HTTPS record, which a zone
with a CNAME at the apex cannot publish at all (RFC 1034 §3.6.2).

## The fix

One filter at one seam. `VerifyDNS` narrows the set before the seal, and
since `sealActivationEvent` feeds both lane builders, V1 and V2 are both
covered with no signature changes.

Required records need no special case. A required record that is missing or
mismatched returns 422 before the seal, so everything required is already
verified by the time the filter runs. The predicate is `Found` alone.

A nil per-record result means the service was built without a verifier (the
test and embedding path — `cmd/ans-ra` always wires one, `noop` included), so
the expected set passes through unchanged. Empty-but-not-nil is the opposite
and attests nothing. Both are pinned by tests.

## Drop causes in the log

Three different conditions reach that point looking identical, and only one is
normal:

- the operator skipped an optional record
- the operator has a record whose value disagrees, which on an unsigned zone
  raises no 422
- the lookup itself failed

That last one mattered more than expected. `LookupVerifier` returns a hard
error only when it cannot resolve a nameserver at all; a SERVFAIL, REFUSED, or
timeout on a single record comes back as a clean not-found and `VerifyRecords`
still reports overall success. TLSA, SVCB and HTTPS are exactly the query
types older resolvers and middleboxes drop while TXT keeps working, so that
fault leaves the required records healthy and quietly narrows a signed leaf.
Nothing else in the RA reads `RecordVerification.Error`, so this log is where
it becomes visible, and it escalates to WARN:

```
{"level":"info","cause":"MISSING","name":"_443._tcp.agent.example.com","type":"TLSA"}
{"level":"warn","cause":"LOOKUP_ERROR","error":"rcode SERVFAIL","name":"_443._tcp.agent.example.com"}
```

Names, types and causes only, never record values. The filter returns the drop
account from the same pass that builds the attested set, so a separate helper
cannot drift and produce a log line that misdescribes the leaf.

## Doc corrections

Four claims the narrowing made false, or that were already false about this
field:

- `ComputeRequiredDNSRecords` no longer emits the same set it computes.
- The V1 revoke envelope's DNS map is tear-down guidance, not a second
  attestation of the activation state. It does no DNS lookup, so there is
  nothing to narrow against, and a verifier should not diff it against the
  registration leaf.
- The `discoveryProfiles` description in `spec/api-spec-v2.yaml` (docsui
  mirror re-synced via `make docs-sync`).
- `event.DNSRecord.DNSSECVerified` claimed TLSA only, while the verifier has
  been setting it for SVCB and HTTPS too.

## Not changing

- **No wire-shape change.** `dnsRecordsProvisioned[]` is already variable
  length by profile and endpoint count, and neither lane's `Validate`
  inspects attestations, so a narrower or empty array cannot be rejected at
  TL ingest.
- **The attested value stays the RA's expected `Value`**, not `r.Actual`, so
  operator-controlled bytes stay out of the signed leaf and a benign
  `Actual != Value` delta on an SVCB subset match does not change the bytes.
- **`dnssecByKey` stays keyed on name+type.** DNSSEC signs RRsets, so records
  sharing an owner name and type share one AD bit by construction.
- **The V1 revoke code itself.** Fixing it properly means either dropping the
  field from the V1 revoke envelope, which breaks reference-schema parity, or
  persisting what was attested at activation, which is a storage change.
  Documented rather than changed.

## Verification

- `make check` passes: fmt, vet, golangci-lint, coverage 90.7% against the
  90% gate.
- `go test -race ./internal/ra/... ./internal/tl/...` clean.
- `recordKey`, `attestedDNSRecords`, `dropCause`, `droppedForLookupError` all
  at 100% statements.
- Ran the real `LookupVerifier` against an in-process DNS server with no TLSA
  published to confirm the premise the tests rest on: `Found=false`,
  `Actual=""`, `AllRequired=true`.
- Mutation-checked the two predicates that carry the correctness:

  | Mutation | Result |
  |---|---|
  | `Found` → `Found \|\| Actual != ""` | fails `optional_with_mismatched_value_is_dropped` |
  | remove the `Error` arm from `dropCause` | fails `optional_lookup_error_is_dropped_and_not_reported_as_missing` |

## Follow-up worth its own PR

TLSA rollover on a DNSSEC-signed zone. Multiple TLSA records at one owner name
work fine today — `verifyTLSA` loops the answer set and returns on the first
match, so extra siblings are ignored. But mid-renewal, before the new record is
published, the old one alone gives `Found=false` with a non-empty `Actual` and
the AD bit set, which trips the hard-fail arm and 422s even though TLSA is
optional. An unsigned operator sails through with the record simply dropped.
Making that gate group-aware (only hard-fail when *no* record at that name
matches, per RFC 7671 §8.1) pairs naturally with adding the `3 1 1` SPKI
variant, since a `3 1 1` record present with no matching `3 0 1` looks
identical to a rewritten one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)