### PR TITLE
feat(dns): add TLSA 3 1 1 (SPKI) record builder for auto-renewing certs

### DIFF
--- a/internal/crypto/x509.go
+++ b/internal/crypto/x509.go
@@ -25,6 +25,9 @@ import (
 // Baseline Requirements for publicly trusted certificates.
 const (
 	MinRSAKeyBits = 2048
+
+	// pemTypeCertificate is the PEM block type header for X.509 certificates.
+	pemTypeCertificate = "CERTIFICATE"
 )
 
 // AllowedSignatureAlgorithms is the allowlist of signature algorithms
@@ -61,7 +64,7 @@ var (
 // ParseCertificatePEM parses a single PEM-encoded X.509 certificate.
 func ParseCertificatePEM(pemData string) (*x509.Certificate, error) {
 	block, _ := pem.Decode([]byte(pemData))
-	if block == nil || block.Type != "CERTIFICATE" {
+	if block == nil || block.Type != pemTypeCertificate {
 		return nil, fmt.Errorf("%w: expected CERTIFICATE block", ErrPEMParse)
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -82,7 +85,7 @@ func ParseCertificateChainPEM(pemData string) ([]*x509.Certificate, error) {
 		if block == nil {
 			break
 		}
-		if block.Type != "CERTIFICATE" {
+		if block.Type != pemTypeCertificate {
 			continue
 		}
 		cert, err := x509.ParseCertificate(block.Bytes)
@@ -145,6 +148,37 @@ func CheckKeyStrength(pub any) error {
 func CertificateFingerprint(cert *x509.Certificate) string {
 	sum := sha256.Sum256(cert.Raw)
 	return hex.EncodeToString(sum[:])
+}
+
+// SPKIFingerprint returns the lowercase hex SHA-256 fingerprint of the
+// certificate's SubjectPublicKeyInfo (SPKI) DER encoding — the value
+// used in a TLSA `3 1 1` (DANE-EE + SPKI + SHA-256) record.
+//
+// Unlike CertificateFingerprint (which hashes the full DER cert), this
+// hash covers only the public-key structure. A cert renewal that reuses
+// the same key pair produces an identical SPKIFingerprint, so a `3 1 1`
+// TLSA record survives rollover without a DNS change — which is the
+// property auto-renewing CAs (Let's Encrypt, short-lived issuers) rely
+// on when the operator holds the key steady.
+func SPKIFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return hex.EncodeToString(sum[:])
+}
+
+// SPKIFingerprintFromPEM parses the first CERTIFICATE block in pemStr
+// and returns its SPKI SHA-256 fingerprint (lowercase hex). Returns an
+// error if the PEM is unparseable or contains no certificate block.
+// Use SPKIFingerprint when you already hold a parsed *x509.Certificate.
+func SPKIFingerprintFromPEM(pemStr string) (string, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil || block.Type != pemTypeCertificate {
+		return "", fmt.Errorf("%w: no CERTIFICATE block found", ErrPEMParse)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrCertParse, err)
+	}
+	return SPKIFingerprint(cert), nil
 }
 
 // VerifyChain verifies leaf against the given intermediates with an

--- a/internal/crypto/x509_test.go
+++ b/internal/crypto/x509_test.go
@@ -457,3 +457,73 @@ func TestCheckCertificateValidity(t *testing.T) {
 		}
 	})
 }
+
+// ----- SPKIFingerprint / SPKIFingerprintFromPEM -----
+
+func TestSPKIFingerprint(t *testing.T) {
+	t.Parallel()
+	_, a := issueSelfSigned(t, "a", nil, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	_, b := issueSelfSigned(t, "b", nil, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+
+	fpA := anscrypto.SPKIFingerprint(a)
+	fpB := anscrypto.SPKIFingerprint(b)
+
+	// SHA-256 in hex is always 64 characters.
+	if len(fpA) != 64 {
+		t.Errorf("SPKI fingerprint length: got %d, want 64 (hex-encoded SHA-256)", len(fpA))
+	}
+
+	// Two different certs with different keys produce different SPKI fingerprints.
+	if fpA == fpB {
+		t.Errorf("distinct certs should have distinct SPKI fingerprints")
+	}
+
+	// Deterministic: fingerprinting the same cert twice returns the same value.
+	if fpA != anscrypto.SPKIFingerprint(a) {
+		t.Errorf("SPKIFingerprint is non-deterministic")
+	}
+
+	// SPKI fingerprint must differ from the full-cert fingerprint —
+	// they hash different byte ranges of the same structure.
+	certFP := anscrypto.CertificateFingerprint(a)
+	if fpA == certFP {
+		t.Errorf("SPKI fingerprint must differ from full-cert fingerprint for the same cert")
+	}
+}
+
+func TestSPKIFingerprintFromPEM(t *testing.T) {
+	t.Parallel()
+	pemStr, cert := issueSelfSigned(t, "a", nil, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+
+	t.Run("matches SPKIFingerprint on the parsed cert", func(t *testing.T) {
+		got, err := anscrypto.SPKIFingerprintFromPEM(pemStr)
+		if err != nil {
+			t.Fatalf("SPKIFingerprintFromPEM: %v", err)
+		}
+		want := anscrypto.SPKIFingerprint(cert)
+		if got != want {
+			t.Errorf("SPKIFingerprintFromPEM = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("error on empty PEM", func(t *testing.T) {
+		_, err := anscrypto.SPKIFingerprintFromPEM("")
+		if !errors.Is(err, anscrypto.ErrPEMParse) {
+			t.Errorf("want ErrPEMParse, got %v", err)
+		}
+	})
+
+	t.Run("error on non-certificate PEM", func(t *testing.T) {
+		_, err := anscrypto.SPKIFingerprintFromPEM("-----BEGIN PRIVATE KEY-----\nYQ==\n-----END PRIVATE KEY-----\n")
+		if !errors.Is(err, anscrypto.ErrPEMParse) {
+			t.Errorf("want ErrPEMParse, got %v", err)
+		}
+	})
+
+	t.Run("error on invalid DER inside certificate block", func(t *testing.T) {
+		_, err := anscrypto.SPKIFingerprintFromPEM("-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n")
+		if !errors.Is(err, anscrypto.ErrCertParse) {
+			t.Errorf("want ErrCertParse, got %v", err)
+		}
+	})
+}

--- a/internal/domain/dnsrecords.go
+++ b/internal/domain/dnsrecords.go
@@ -131,6 +131,11 @@ type ExpectedDNSRecord struct {
 // fingerprint — a SHA-256 over the full DER cert (internal/crypto/x509.go
 // CertificateFingerprint) — so selector 0 is what matches those bytes.
 //
+// Note: selector 0 does NOT survive cert rotation when the key is
+// reused. For auto-renewing CAs (Let's Encrypt, short-lived issuers)
+// prefer TLSARecordForCertSPKI, which emits `3 1 1` and survives
+// rollover without a DNS change as long as the key pair is held steady.
+//
 // Required=false: a TLSA record is only trustworthy in a DNSSEC-signed
 // zone, which the domain layer cannot know. The verify layer enforces
 // the stricter rule at query time: a DNSSEC-validated TLSA response MUST
@@ -140,6 +145,36 @@ func TLSARecordForCert(fqdn, fingerprint string) ExpectedDNSRecord {
 		Name:     fmt.Sprintf("_443._tcp.%s", fqdn),
 		Type:     DNSRecordTLSA,
 		Value:    fmt.Sprintf("3 0 1 %s", fingerprint),
+		Purpose:  PurposeCertificateBinding,
+		Required: false,
+		TTL:      3600,
+	}
+}
+
+// TLSARecordForCertSPKI builds a DANE-EE TLSA record using selector 1
+// (SubjectPublicKeyInfo) and matching-type 1 (SHA-256). The record
+// format is `3 1 1 <hex>` where hex is the SHA-256 of the certificate's
+// SPKI DER encoding (RFC 6698 §2.1).
+//
+// Unlike TLSARecordForCert (`3 0 1`), a `3 1 1` record is bound to the
+// public key, not the full certificate. A cert renewal that reuses the
+// same key pair — the normal behavior for auto-renewing CAs such as
+// Let's Encrypt — produces the same SPKI fingerprint, so the DNS record
+// does not need to change on rotation. This makes `3 1 1` the
+// appropriate default for any registration backed by an auto-renewing
+// CA.
+//
+// `spkiFingerprint` is the lowercase hex SHA-256 of the certificate's
+// SubjectPublicKeyInfo DER bytes. Compute it with
+// internal/crypto.SPKIFingerprint(*x509.Certificate) or
+// internal/crypto.SPKIFingerprintFromPEM(leafPEM) at the call site.
+//
+// Required=false follows the same DNSSEC-zone caveat as TLSARecordForCert.
+func TLSARecordForCertSPKI(fqdn, spkiFingerprint string) ExpectedDNSRecord {
+	return ExpectedDNSRecord{
+		Name:     fmt.Sprintf("_443._tcp.%s", fqdn),
+		Type:     DNSRecordTLSA,
+		Value:    fmt.Sprintf("3 1 1 %s", spkiFingerprint),
 		Purpose:  PurposeCertificateBinding,
 		Required: false,
 		TTL:      3600,

--- a/internal/domain/dnsrecords_test.go
+++ b/internal/domain/dnsrecords_test.go
@@ -1,9 +1,19 @@
 package domain
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestValidDiscoveryProfiles pins the canonical valid set of
@@ -46,4 +56,79 @@ func TestDiscoveryProfile_IsValid(t *testing.T) {
 			assert.Equal(t, tc.want, tc.s.IsValid())
 		})
 	}
+}
+
+// tlsaTestCert mints a self-signed P-256 certificate for use in TLSA
+// tests. Returns the parsed cert so callers can inspect RawSubjectPublicKeyInfo.
+func tlsaTestCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "agent.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     []string{"agent.example.com"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// TestTLSARecordForCertSPKI_HashMatchesSPKI verifies that
+// TLSARecordForCertSPKI emits `3 1 1 <hash>` where hash is the
+// SHA-256 of the certificate's SubjectPublicKeyInfo DER bytes — NOT
+// the full-certificate hash that TLSARecordForCert uses.
+//
+// This is the critical DANE selector-1 invariant: the record value
+// must equal hex(SHA-256(cert.RawSubjectPublicKeyInfo)) so a relying
+// party performing DANE-EE validation against a live TLS handshake
+// can compute the same hash from the presented certificate's SPKI
+// and find a match.
+func TestTLSARecordForCertSPKI_HashMatchesSPKI(t *testing.T) {
+	cert := tlsaTestCert(t)
+	fqdn := "agent.example.com"
+
+	// Ground-truth: SHA-256 of the SPKI DER (selector 1, matching-type 1).
+	spkiSum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	wantHex := hex.EncodeToString(spkiSum[:])
+
+	rec := TLSARecordForCertSPKI(fqdn, wantHex)
+
+	assert.Equal(t, "_443._tcp.agent.example.com", rec.Name)
+	assert.Equal(t, DNSRecordTLSA, rec.Type)
+	assert.Equal(t, "3 1 1 "+wantHex, rec.Value, "TLSA value must be '3 1 1 <sha256(SPKI)>'")
+	assert.Equal(t, PurposeCertificateBinding, rec.Purpose)
+	assert.False(t, rec.Required)
+	assert.Equal(t, 3600, rec.TTL)
+}
+
+// TestTLSARecordForCertSPKI_DiffersFromFullCertHash guards the
+// correctness trap: selector 1 (SPKI) and selector 0 (full cert)
+// produce different hashes for the same certificate. Emitting `3 1 1`
+// with the full-cert SHA-256 would create a record that no conformant
+// DANE implementation matches.
+func TestTLSARecordForCertSPKI_DiffersFromFullCertHash(t *testing.T) {
+	cert := tlsaTestCert(t)
+
+	fullCertSum := sha256.Sum256(cert.Raw)
+	fullCertHex := hex.EncodeToString(fullCertSum[:])
+
+	spkiSum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	spkiHex := hex.EncodeToString(spkiSum[:])
+
+	// The two fingerprints must differ — if they were equal we would
+	// have the same cert encoding as its SPKI encoding, which is never
+	// true for a real X.509 certificate.
+	assert.NotEqual(t, fullCertHex, spkiHex,
+		"SPKI fingerprint must differ from full-cert fingerprint")
+
+	spkiRec := TLSARecordForCertSPKI("agent.example.com", spkiHex)
+	certRec := TLSARecordForCert("agent.example.com", fullCertHex)
+
+	assert.NotEqual(t, spkiRec.Value, certRec.Value,
+		"3 1 1 record value must differ from 3 0 1 record value for the same cert")
 }


### PR DESCRIPTION
## BLUF

The reference impl emitted only `TLSA 3 0 1` (full-cert hash), which changes on every renewal and breaks DANE for auto-renewing certs. This adds a `3 1 1` (SPKI-hash) record builder that survives renewals reusing the same key; the existing `3 0 1` builder is untouched.

Closes https://github.com/agentnameservice/ans/issues/105

## What changed

**internal/domain/dnsrecords.go** -- new TLSARecordForCertSPKI(fqdn, spkiFingerprint string) emitting 3 1 1. The existing TLSARecordForCert (3 0 1) is untouched.

**internal/crypto/x509.go** -- two new helpers: SPKIFingerprint(*x509.Certificate) and SPKIFingerprintFromPEM(pem string). Also extracts pemTypeCertificate constant to resolve a goconst finding.

**Tests** -- dnsrecords_test.go asserts rec.Value == "3 1 1 " + hex(sha256(cert.RawSubjectPublicKeyInfo)) using a generated cert. A companion test asserts the SPKI fingerprint differs from the full-cert fingerprint (the selector-1 correctness trap).

## Why 3 1 1 survives rotation

Selector 0 (full cert) hashes the entire DER certificate -- changes on every renewal. Selector 1 (SPKI) hashes only the SubjectPublicKeyInfo -- stable across renewals that reuse the same key pair. This is the property ACME auto-renewing CAs rely on.

## Caller availability finding

All three TLSARecordForCert call sites are in internal/ra/service/renewal.go (lines 222, 372, 475). At those sites the code holds a *domain.ByocServerCertificate (LeafCertificatePEM) or *port.ValidatedCert (LeafPEM) -- no pre-parsed *x509.Certificate and no pre-computed SPKI hash. Wiring up TLSARecordForCertSPKI requires one additional anscrypto.SPKIFingerprintFromPEM call per site. Not a structural refactor; straightforward to wire up in a follow-on or in this PR per reviewer preference.

## Design options (recommendation: a)

**(a) Replace 3 0 1 with 3 1 1 as the default in the renewal-status DTO.** The DTO is an operator hint; the selector change is backward-compatible and benefits auto-renewing BYOC immediately. This is my recommendation.

**(b) Emit both records.** Valid DANE; gives operators a transition window. Doubles DNS records per hostname.

**(c) Make it configurable.** Adds a flag to the registration model. Appropriate only if operators need 3 0 1 long-term (CAs that replace keys on each issuance); not the common BYOC path.
