### PR TITLE
feat(ans-verify): verify attested metadata hashes against the served descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ The verifier:
 6. ES256-verifies the signature over Sig_structure.
 7. Cross-checks that the receipt's computed leaf hash matches the
    badge's `merkleProof.leafHash` (same leaf in the same tree).
+8. For every metadata hash the leaf attests, fetches the descriptor at
+   the URL the attested SVCB row carries (`key65400`) and compares its
+   SHA-256 with the attested value. A mismatch fails verification; an
+   unreachable descriptor is reported only. `-check-metadata=false`
+   skips this step.
 
 ## Configuration
 

--- a/cmd/ans-verify/main.go
+++ b/cmd/ans-verify/main.go
@@ -23,6 +23,12 @@
 //     verification keys.
 //  6. Fetches the badge (/v1/agents/{agentId}) and cross-checks
 //     that the badge's merkleProof matches the receipt's proof.
+//  7. For every metadata hash the leaf attests, fetches the
+//     descriptor at the URL the attested SVCB row carries (key65400)
+//     and compares its SHA-256 with the attested value. A mismatch
+//     fails verification: the registration asserts something that
+//     is not true. An unreachable descriptor is reported only.
+//     Disable with -check-metadata=false.
 //
 // If -pubkey <path> is given, the tool loads that PEM public key
 // instead of fetching /root-keys. This is useful for
@@ -61,10 +67,12 @@ func main() {
 	}
 
 	var (
-		baseURL   string
-		agentID   string
-		pubKeyPEM string
-		verbose   bool
+		baseURL         string
+		agentID         string
+		pubKeyPEM       string
+		verbose         bool
+		checkMetadata   bool
+		metadataTimeout time.Duration
 	)
 
 	flag.StringVar(&baseURL, "url", "http://localhost:18081",
@@ -75,6 +83,10 @@ func main() {
 		"Path to a PEM public key file (optional; default fetches /root-keys)")
 	flag.BoolVar(&verbose, "v", false,
 		"Verbose output (show raw event JSON)")
+	flag.BoolVar(&checkMetadata, "check-metadata", true,
+		"Fetch each attested metadata descriptor and verify its hash (step 7)")
+	flag.DurationVar(&metadataTimeout, "metadata-timeout", 15*time.Second,
+		"Per-request timeout for step 7 descriptor fetches")
 	flag.Parse()
 
 	if agentID == "" {
@@ -156,6 +168,13 @@ func main() {
 	// --- Step 6: Cross-check against badge ---------------------------
 	fmt.Println("── Step 6: Cross-check against badge ──")
 	compareBadge(context.Background(), baseURL, agentID, receiptBytes)
+	fmt.Println()
+
+	// --- Step 7: Attested metadata hashes ---------------------------
+	fmt.Println("── Step 7: Attested metadata hashes ──")
+	if runMetadataStep(context.Background(), receiptBytes, checkMetadata, metadataTimeout) {
+		fatalf("metadata hash mismatch: the leaf attests a hash the served descriptor does not have")
+	}
 }
 
 // verifyReceiptStep extracts the receipt-verify nested logic out of

--- a/cmd/ans-verify/metadata.go
+++ b/cmd/ans-verify/metadata.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/agentnameservice/ans/internal/tl/receipt"
+)
+
+// SVCB SvcParam presentation prefixes the metadata check reads out of an
+// attested `dnsRecordsProvisioned[]` row. key65400 / key65402 are the RFC
+// 9460 §14.3.1 Private Use presentation of the DNS-AID draft-02 `cap` and
+// `bap` params, exactly as internal/adapter/discovery/ans emits them. They
+// are restated here rather than imported because the verifier is
+// deliberately a leaf that depends only on internal/tl/receipt.
+const (
+	svcbParamALPN = "alpn="
+	svcbParamCap  = "key65400="
+	svcbParamBAP  = "key65402="
+
+	// metadataHashPrefix is the algorithm tag the RA validates on every
+	// registered metadataHash (domain.metadataHashPattern).
+	metadataHashPrefix = "SHA256:"
+
+	// dnsaidHTTPAPIToken is the DNS-AID alpn/bap token for the HTTP_API
+	// protocol (protocolToDNSAIDValue); every other protocol is its
+	// lowercased name.
+	dnsaidHTTPAPIToken = "x-http"
+	protocolHTTPAPI    = "HTTP_API"
+
+	rrTypeHTTPS = "HTTPS"
+	rrTypeSVCB  = "SVCB"
+)
+
+// metadataOutcome classifies one attested-hash check.
+type metadataOutcome int
+
+const (
+	// metadataMatch: the document at the attested URL hashes to the
+	// attested value.
+	metadataMatch metadataOutcome = iota
+	// metadataMismatch: the document was fetched and its hash differs.
+	// The registration asserts something that is not true.
+	metadataMismatch
+	// metadataUnreachable: the document could not be fetched (network
+	// error or non-200). Reported, not failed: it may be a 401.
+	metadataUnreachable
+	// metadataNoURL: the leaf attests a hash for this protocol but no
+	// attested SVCB row carries a descriptor URL for it, so there is
+	// nothing to fetch.
+	metadataNoURL
+)
+
+// metadataCheck is one attested (protocol → hash) pair joined to the
+// descriptor URL the attested SVCB row for that protocol carries.
+type metadataCheck struct {
+	Protocol string // attestation key as registered: "A2A", "MCP", "HTTP_API"
+	URL      string // key65400 of the matching attested SVCB row; "" if none
+	WantHash string // "SHA256:<64 hex>" as sealed in the leaf
+}
+
+// metadataResult is the outcome of fetching and hashing one check.
+type metadataResult struct {
+	metadataCheck
+	Outcome metadataOutcome
+	GotHash string // "SHA256:<64 hex>" of the fetched body, when fetched
+	Err     error  // fetch error, when Outcome is metadataUnreachable
+}
+
+// attestedRecord is the lane-agnostic view of one dnsRecordsProvisioned
+// entry: V2 seals a typed {name,data,type} array, V1 a name→data map.
+type attestedRecord struct {
+	Name string `json:"name"`
+	Data string `json:"data"`
+	Type string `json:"type"`
+}
+
+// metadataChecksFromEvent reads the attested metadataHashes and the
+// attested SVCB rows out of a receipt's event payload and pairs them by
+// protocol. It returns nil when the leaf attests no metadata hash — the
+// registration declared none, so there is nothing to check.
+//
+// Both inputs come from the same signed leaf, so the check is closed over
+// what the log carries: no DNS lookup, no operator input.
+func metadataChecksFromEvent(payload []byte) ([]metadataCheck, error) {
+	var env struct {
+		Payload struct {
+			Producer struct {
+				Event struct {
+					Attestations struct {
+						MetadataHashes        map[string]string `json:"metadataHashes"`
+						DNSRecordsProvisioned json.RawMessage   `json:"dnsRecordsProvisioned"`
+					} `json:"attestations"`
+				} `json:"event"`
+			} `json:"producer"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil {
+		return nil, fmt.Errorf("decode event payload: %w", err)
+	}
+	att := env.Payload.Producer.Event.Attestations
+	if len(att.MetadataHashes) == 0 {
+		return nil, nil
+	}
+	urls := descriptorURLsByToken(decodeAttestedRecords(att.DNSRecordsProvisioned))
+	checks := make([]metadataCheck, 0, len(att.MetadataHashes))
+	for _, proto := range slices.Sorted(maps.Keys(att.MetadataHashes)) {
+		checks = append(checks, metadataCheck{
+			Protocol: proto,
+			URL:      urls[dnsaidTokenForProtocol(proto)],
+			WantHash: att.MetadataHashes[proto],
+		})
+	}
+	return checks, nil
+}
+
+// decodeAttestedRecords accepts either lane's encoding of
+// dnsRecordsProvisioned. Unknown shapes decode to nothing rather than
+// failing the whole step: the hash check then reports "no URL", which is
+// the honest answer.
+func decodeAttestedRecords(raw json.RawMessage) []attestedRecord {
+	if len(raw) == 0 {
+		return nil
+	}
+	var typed []attestedRecord
+	if err := json.Unmarshal(raw, &typed); err == nil {
+		return typed
+	}
+	var byName map[string]string
+	if err := json.Unmarshal(raw, &byName); err != nil {
+		return nil
+	}
+	out := make([]attestedRecord, 0, len(byName))
+	for _, name := range slices.Sorted(maps.Keys(byName)) {
+		out = append(out, attestedRecord{Name: name, Data: byName[name]})
+	}
+	return out
+}
+
+// descriptorURLsByToken indexes the key65400 descriptor URL of every
+// attested SVCB/HTTPS row by the row's alpn and bap tokens. A row without
+// key65400 contributes nothing. First row wins per token, matching how
+// the RA collapses metadataHashes per protocol.
+func descriptorURLsByToken(records []attestedRecord) map[string]string {
+	urls := map[string]string{}
+	for _, rec := range records {
+		if rec.Type != "" && rec.Type != rrTypeHTTPS && rec.Type != rrTypeSVCB {
+			continue
+		}
+		var alpn, bap, capURL string
+		for _, field := range strings.Fields(rec.Data) {
+			switch {
+			case strings.HasPrefix(field, svcbParamALPN):
+				alpn = strings.TrimPrefix(field, svcbParamALPN)
+			case strings.HasPrefix(field, svcbParamBAP):
+				bap = strings.TrimPrefix(field, svcbParamBAP)
+			case strings.HasPrefix(field, svcbParamCap):
+				capURL = strings.TrimPrefix(field, svcbParamCap)
+			}
+		}
+		if capURL == "" {
+			continue
+		}
+		for _, tok := range []string{alpn, bap} {
+			if tok == "" {
+				continue
+			}
+			if _, seen := urls[strings.ToLower(tok)]; !seen {
+				urls[strings.ToLower(tok)] = capURL
+			}
+		}
+	}
+	return urls
+}
+
+// dnsaidTokenForProtocol maps a registered protocol name to the alpn/bap
+// token the DNSAID profile emits for it (protocolToDNSAIDValue).
+func dnsaidTokenForProtocol(protocol string) string {
+	if strings.EqualFold(protocol, protocolHTTPAPI) {
+		return dnsaidHTTPAPIToken
+	}
+	return strings.ToLower(protocol)
+}
+
+// verifyMetadata fetches each check's descriptor and compares its SHA-256
+// with the attested hash. Bodies are capped at maxResponseBytes like every
+// other fetch in this binary.
+func verifyMetadata(ctx context.Context, client *http.Client, checks []metadataCheck) []metadataResult {
+	results := make([]metadataResult, 0, len(checks))
+	for _, c := range checks {
+		results = append(results, verifyOneMetadata(ctx, client, c))
+	}
+	return results
+}
+
+func verifyOneMetadata(ctx context.Context, client *http.Client, c metadataCheck) metadataResult {
+	res := metadataResult{metadataCheck: c}
+	if c.URL == "" {
+		res.Outcome = metadataNoURL
+		return res
+	}
+	body, err := fetchDescriptor(ctx, client, c.URL)
+	if err != nil {
+		res.Outcome = metadataUnreachable
+		res.Err = err
+		return res
+	}
+	sum := sha256.Sum256(body)
+	res.GotHash = metadataHashPrefix + hex.EncodeToString(sum[:])
+	if strings.EqualFold(res.GotHash, c.WantHash) {
+		res.Outcome = metadataMatch
+	} else {
+		res.Outcome = metadataMismatch
+	}
+	return res
+}
+
+// fetchDescriptor GETs the descriptor with the body cap applied. Any
+// non-200 is an error so a 401 or 404 reads as "unreachable", not as a
+// document that fails to hash.
+func fetchDescriptor(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("body exceeds %d bytes", maxResponseBytes)
+	}
+	return body, nil
+}
+
+// runMetadataStep is Step 7 of the CLI: it verifies every metadata hash
+// the leaf attests against the document at the attested descriptor URL.
+// It prints one line per protocol and returns true when at least one
+// hash MISMATCHES — the only outcome that fails verification. Unreachable
+// and no-URL are reported and do not fail. When the leaf attests no
+// hash, or the step is disabled, it returns false.
+func runMetadataStep(ctx context.Context, receiptBytes []byte, enabled bool, timeout time.Duration) bool {
+	if !enabled {
+		fmt.Println("  ⚠ skipped (-check-metadata=false)")
+		return false
+	}
+	payload, err := receipt.ExtractPayload(receiptBytes)
+	if err != nil {
+		fmt.Printf("  ⚠ %v\n", err)
+		return false
+	}
+	return metadataStepForPayload(ctx, payload, &http.Client{Timeout: timeout})
+}
+
+// metadataStepForPayload is runMetadataStep after the receipt has been
+// opened: the part that reads the leaf, fetches, compares and prints.
+// Split out so it can be exercised on a bare event payload.
+func metadataStepForPayload(ctx context.Context, payload []byte, client *http.Client) bool {
+	checks, err := metadataChecksFromEvent(payload)
+	if err != nil {
+		fmt.Printf("  ⚠ %v\n", err)
+		return false
+	}
+	if len(checks) == 0 {
+		fmt.Println("  ✓ leaf attests no metadata hash — nothing to check")
+		return false
+	}
+	failed := false
+	for _, r := range verifyMetadata(ctx, client, checks) {
+		printMetadataResult(r)
+		if r.Outcome == metadataMismatch {
+			failed = true
+		}
+	}
+	return failed
+}
+
+func printMetadataResult(r metadataResult) {
+	switch r.Outcome {
+	case metadataMatch:
+		fmt.Printf("  ✓ %s: %s matches attested %s\n", r.Protocol, r.URL, r.WantHash)
+	case metadataMismatch:
+		fmt.Printf("  ✗ %s: %s hashes to %s, leaf attests %s\n", r.Protocol, r.URL, r.GotHash, r.WantHash)
+	case metadataUnreachable:
+		fmt.Printf("  ⚠ %s: %s unreachable (%v) — attested %s not checked\n", r.Protocol, r.URL, r.Err, r.WantHash)
+	case metadataNoURL:
+		fmt.Printf("  ⚠ %s: leaf attests %s but no attested SVCB row carries a descriptor URL\n",
+			r.Protocol, r.WantHash)
+	}
+}

--- a/cmd/ans-verify/metadata_test.go
+++ b/cmd/ans-verify/metadata_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// envelopeWithAttestations wraps an attestations JSON object in the
+// envelope path the receipt payload uses
+// (payload.producer.event.attestations).
+func envelopeWithAttestations(attestations string) []byte {
+	return []byte(`{"schemaVersion":"V2","payload":{"producer":{"event":{` +
+		`"eventType":"AGENT_REGISTERED","attestations":` + attestations + `}}}}`)
+}
+
+func sha256Tag(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return metadataHashPrefix + hex.EncodeToString(sum[:])
+}
+
+func TestMetadataChecksFromEvent_V2PairsHashWithSVCBRow(t *testing.T) {
+	t.Parallel()
+	payload := envelopeWithAttestations(`{
+		"metadataHashes":{"A2A":"SHA256:aa","HTTP_API":"SHA256:bb","MCP":"SHA256:cc"},
+		"dnsRecordsProvisioned":[
+			{"name":"agent.example.com","type":"HTTPS","data":"1 . alpn=a2a port=443 key65400=https://agent.example.com/.well-known/agent.json key65401=x key65402=a2a"},
+			{"name":"agent.example.com","type":"HTTPS","data":"1 . alpn=x-http port=443 key65400=https://agent.example.com/openapi.json key65402=x-http"},
+			{"name":"agent.example.com","type":"HTTPS","data":"1 . alpn=mcp port=443 key65402=mcp"},
+			{"name":"_ans.agent.example.com","type":"TXT","data":"v=ans1 key65400=https://not-a-svcb-row.example"}
+		]}`)
+	checks, err := metadataChecksFromEvent(payload)
+	if err != nil {
+		t.Fatalf("metadataChecksFromEvent: %v", err)
+	}
+	want := []metadataCheck{
+		{Protocol: "A2A", URL: "https://agent.example.com/.well-known/agent.json", WantHash: "SHA256:aa"},
+		{Protocol: "HTTP_API", URL: "https://agent.example.com/openapi.json", WantHash: "SHA256:bb"},
+		{Protocol: "MCP", URL: "", WantHash: "SHA256:cc"}, // row has no key65400
+	}
+	if len(checks) != len(want) {
+		t.Fatalf("got %d checks, want %d: %+v", len(checks), len(want), checks)
+	}
+	for i := range want {
+		if checks[i] != want[i] {
+			t.Errorf("check %d = %+v, want %+v", i, checks[i], want[i])
+		}
+	}
+}
+
+func TestMetadataChecksFromEvent_V1MapShape(t *testing.T) {
+	t.Parallel()
+	payload := envelopeWithAttestations(`{
+		"metadataHashes":{"MCP":"SHA256:cc"},
+		"dnsRecordsProvisioned":{
+			"agent.example.com":"1 . alpn=mcp port=443 key65400=https://agent.example.com/mcp.json key65402=mcp",
+			"_ans.agent.example.com":"v=ans1"
+		}}`)
+	checks, err := metadataChecksFromEvent(payload)
+	if err != nil {
+		t.Fatalf("metadataChecksFromEvent: %v", err)
+	}
+	if len(checks) != 1 || checks[0].URL != "https://agent.example.com/mcp.json" {
+		t.Fatalf("got %+v, want one MCP check with the V1-map URL", checks)
+	}
+}
+
+func TestMetadataChecksFromEvent_NoHashesMeansNothingToCheck(t *testing.T) {
+	t.Parallel()
+	for name, att := range map[string]string{
+		"absent": `{"domainValidation":"ACME-DNS-01"}`,
+		"empty":  `{"metadataHashes":{}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			checks, err := metadataChecksFromEvent(envelopeWithAttestations(att))
+			if err != nil || checks != nil {
+				t.Fatalf("got (%v, %v), want (nil, nil)", checks, err)
+			}
+		})
+	}
+}
+
+func TestMetadataChecksFromEvent_BadJSON(t *testing.T) {
+	t.Parallel()
+	if _, err := metadataChecksFromEvent([]byte(`{not json`)); err == nil {
+		t.Fatal("expected decode error")
+	}
+}
+
+func TestDecodeAttestedRecords_UnknownShapeIsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := decodeAttestedRecords([]byte(`42`)); got != nil {
+		t.Fatalf("got %+v, want nil", got)
+	}
+	if got := decodeAttestedRecords(nil); got != nil {
+		t.Fatalf("got %+v, want nil", got)
+	}
+}
+
+func TestDescriptorURLsByToken_BAPAloneAndFirstRowWins(t *testing.T) {
+	t.Parallel()
+	urls := descriptorURLsByToken([]attestedRecord{
+		{Type: "SVCB", Data: "1 . port=443 key65400=https://a.example/one key65402=A2A"},
+		{Type: "SVCB", Data: "1 . alpn=a2a port=8443 key65400=https://a.example/two key65402=a2a"},
+		{Type: "TLSA", Data: "3 1 1 deadbeef"},
+	})
+	if urls["a2a"] != "https://a.example/one" {
+		t.Fatalf("a2a → %q, want the first row's URL (bap-only, case-folded)", urls["a2a"])
+	}
+	if len(urls) != 1 {
+		t.Fatalf("urls = %v, want exactly one token", urls)
+	}
+}
+
+func TestDNSAIDTokenForProtocol(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{"A2A": "a2a", "MCP": "mcp", "HTTP_API": "x-http", "http_api": "x-http"}
+	for in, want := range cases {
+		if got := dnsaidTokenForProtocol(in); got != want {
+			t.Errorf("dnsaidTokenForProtocol(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// descriptorServer serves a fixed document at /card.json and 401s
+// everything else.
+func descriptorServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/card.json" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestVerifyMetadata_Outcomes(t *testing.T) {
+	t.Parallel()
+	const doc = `{"name":"agent","capabilities":["pay"]}`
+	srv := descriptorServer(t, doc)
+	checks := []metadataCheck{
+		{Protocol: "A2A", URL: srv.URL + "/card.json", WantHash: strings.ToUpper(sha256Tag(doc))},
+		{Protocol: "MCP", URL: srv.URL + "/card.json", WantHash: sha256Tag("something else")},
+		{Protocol: "HTTP_API", URL: srv.URL + "/private.json", WantHash: sha256Tag(doc)},
+		{Protocol: "X", URL: "", WantHash: sha256Tag(doc)},
+	}
+	results := verifyMetadata(context.Background(), srv.Client(), checks)
+	want := []metadataOutcome{metadataMatch, metadataMismatch, metadataUnreachable, metadataNoURL}
+	for i, r := range results {
+		if r.Outcome != want[i] {
+			t.Errorf("%s: outcome %d, want %d (err=%v)", r.Protocol, r.Outcome, want[i], r.Err)
+		}
+	}
+	if results[0].GotHash != sha256Tag(doc) {
+		t.Errorf("match GotHash = %s, want %s", results[0].GotHash, sha256Tag(doc))
+	}
+	if results[2].Err == nil || !strings.Contains(results[2].Err.Error(), "HTTP 401") {
+		t.Errorf("unreachable err = %v, want HTTP 401", results[2].Err)
+	}
+}
+
+func TestFetchDescriptor_BodyCapped(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := strings.Repeat("x", 1<<20)
+		for range (maxResponseBytes >> 20) + 1 {
+			if _, err := fmt.Fprint(w, chunk); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	if _, err := fetchDescriptor(context.Background(), srv.Client(), srv.URL); err == nil {
+		t.Fatal("expected body-cap error")
+	}
+}
+
+func TestFetchDescriptor_BadURL(t *testing.T) {
+	t.Parallel()
+	if _, err := fetchDescriptor(context.Background(), http.DefaultClient, "://bad"); err == nil {
+		t.Fatal("expected request-build error")
+	}
+}
+
+func TestRunMetadataStep_Disabled(t *testing.T) {
+	t.Parallel()
+	if runMetadataStep(context.Background(), nil, false, time.Second) {
+		t.Fatal("disabled step must not fail")
+	}
+}
+
+func TestRunMetadataStep_UnparsableReceiptDoesNotFail(t *testing.T) {
+	t.Parallel()
+	if runMetadataStep(context.Background(), []byte("not a receipt"), true, time.Second) {
+		t.Fatal("unparsable receipt must report, not fail")
+	}
+}
+
+func TestPrintMetadataResult_CoversEveryOutcome(t *testing.T) {
+	t.Parallel()
+	for _, o := range []metadataOutcome{metadataMatch, metadataMismatch, metadataUnreachable, metadataNoURL} {
+		printMetadataResult(metadataResult{
+			metadataCheck: metadataCheck{Protocol: "A2A", URL: "https://x", WantHash: "SHA256:aa"},
+			Outcome:       o, GotHash: "SHA256:bb", Err: errors.New("HTTP 401"),
+		})
+	}
+}
+
+func TestMetadataStepForPayload_FailsOnlyOnMismatch(t *testing.T) {
+	t.Parallel()
+	const doc = `{"name":"agent"}`
+	srv := descriptorServer(t, doc)
+	row := func(alpn, url string) string {
+		return `{"name":"agent.example.com","type":"HTTPS","data":"1 . alpn=` + alpn +
+			` port=443 key65400=` + url + ` key65402=` + alpn + `"}`
+	}
+	cases := map[string]struct {
+		attestations string
+		wantFail     bool
+	}{
+		"match": {
+			`{"metadataHashes":{"A2A":"` + sha256Tag(doc) + `"},"dnsRecordsProvisioned":[` +
+				row("a2a", srv.URL+"/card.json") + `]}`, false},
+		"mismatch": {
+			`{"metadataHashes":{"A2A":"` + sha256Tag("other") + `"},"dnsRecordsProvisioned":[` +
+				row("a2a", srv.URL+"/card.json") + `]}`, true},
+		"unreachable is reported not failed": {
+			`{"metadataHashes":{"A2A":"` + sha256Tag(doc) + `"},"dnsRecordsProvisioned":[` +
+				row("a2a", srv.URL+"/private.json") + `]}`, false},
+		"no url is reported not failed": {
+			`{"metadataHashes":{"A2A":"` + sha256Tag(doc) + `"},"dnsRecordsProvisioned":[]}`, false},
+		"nothing attested": {`{}`, false},
+		"mismatch beside a match still fails": {
+			`{"metadataHashes":{"A2A":"` + sha256Tag(doc) + `","MCP":"` + sha256Tag("other") +
+				`"},"dnsRecordsProvisioned":[` + row("a2a", srv.URL+"/card.json") + `,` +
+				row("mcp", srv.URL+"/card.json") + `]}`, true},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := metadataStepForPayload(context.Background(), envelopeWithAttestations(c.attestations), srv.Client())
+			if got != c.wantFail {
+				t.Fatalf("failed = %v, want %v", got, c.wantFail)
+			}
+		})
+	}
+}
+
+func TestMetadataStepForPayload_BadPayloadDoesNotFail(t *testing.T) {
+	t.Parallel()
+	if metadataStepForPayload(context.Background(), []byte("{"), http.DefaultClient) {
+		t.Fatal("undecodable payload must report, not fail")
+	}
+}


### PR DESCRIPTION
Refs #99 — the part @csnitker-godaddy said belongs in `ans-verify`: the RA attests a metadata hash and nothing checks it.

**What.** `ans-verify` gains Step 7. For every `attestations.metadataHashes[protocol]` in the receipt's leaf it finds the attested SVCB/HTTPS row for that protocol (matched on `alpn=` / `key65402=`), reads the descriptor URL from that row's `key65400=`, fetches it, and compares SHA-256 with the attested value. Both inputs come from the same signed leaf, so the check is closed over what the log carries: no DNS lookup, no operator input. Since #106 the attested rows are the ones verification actually found, so the URL is one the RA saw served.

**Outcomes.** Mismatch → `✗` and exit 1 (the registration asserts something that is not true). Unreachable (network error or non-200, a 401 included) → `⚠`, exit 0. A hash with no attested row carrying a URL → `⚠`, exit 0. No attested hashes → `✓ nothing to check`. `-check-metadata=false` skips the step; `-metadata-timeout` (default 15s) bounds each fetch. Bodies are capped at the existing `maxResponseBytes`.

**Lanes.** Reads the V2 `dnsRecordsProvisioned[]` array and the V1 name→data map.

**Tests.** 14 cases in `metadata_test.go`: V2 pairing incl. HTTP_API→`x-http`, V1 map shape, nothing attested, bad JSON, unknown record shape, bap-only rows and first-row-wins, the four outcomes against an `httptest` server, body cap, bad URL, and the step's fail-only-on-mismatch rule (six sub-cases). The demo `run-lifecycle.sh` registers no metadata hash, so its step 14 prints "nothing to check" and stays green.

**Gate.** `go vet` ok, `golangci-lint` (v2.11.4) 0 issues, `go test -race ./...` clean, coverage 90.7% (the `test-cover` recipe; `cmd/` is outside the gate by design, and every new function sits at 87–100%).

Not in this PR: the FQDN entry point from the issue. Happy to do it next as its own PR.

Assisted-by: Claude Code (claude-fable-5-1)
