### PR TITLE
fix(dns): split alpn on the escape form that actually reaches the verifier

### DIFF
--- a/internal/adapter/dns/dns_test.go
+++ b/internal/adapter/dns/dns_test.go
@@ -401,8 +401,10 @@ func TestSVCParamMatches(t *testing.T) {
 		{"alpn_list_in_longer_list", "alpn", "h2,h3", "h3,h2,http/1.1", true},
 		{"alpn_absent_from_list", "alpn", "h2", "h3,http/1.1", false},
 		{"alpn_exact", "alpn", "h2", "h2", true},
-		// A protocol id may itself contain a comma, escaped in
-		// presentation form (§7.1.1); the escape must not split the id.
+		// A protocol id may itself contain a comma. These two carry the
+		// single-escaped form a person might write by hand; the form that
+		// actually arrives from the wire is exercised in
+		// TestSplitAlpnAgainstEmittedForm below.
 		{"alpn_escaped_comma_is_one_id", "alpn", `f\,oo`, `h2,f\,oo`, true},
 		{"alpn_escaped_comma_not_two_ids", "alpn", "oo", `h2,f\,oo`, false},
 	}
@@ -415,6 +417,49 @@ func TestSVCParamMatches(t *testing.T) {
 					tc.key, tc.want, tc.got, got, tc.shouldPass)
 			}
 		})
+	}
+}
+
+// TestSplitAlpnAgainstEmittedForm pins the split against the presentation
+// form the verifier is actually handed, rather than the one a person would
+// write. RFC 9460 §A.1 escapes an alpn value once for the list and again
+// for the zone file, and miekg/dns emits that double form, so the id
+// `f,oo` arrives as `f\\\044oo` and carries no comma byte at all.
+//
+// The record is rendered through formatHTTPSValue rather than hard-coded,
+// so the test fails if that emission ever changes under us.
+func TestSplitAlpnAgainstEmittedForm(t *testing.T) {
+	t.Parallel()
+	rr := &miekg.SVCB{Priority: 1, Target: "."}
+	rr.Value = []miekg.SVCBKeyValue{&miekg.SVCBAlpn{Alpn: []string{"f,oo", "h2"}}}
+
+	served := formatHTTPSValue(rr)
+	if !strings.Contains(served, `alpn=f\\\044oo,h2`) {
+		t.Fatalf("miekg no longer emits the double-escaped form; got %q", served)
+	}
+
+	parsed, err := parseSVCBValue(served)
+	if err != nil {
+		t.Fatalf("parseSVCBValue: %v", err)
+	}
+	ids := splitAlpn(parsed.params["alpn"])
+	if len(ids) != 2 {
+		t.Fatalf("comma-bearing id must stay one segment; got %q", ids)
+	}
+	if ids[0] != `f\\\044oo` {
+		t.Errorf("segment must be returned verbatim; got %q", ids[0])
+	}
+
+	// The served value satisfies an expected one written the same way, and
+	// the escaped id is not readable as the separate ids it looks like.
+	if !svcParamMatches("alpn", `f\\\044oo`, parsed.params["alpn"]) {
+		t.Error("an identically written expected id must match")
+	}
+	if svcParamMatches("alpn", "oo", parsed.params["alpn"]) {
+		t.Error(`"oo" is part of one escaped id, not an id of its own`)
+	}
+	if !svcParamMatches("alpn", "h2", parsed.params["alpn"]) {
+		t.Error("h2 sits after the separator and must still match")
 	}
 }
 

--- a/internal/adapter/dns/lookup.go
+++ b/internal/adapter/dns/lookup.go
@@ -489,26 +489,38 @@ func svcParamMatches(key, want, got string) bool {
 }
 
 // splitAlpn splits an alpn SvcParam's presentation value on its
-// separators. RFC 9460 §7.1.1 allows a protocol id to contain a comma,
-// escaped as `\,` in presentation form, so splitting on every comma
-// would tear one id in two; the escape is consumed and the id kept
-// whole.
+// separators, returning each id exactly as it was written.
+//
+// A comma inside a protocol id does not reach here as a comma. RFC 9460
+// §A.1 has the value escaped once for the alpn list and again for the
+// zone file, and miekg/dns emits that double form from SVCBAlpn.String()
+// — the id `f,oo` renders as `f\\\044oo`, with no comma byte in it. So
+// every comma in this string is a separator, and the escape handling
+// below only matters for an expected value someone wrote by hand in the
+// single-escaped `\,` form.
+//
+// Segments are returned verbatim rather than unescaped: both sides of the
+// comparison arrive as presentation text, and unescaping one convention
+// but not the other would make a served value differ from an identically
+// written expected one.
 func splitAlpn(s string) []string {
 	out := []string{}
-	var cur strings.Builder
-	for i := 0; i < len(s); i++ {
+	start, i := 0, 0
+	for i < len(s) {
 		switch {
 		case s[i] == '\\' && i+1 < len(s):
-			i++
-			cur.WriteByte(s[i])
+			// Skip the escape and the byte it escapes, so a comma that is
+			// part of an escape sequence is not read as a separator.
+			i += 2
 		case s[i] == ',':
-			out = append(out, cur.String())
-			cur.Reset()
+			out = append(out, s[start:i])
+			i++
+			start = i
 		default:
-			cur.WriteByte(s[i])
+			i++
 		}
 	}
-	return append(out, cur.String())
+	return append(out, s[start:])
 }
 
 // effectiveSVCBTarget returns the canonical effective TargetName of


### PR DESCRIPTION
Fixes #117. Follow-up to @csnitker-godaddy's review note on #116 — the call was right.

**BLUF.** `splitAlpn` said a comma inside a protocol id arrives escaped as `\,`. What arrives is the double-escaped zone-file form: `miekg/dns` renders `f,oo` as `f\\\044oo`, carrying no comma byte. Every comma the verifier splits on is a separator, so the premise the helper was written against never occurs.

**What was actually wrong.** Nothing was mis-split — there is no comma in the escaped form to split on. One layer down, though, the loop rebuilt each segment byte by byte and consumed a backslash doing it, so `f\\\044oo` came back as `f\044oo`: text matching neither the served value nor an identically written expected one. A silent difference inside a comparison function.

**What changed.** Segments are returned verbatim as substrings; the escape handling stays, now only for its real case — an expected value written by hand in the single-escaped form. The comment says what arrives instead of what a person would write.

**Tests.** `TestSplitAlpnAgainstEmittedForm` builds an `SVCBAlpn` with a comma-bearing id, renders it through `formatHTTPSValue`, and asserts on that: the id stays one segment, comes back verbatim, matches an identically written expected value, and is not readable as the separate ids it resembles. Rendering rather than hard-coding means the test fails if the emission ever changes under us. The two hand-written cases in `TestSVCParamMatches` stay and now say which form they carry.

**Gate.** `go vet` clean, `go test -race ./...` clean, `make test-cover` 90.7% against the 90% floor, `splitAlpn` and `svcParamMatches` at 100%. `golangci-lint` not run locally — not installed here.

**Not in scope.** The other note on #116, that the subset rule tolerates a served key the expected row lacks (a `port=`, say), applies equally to SVCB and is a design question rather than a bug in this helper. Left where you put it.

### AI assistance

Assisted-by: Claude Code (claude-opus-5)
