### PR TITLE
ci: run the quality gate on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Related issue

Fixes #110

## Summary

The `main` ruleset runs a merge queue and requires the `Build & Test`, `Lint`, and `DCO` checks, but this workflow only triggered on `push` and `pull_request`. The queue waits for required checks on the merge-group commit, so without a `merge_group` trigger every queued pull request would sit for the 10-minute status-check timeout and then be removed from the queue. No `merge_group` workflow run has ever occurred in this repository; earlier pull requests went through the queue only because no checks were required at the time.

This adds `merge_group:` to the workflow's `on:` block. `Lint` stays conditioned on `pull_request` and reports as skipped on merge groups, which GitHub counts as passing. The DCO merge-group shim already covers `DCO`.

Merge this before other queued pull requests. Merge-group workflows run from the group commit, so this change carries itself through the queue, and everything queued afterward inherits it from `main`.

## Testing

Workflow trigger change only; no Go code touched. The YAML parses with the three triggers `push`, `pull_request`, and `merge_group`. The real verification is this pull request's own trip through the merge queue: `Build & Test` must run and report on the merge-group commit, `Lint` must report as skipped, and `DCO` must be reported by the shim.

## AI assistance

Assisted-by: Claude Code (claude-fable-5-1)

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org) — release notes are generated from it
- [ ] Tests cover the change: not applicable, this is CI trigger configuration verified by the merge-queue run itself
- [x] The linked issue above uses a closing keyword
- [x] Every commit is signed off (`git commit -s`) certifying the [DCO](https://developercertificate.org)