### PR TITLE
fix(dns): match the HTTPS record by SvcParam subset, with alpn as a list (RFC 9460 §7.1.1)

### DIFF
--- a/internal/adapter/dns/dns_test.go
+++ b/internal/adapter/dns/dns_test.go
@@ -292,6 +292,132 @@ func TestLookupVerifier_HTTPSMatch(t *testing.T) {
 	}
 }
 
+// TestLookupVerifier_HTTPSSubset pins the subset rule on the HTTPS RR:
+// the expected SvcParams must be present, extras are tolerated, alpn is
+// compared as a list (RFC 9460 §7.1.1), and the TargetName forms of
+// §2.5.2 designate the same target. The first case is the shape a CDN
+// edge synthesizes on a proxied name — the operator cannot publish any
+// other value, so a verbatim comparison would strand them.
+func TestLookupVerifier_HTTPSSubset(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		rr    string
+		want  string
+		found bool
+	}{
+		{
+			name:  "cdn_synthesized_record_satisfies_expected_alpn",
+			rr:    `agent.example.com. 300 IN HTTPS 1 . alpn="h3,h2" ipv4hint=192.0.2.1 ech="AEX+DQBB" ipv6hint=2001:db8::1`,
+			want:  `1 . alpn=h2`,
+			found: true,
+		},
+		{
+			// §2.5.2, as fixed for SVCB in #108: at this owner name the
+			// explicit FQDN and "." are the same target.
+			name:  "explicit_targetname_matches_dot",
+			rr:    `agent.example.com. 300 IN HTTPS 1 agent.example.com. alpn="h2"`,
+			want:  `1 . alpn=h2`,
+			found: true,
+		},
+		{
+			name:  "alpn_without_the_expected_protocol_does_not_match",
+			rr:    `agent.example.com. 300 IN HTTPS 1 . alpn="h3"`,
+			want:  `1 . alpn=h2`,
+			found: false,
+		},
+		{
+			name:  "different_priority_does_not_match",
+			rr:    `agent.example.com. 300 IN HTTPS 2 . alpn="h2"`,
+			want:  `1 . alpn=h2`,
+			found: false,
+		},
+		{
+			name:  "missing_expected_param_does_not_match",
+			rr:    `agent.example.com. 300 IN HTTPS 1 . alpn="h2"`,
+			want:  `1 . alpn=h2 port=8443`,
+			found: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := newTestServer(t)
+			s.add("agent.example.com.", "HTTPS", tc.rr)
+
+			recs := []domain.ExpectedDNSRecord{{
+				Name: "agent.example.com", Type: domain.DNSRecordHTTPS,
+				Value: tc.want, Required: false,
+			}}
+			got := s.verifyAgainst(t, recs)
+			if got[0].found != tc.found {
+				t.Errorf("found = %v, want %v (actual=%q)", got[0].found, tc.found, got[0].actual)
+			}
+			// Whether or not it matched, the served value is reported so
+			// the operator sees what the zone actually answered.
+			if got[0].actual == "" {
+				t.Error("Actual must carry the served record")
+			}
+		})
+	}
+}
+
+// TestLookupVerifier_HTTPSBadExpectedValue pins the branch that parsing
+// the expected value introduces: a stored value the RA could not have
+// written surfaces as an error, not as a silent not-found.
+func TestLookupVerifier_HTTPSBadExpectedValue(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t)
+	s.add("agent.example.com.", "HTTPS", `agent.example.com. 300 IN HTTPS 1 . alpn="h2"`)
+
+	recs := []domain.ExpectedDNSRecord{{
+		Name: "agent.example.com", Type: domain.DNSRecordHTTPS,
+		Value: "1", Required: false,
+	}}
+	got := s.verifyAgainst(t, recs)
+	if got[0].found {
+		t.Error("an unparseable expected value must not match")
+	}
+	if !strings.Contains(got[0].errString, "expected HTTPS value") {
+		t.Errorf("Error should name the expected value; got %q", got[0].errString)
+	}
+}
+
+// TestSVCParamMatches covers the per-key comparison rule directly,
+// including the escaped-comma alpn form that no live record in the
+// suite produces.
+func TestSVCParamMatches(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		key        string
+		want, got  string
+		shouldPass bool
+	}{
+		{"scalar_param_equal", "port", "443", "443", true},
+		{"scalar_param_differs", "port", "443", "8443", false},
+		{"alpn_single_in_list", "alpn", "h2", "h3,h2", true},
+		{"alpn_list_in_longer_list", "alpn", "h2,h3", "h3,h2,http/1.1", true},
+		{"alpn_absent_from_list", "alpn", "h2", "h3,http/1.1", false},
+		{"alpn_exact", "alpn", "h2", "h2", true},
+		// A protocol id may itself contain a comma, escaped in
+		// presentation form (§7.1.1); the escape must not split the id.
+		{"alpn_escaped_comma_is_one_id", "alpn", `f\,oo`, `h2,f\,oo`, true},
+		{"alpn_escaped_comma_not_two_ids", "alpn", "oo", `h2,f\,oo`, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := svcParamMatches(tc.key, tc.want, tc.got); got != tc.shouldPass {
+				t.Errorf("svcParamMatches(%q, %q, %q) = %v, want %v",
+					tc.key, tc.want, tc.got, got, tc.shouldPass)
+			}
+		})
+	}
+}
+
 // TestLookupVerifier_SVCB exercises the Consolidated Approach SVCB
 // verifier across match, missing, and shape-mismatch paths. The match
 // case tests the same presentation form the RA's profile emitters

--- a/internal/adapter/dns/lookup.go
+++ b/internal/adapter/dns/lookup.go
@@ -254,16 +254,31 @@ func (v *LookupVerifier) verifyTLSA(ctx context.Context, server string, rec doma
 	return r
 }
 
-// verifyHTTPS checks for an HTTPS-type record (RFC 9460). Matching
-// compares the SvcPriority + TargetName + params text verbatim
-// against the expected value after whitespace normalization.
+// verifyHTTPS checks for an HTTPS-type record (RFC 9460) at the
+// agent's bare FQDN. HTTPS is SVCB with a fixed service, so matching
+// uses the same subset rule as verifySVCB: priority must equal the
+// expected value, targets must designate the same effective TargetName
+// (§2.5.2), every expected SvcParam must be present, and additional
+// SvcParams are tolerated (§8).
+//
+// The subset rule is not a nicety here — for HTTPS it is the only rule
+// an operator behind a CDN can satisfy. Where the RA expects
+// `1 . alpn=h2`, an edge that also speaks HTTP/3 answers
+// `1 . alpn=h3,h2` with `ech` and address hints attached, and on a
+// proxied name the operator cannot publish anything else: the provider
+// synthesizes that record and serves it in place of a manual one. A
+// verbatim comparison marks it not-found, and in a DNSSEC-signed zone
+// the lifecycle layer then reads the disagreement as tampering
+// (HTTPS_DNSSEC_MISMATCH, a hard fail regardless of Required) — so the
+// record's optionality, which exists precisely for operators who cannot
+// publish it, never reaches them: the branch that grants the exemption
+// requires the record to be absent, and theirs is present with content
+// they do not control.
 //
 // Captures the DNSSEC AuthenticatedData bit on the response, mirroring
-// verifyTLSA and verifySVCB. The service-layer post-verify rule
-// (lifecycle.go verifyDNSRecords) treats a DNSSEC-authenticated HTTPS
-// record whose value disagrees with the expected one as a hard fail
-// — same threat shape as TLSA: an attacker rewrote a record in a
-// signed zone.
+// verifyTLSA and verifySVCB. Real tampering still fails: a different
+// priority, a different effective target, or an alpn that does not
+// carry the expected protocol.
 func (v *LookupVerifier) verifyHTTPS(ctx context.Context, server string, rec domain.ExpectedDNSRecord) port.RecordVerification {
 	r := port.RecordVerification{Record: rec}
 	resp, err := v.exchange(ctx, server, rec.Name, dns.TypeHTTPS)
@@ -275,19 +290,30 @@ func (v *LookupVerifier) verifyHTTPS(ctx context.Context, server string, rec dom
 		return r
 	}
 	r.DNSSECVerified = resp.AuthenticatedData
-	wantNorm := normalizeHTTPS(rec.Value)
+
+	expected, err := parseSVCBValue(rec.Value)
+	if err != nil {
+		r.Error = fmt.Sprintf("expected HTTPS value: %v", err)
+		return r
+	}
 	for _, rr := range resp.Answer {
 		https, ok := rr.(*dns.HTTPS)
 		if !ok {
 			continue
 		}
-		got := formatHTTPSValue(&https.SVCB)
+		gotStr := formatHTTPSValue(&https.SVCB)
 		if r.Actual == "" {
-			r.Actual = got
+			r.Actual = gotStr
 		}
-		if normalizeHTTPS(got) == wantNorm {
+		actual, err := parseSVCBValue(gotStr)
+		if err != nil {
+			// Skip records we can't parse — they'll surface as
+			// not-found if no other answer matches.
+			continue
+		}
+		if matchesSVCBSubset(expected, actual, rec.Name) {
 			r.Found = true
-			r.Actual = got
+			r.Actual = gotStr
 			return r
 		}
 	}
@@ -430,11 +456,59 @@ func matchesSVCBSubset(expected, actual parsedSVCB, owner string) bool {
 	}
 	for k, want := range expected.params {
 		got, ok := actual.params[k]
-		if !ok || got != want {
+		if !ok || !svcParamMatches(k, want, got) {
 			return false
 		}
 	}
 	return true
+}
+
+// svcParamMatches reports whether a live SvcParam value satisfies the
+// expected one. Every key compares by equality except `alpn`, which
+// RFC 9460 §7.1.1 defines as a *list* of protocol ids rather than a
+// scalar: the expected ids must all be advertised, and the server may
+// advertise more. An edge that speaks HTTP/3 as well as HTTP/2 serves
+// `alpn=h3,h2`, which satisfies an expected `alpn=h2` — the binding
+// the RA committed to is there, alongside another. An alpn that does
+// not carry the expected protocol still fails, so a record swapped for
+// one advertising a different service is caught.
+func svcParamMatches(key, want, got string) bool {
+	if key != "alpn" {
+		return want == got
+	}
+	advertised := make(map[string]struct{})
+	for _, id := range splitAlpn(got) {
+		advertised[id] = struct{}{}
+	}
+	for _, id := range splitAlpn(want) {
+		if _, ok := advertised[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// splitAlpn splits an alpn SvcParam's presentation value on its
+// separators. RFC 9460 §7.1.1 allows a protocol id to contain a comma,
+// escaped as `\,` in presentation form, so splitting on every comma
+// would tear one id in two; the escape is consumed and the id kept
+// whole.
+func splitAlpn(s string) []string {
+	out := []string{}
+	var cur strings.Builder
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '\\' && i+1 < len(s):
+			i++
+			cur.WriteByte(s[i])
+		case s[i] == ',':
+			out = append(out, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(s[i])
+		}
+	}
+	return append(out, cur.String())
 }
 
 // effectiveSVCBTarget returns the canonical effective TargetName of
@@ -458,11 +532,4 @@ func effectiveSVCBTarget(target, owner string, serviceMode bool) string {
 // "3 1 1 abcd..." matches "3  1  1 ABCD...".
 func normalizeTLSA(s string) string {
 	return strings.ToLower(strings.Join(strings.Fields(s), " "))
-}
-
-// normalizeHTTPS collapses whitespace for comparison. The SVCB
-// param ordering is canonical via miekg/dns's Marshal, so field
-// order isn't an issue for correctly-formed records.
-func normalizeHTTPS(s string) string {
-	return strings.Join(strings.Fields(s), " ")
 }


### PR DESCRIPTION
Fixes #115.

**BLUF.** `verifyHTTPS` compared the served record against the expected `1 . alpn=h2` verbatim — `normalizeHTTPS` collapses whitespace and nothing else. `verifySVCB` has done subset matching since #108; the sibling record type never got it, so a CDN-proxied name in a signed zone hard-fails `verify-dns` on a record the operator cannot publish.

**What.** `verifyHTTPS` now parses both sides with `parseSVCBValue` and matches with `matchesSVCBSubset`, exactly as `verifySVCB` does: priority equal, effective TargetName equal (§2.5.2), every expected SvcParam present, extras tolerated (§8).

One refinement SVCB did not need: `alpn` is a list (§7.1.1), not a scalar. `svcParamMatches` compares it as set inclusion — the expected ids must be advertised, the server may advertise more — so an expected `alpn=h2` is satisfied by a served `alpn=h3,h2`. Every other key still compares by equality. `splitAlpn` splits on unescaped commas only, since §7.1.1 lets a protocol id contain a comma escaped as `\,`.

That rule also reaches SVCB, in the same RFC-correct direction: a row carrying `alpn=a2a,mcp` now satisfies an expected `alpn=a2a` instead of hard-failing. Calling it out because it is behaviour outside the record type in the title. It is the same argument as the subset match itself — the Consolidated Approach designs for one row shared by several families, and a scalar comparison of a list-valued param defeats that.

Real tampering still fails: a different priority, a different effective target, or an `alpn` that does not carry the expected protocol.

`normalizeHTTPS` goes with its last caller.

**Tests.** `TestLookupVerifier_HTTPSSubset`, five cases: the CDN-synthesized shape (`alpn="h3,h2"` with `ech` and both hint families) matches `1 . alpn=h2`; the explicit TargetName form matches `.`; `alpn=h3` alone does not; priority `2` does not; a record missing an expected `port=` does not. Each asserts `Actual` carries the served value either way, so the operator sees what the zone answered. `TestSVCParamMatches` covers the per-key rule directly, including the escaped-comma id that no live record in the suite produces. `TestLookupVerifier_HTTPSBadExpectedValue` pins the branch that parsing the expected value introduces.

**Gate.** `go vet` clean, `go test -race ./...` clean, `make test-cover` 90.7% against the 90% floor. `verifyHTTPS` 92.6%, `matchesSVCBSubset` / `svcParamMatches` / `splitAlpn` 100%. `golangci-lint` was not run locally — not installed here; happy to fix anything CI flags.

**Not in this PR.** Whether `Required: false` should also exempt a *present but unmatched* HTTPS record in a signed zone is a lifecycle-layer decision, and this change makes it unnecessary for the CDN case rather than settling it.

### AI assistance

Assisted-by: Claude Code (claude-opus-5)
