### PR TITLE
fix(dns): compare SVCB TargetName as effective target, not presentation string (RFC 9460 §2.5.2)

### DIFF
--- a/internal/adapter/dns/dns_test.go
+++ b/internal/adapter/dns/dns_test.go
@@ -304,6 +304,34 @@ func TestLookupVerifier_SVCB(t *testing.T) {
 			why:       "ServiceMode expectation should not match an AliasMode record",
 		},
 		{
+			// RFC 9460 §2.5.2: in ServiceMode, TargetName "." designates
+			// the record's owner name, so a live record whose target is
+			// the explicit owner FQDN — the form emitted by publishing
+			// tools such as the DNS-AID reference implementation — is
+			// the same target as the expected ".". Comparing the
+			// presentation strings literally would report a present,
+			// correct record as not-found.
+			name:      "servicemode-explicit-owner-fqdn-matches-expected-dot",
+			zoneName:  "agent.example.com.",
+			zoneRR:    `agent.example.com. 3600 IN SVCB 1 agent.example.com. alpn=a2a port=443`,
+			queryName: "agent.example.com",
+			want:      `1 . alpn=a2a port=443`,
+			found:     true,
+			why:       "RFC 9460 §2.5.2: '.' and the explicit owner FQDN are the same effective TargetName",
+		},
+		{
+			// Effective-TargetName comparison must not degrade into
+			// "any target matches": an explicit target naming a host
+			// other than the owner is still a real mismatch.
+			name:      "servicemode-different-explicit-target-still-fails",
+			zoneName:  "agent.example.com.",
+			zoneRR:    `agent.example.com. 3600 IN SVCB 1 other.example.com. alpn=a2a port=443`,
+			queryName: "agent.example.com",
+			want:      `1 . alpn=a2a port=443`,
+			found:     false,
+			why:       "a target that is neither '.' nor the owner name designates a different endpoint",
+		},
+		{
 			// RFC 9460 §8 unknown-key ignore: a live record with extra
 			// SvcParams (e.g. another agentic spec adding its own keys to
 			// the same SVCB row) must still match when our committed

--- a/internal/adapter/dns/lookup.go
+++ b/internal/adapter/dns/lookup.go
@@ -270,10 +270,12 @@ func formatHTTPSValue(s *dns.SVCB) string {
 // designs for multi-family coexistence in a single record — sibling
 // families can share one SVCB row, distinguished by their own
 // SvcParamKeys. Verification therefore implements RFC 9460 §8
-// unknown-key ignore semantics as a *subset* match: priority and
-// target must equal the expected value exactly, every expected
-// SvcParam must be present in the live record with an equal value,
-// and additional SvcParams in the live record are tolerated.
+// unknown-key ignore semantics as a *subset* match: priority must
+// equal the expected value exactly, targets must designate the same
+// effective TargetName (RFC 9460 §2.5.2 — "." and the explicit owner
+// FQDN are the same target in ServiceMode), every expected SvcParam
+// must be present in the live record with an equal value, and
+// additional SvcParams in the live record are tolerated.
 //
 // A strict-equality matcher would mark a multi-spec record not-found
 // and (in a DNSSEC-signed zone) trip the SVCB_DNSSEC_MISMATCH hard
@@ -312,7 +314,7 @@ func (v *LookupVerifier) verifySVCB(ctx context.Context, server string, rec doma
 			// not-found if no other answer matches.
 			continue
 		}
-		if matchesSVCBSubset(expected, actual) {
+		if matchesSVCBSubset(expected, actual, rec.Name) {
 			r.Found = true
 			r.Actual = gotStr
 			return r
@@ -366,14 +368,23 @@ func parseSVCBValue(s string) (parsedSVCB, error) {
 
 // matchesSVCBSubset reports whether `actual` carries all SvcParams
 // in `expected` (with equal values), tolerating any additional
-// SvcParams in `actual`. Priority and target must match exactly.
+// SvcParams in `actual`. Priority must match exactly; targets are
+// compared as effective TargetNames (see effectiveSVCBTarget), so a
+// ServiceMode "." and the explicit owner FQDN — the same target per
+// RFC 9460 §2.5.2 — match regardless of which presentation form a
+// publishing tool emitted.
 //
 // This is the verifier-side embodiment of RFC 9460 §8 unknown-key
 // ignore semantics: the RA only verifies the SvcParams it committed
 // to write; SvcParams from other agentic specs sharing the same
 // SVCB row pass through unexamined.
-func matchesSVCBSubset(expected, actual parsedSVCB) bool {
-	if expected.priority != actual.priority || expected.target != actual.target {
+func matchesSVCBSubset(expected, actual parsedSVCB, owner string) bool {
+	if expected.priority != actual.priority {
+		return false
+	}
+	serviceMode := expected.priority != 0
+	if effectiveSVCBTarget(expected.target, owner, serviceMode) !=
+		effectiveSVCBTarget(actual.target, owner, serviceMode) {
 		return false
 	}
 	for k, want := range expected.params {
@@ -383,6 +394,23 @@ func matchesSVCBSubset(expected, actual parsedSVCB) bool {
 		}
 	}
 	return true
+}
+
+// effectiveSVCBTarget returns the canonical effective TargetName of
+// an SVCB record for comparison purposes. RFC 9460 §2.5.2: "For
+// ServiceMode SVCB RRs, if TargetName has the value '.', then the
+// owner name of this record MUST be used as the effective
+// TargetName." So at owner `agent.example.com`, a target of "." and
+// an explicit `agent.example.com.` designate the same target; which
+// form appears is a choice of the publishing tool, not an identity.
+// In AliasMode (priority 0) "." means "service not available" and is
+// left as-is. Canonicalization (lowercase, trailing dot) also makes
+// the comparison case- and FQDN-dot-insensitive, as DNS names are.
+func effectiveSVCBTarget(target, owner string, serviceMode bool) string {
+	if serviceMode && target == "." {
+		return dns.CanonicalName(owner)
+	}
+	return dns.CanonicalName(target)
 }
 
 // normalizeTLSA collapses whitespace and lowercases the hex so


### PR DESCRIPTION
`matchesSVCBSubset` compared the SVCB TargetName as a raw presentation string. The RA builds the expected row with target `.`, so a live record whose target is the explicit owner FQDN (the form emitted by publishing tools such as the DNS-AID reference implementation) failed `verify-dns` with "record not found", despite designating the same target per RFC 9460 §2.5.2:

> For ServiceMode SVCB RRs, if TargetName has the value ".", then the owner name of this record MUST be used as the effective TargetName.

This normalizes both sides to the effective TargetName before comparing: in ServiceMode `.` expands to the record's owner name, and both targets are canonicalized (lowercase, trailing dot) so the comparison is case- and FQDN-dot-insensitive, as DNS names are. AliasMode (priority 0) `.` keeps its "service not available" meaning and is left as-is.




Assisted-by: Claude Code (claude-fable-5)
